### PR TITLE
Fix missing 2D friction helpers for physics tests

### DIFF
--- a/packages/common/physics.h
+++ b/packages/common/physics.h
@@ -33,6 +33,7 @@ void evolve_bot(PlayerState *loser, PlayerState *winner);
 PlayerState* get_best_bot();
 
 typedef struct { float x, y, z, w, h, d; } Box;
+typedef struct { float x, y; } Vec2;
 
 // --- THE BONEYARD (Phase 489: Compressed & Dense) ---
 static Box map_geo[] = {
@@ -73,6 +74,17 @@ static Box map_geo[] = {
 static int map_count = sizeof(map_geo) / sizeof(Box);
 
 float phys_rand_f() { return ((float)(rand()%1000)/500.0f) - 1.0f; }
+
+static inline void apply_friction_2d(Vec2 *vel, float friction, float dt) {
+    float speed = sqrtf(vel->x * vel->x + vel->y * vel->y);
+    if (speed <= 0.0001f) return;
+    float drop = speed * friction * dt;
+    float newspeed = speed - drop;
+    if (newspeed < 0.0f) newspeed = 0.0f;
+    float ratio = newspeed / speed;
+    vel->x *= ratio;
+    vel->y *= ratio;
+}
 
 static inline float angle_diff(float a, float b) {
     float d = a - b;


### PR DESCRIPTION
### Motivation
- Restore missing 2D helpers used by physics tests so `tests/test_physics.c` can compile, addressing the regression that produced unknown `Vec2` type and missing `apply_friction_2d` errors.

### Description
- Add `typedef struct { float x, y; } Vec2;` and `static inline void apply_friction_2d(Vec2 *vel, float friction, float dt)` to `packages/common/physics.h`, implementing speed-based friction reduction for 2D velocity vectors.

### Testing
- No automated tests were run after the change; this patch was created to address the compile-time regression observed in the earlier test run which failed to build due to the missing type and function.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d27465ec48327a0f85bc8ceb5fd52)