### PR TITLE
feat: add Neon Ronin procedural 3rd‑person player model (jacket, pants, mask)

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -268,6 +268,68 @@ void draw_gun_model(int weapon_id) {
     glEnd();
 }
 
+static void draw_box(float w, float h, float d) {
+    glPushMatrix();
+    glScalef(w, h, d);
+    glBegin(GL_QUADS);
+    // Front
+    glVertex3f(-0.5f,-0.5f,0.5f); glVertex3f(0.5f,-0.5f,0.5f); glVertex3f(0.5f,0.5f,0.5f); glVertex3f(-0.5f,0.5f,0.5f);
+    // Back
+    glVertex3f(-0.5f,-0.5f,-0.5f); glVertex3f(-0.5f,0.5f,-0.5f); glVertex3f(0.5f,0.5f,-0.5f); glVertex3f(0.5f,-0.5f,-0.5f);
+    // Left
+    glVertex3f(-0.5f,-0.5f,-0.5f); glVertex3f(-0.5f,-0.5f,0.5f); glVertex3f(-0.5f,0.5f,0.5f); glVertex3f(-0.5f,0.5f,-0.5f);
+    // Right
+    glVertex3f(0.5f,-0.5f,-0.5f); glVertex3f(0.5f,0.5f,-0.5f); glVertex3f(0.5f,0.5f,0.5f); glVertex3f(0.5f,-0.5f,0.5f);
+    // Top
+    glVertex3f(-0.5f,0.5f,0.5f); glVertex3f(0.5f,0.5f,0.5f); glVertex3f(0.5f,0.5f,-0.5f); glVertex3f(-0.5f,0.5f,-0.5f);
+    // Bottom
+    glVertex3f(-0.5f,-0.5f,0.5f); glVertex3f(-0.5f,-0.5f,-0.5f); glVertex3f(0.5f,-0.5f,-0.5f); glVertex3f(0.5f,-0.5f,0.5f);
+    glEnd();
+    glPopMatrix();
+}
+
+static void draw_ronin_shell(void) {
+    // Jacket core (cropped waist, broad shoulders)
+    glColor3f(0.1f, 0.1f, 0.1f); // Matte black
+    glPushMatrix();
+    glTranslatef(0.0f, 0.9f, 0.0f);
+    draw_box(1.35f, 1.15f, 0.75f);
+    // Shoulder pads
+    glPushMatrix(); glTranslatef(-0.95f, 0.35f, 0.0f); draw_box(0.45f, 0.45f, 0.7f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.95f, 0.35f, 0.0f); draw_box(0.45f, 0.45f, 0.7f); glPopMatrix();
+    // Sleeves
+    glPushMatrix(); glTranslatef(-0.85f, -0.25f, 0.0f); draw_box(0.35f, 1.1f, 0.45f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.85f, -0.25f, 0.0f); draw_box(0.35f, 1.1f, 0.45f); glPopMatrix();
+    // Red satin lining at hem
+    glColor3f(0.6f, 0.0f, 0.0f);
+    glBegin(GL_QUADS);
+    glVertex3f(-0.68f, -0.6f, 0.39f); glVertex3f(0.68f, -0.6f, 0.39f);
+    glVertex3f(0.68f, -0.52f, 0.39f); glVertex3f(-0.68f, -0.52f, 0.39f);
+    glEnd();
+    glPopMatrix();
+
+    // Tech cargo pants (baggy)
+    glColor3f(0.18f, 0.18f, 0.2f); // Charcoal
+    glPushMatrix(); glTranslatef(-0.32f, 0.0f, 0.0f); draw_box(0.55f, 1.55f, 0.7f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.32f, 0.0f, 0.0f); draw_box(0.55f, 1.55f, 0.7f); glPopMatrix();
+}
+
+static void draw_storm_mask(void) {
+    // Head base
+    glColor3f(0.06f, 0.06f, 0.06f);
+    draw_box(0.65f, 0.75f, 0.65f);
+    // Faceplate
+    glColor3f(0.2f, 0.2f, 0.22f);
+    glPushMatrix(); glTranslatef(0.0f, -0.05f, 0.37f); draw_box(0.55f, 0.45f, 0.08f); glPopMatrix();
+    // Cyan vents
+    glColor3f(0.0f, 1.0f, 1.0f);
+    glPushMatrix(); glTranslatef(0.22f, -0.08f, 0.42f); draw_box(0.12f, 0.22f, 0.03f); glPopMatrix();
+    glPushMatrix(); glTranslatef(-0.22f, -0.08f, 0.42f); draw_box(0.12f, 0.22f, 0.03f); glPopMatrix();
+    // Broken horn silhouette (single jagged horn)
+    glColor3f(0.08f, 0.08f, 0.08f);
+    glPushMatrix(); glTranslatef(0.28f, 0.52f, 0.05f); draw_box(0.12f, 0.28f, 0.12f); glPopMatrix();
+}
+
 void draw_weapon_p(PlayerState *p) {
     if (p->in_vehicle) return; 
     glPushMatrix();
@@ -305,24 +367,19 @@ void draw_head(int weapon_id) {
 
 void draw_player_3rd(PlayerState *p) {
     glPushMatrix();
-    glTranslatef(p->x, p->y + 2.0f, p->z);
+    glTranslatef(p->x, p->y + 0.2f, p->z);
     glRotatef(-p->yaw, 0, 1, 0);
     if (p->in_vehicle) {
         draw_buggy_model();
     } else {
-        if(p->health <= 0) glColor3f(0.2, 0, 0); else glColor3f(1, 0, 0);
-        glPushMatrix(); glScalef(0.97f, 2.91f, 0.97f); 
-        glBegin(GL_QUADS);
-        glVertex3f(-0.5,-0.5,0.5); glVertex3f(0.5,-0.5,0.5); glVertex3f(0.5,0.5,0.5); glVertex3f(-0.5,0.5,0.5);
-        glVertex3f(-0.5,0.5,0.5); glVertex3f(0.5,0.5,0.5); glVertex3f(0.5,0.5,-0.5); glVertex3f(-0.5,0.5,-0.5);
-        glVertex3f(-0.5,-0.5,-0.5); glVertex3f(0.5,-0.5,-0.5); glVertex3f(0.5,0.5,-0.5); glVertex3f(-0.5,0.5,-0.5);
-        glVertex3f(-0.5,-0.5,-0.5); glVertex3f(-0.5,-0.5,0.5); glVertex3f(-0.5,0.5,0.5);
-        glVertex3f(-0.5,0.5,-0.5);
-        glVertex3f(0.5,-0.5,0.5); glVertex3f(0.5,-0.5,-0.5); glVertex3f(0.5,0.5,-0.5); glVertex3f(0.5,0.5,0.5);
-        glEnd(); glPopMatrix();
-        glPushMatrix(); glTranslatef(0, 1.54f, 0); draw_head(p->current_weapon); glPopMatrix();
-        glPushMatrix(); glTranslatef(0.5f, 1.0f, 0.5f);
-        glRotatef(p->pitch, 1, 0, 0);   
+        draw_ronin_shell();
+        glPushMatrix();
+        glTranslatef(0.0f, 1.85f, 0.0f);
+        glRotatef(p->pitch, 1, 0, 0);
+        draw_storm_mask();
+        glPopMatrix();
+        glPushMatrix(); glTranslatef(0.6f, 1.1f, 0.55f);
+        glRotatef(p->pitch, 1, 0, 0);
         glScalef(0.8f, 0.8f, 0.8f); draw_gun_model(p->current_weapon); glPopMatrix(); 
     }
     glPopMatrix();


### PR DESCRIPTION
### Motivation
- Replace the placeholder third‑person red capsule with a physically represented Neon Ronin outfit so other players/bots visually wear the Phase 525 merch in world. 
- Implement the Digital Tailor spec: cropped Ronin Shell with red satin lining, Storm Mask with cyan vents and broken horn silhouette, and baggy Tech Cargo pants. 
- Provide a simple low‑poly, procedural approach that fits the existing immediate‑mode GL renderer without adding external assets.

### Description
- Added a reusable box primitive `draw_box` and modelling helpers `draw_ronin_shell` and `draw_storm_mask` in `apps/lobby/src/main.c` to build the outfit procedurally. 
- Replaced the old third‑person capsule geometry in `draw_player_3rd` with `draw_ronin_shell()` and a positioned `draw_storm_mask()`, and adjusted the model origin from `p->y + 2.0f` to `p->y + 0.2f` to align the new pieces. 
- Kept weapon placement and rendering via the existing `draw_gun_model` but adjusted the local offsets so weapons remain visually attached to the new model. 
- Applied faction colors in code: matte black jacket, charcoal pants, cyan vents on the mask, and a red satin hem detail.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d7107aef48327a47dbf4cb8b48154)