### PR TITLE
Add Umbrella Glide ability (deploy -> glide) replacing Storm Arrows

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -1025,6 +1025,46 @@ void draw_player_3rd(PlayerState *p) {
         glRotatef(-draw_recoil * 10.0f, 1, 0, 0);
         glTranslatef(0.0f, 0.0f, -draw_recoil * 0.08f);
         glScalef(0.8f, 0.8f, 0.8f); draw_gun_model(p->current_weapon); glPopMatrix(); 
+        if (p->umbrella_state == UMBRELLA_STATE_DEPLOY || p->umbrella_state == UMBRELLA_STATE_GLIDE) {
+            float open = p->umbrella_anim;
+            if (open < 0.1f) open = 0.1f;
+            float move_mag = sqrtf(p->vx * p->vx + p->vz * p->vz);
+            float sway = sinf(SDL_GetTicks() * 0.006f + p->id * 0.5f) * 6.0f * open + move_mag * 8.0f;
+            glPushMatrix();
+            glTranslatef(0.0f, 4.3f + open * 0.25f, 0.0f);
+            glRotatef(sway, 0, 0, 1);
+            glColor3f(0.08f, 0.08f, 0.1f);
+            glBegin(GL_TRIANGLE_FAN);
+            glVertex3f(0.0f, 0.0f, 0.0f);
+            for (int s = 0; s <= 12; s++) {
+                float t = (float)s / 12.0f;
+                float a = t * 6.2831853f;
+                float r = 1.8f * open;
+                glVertex3f(cosf(a) * r, -0.1f - 0.18f * open, sinf(a) * r);
+            }
+            glEnd();
+            glColor3f(0.0f, 1.0f, 0.8f);
+            glBegin(GL_LINE_LOOP);
+            for (int s = 0; s < 12; s++) {
+                float t = (float)s / 12.0f;
+                float a = t * 6.2831853f;
+                float r = 1.8f * open;
+                glVertex3f(cosf(a) * r, -0.1f - 0.18f * open, sinf(a) * r);
+            }
+            glEnd();
+            glBegin(GL_LINES);
+            glVertex3f(0.0f, -2.1f, 0.0f);
+            glVertex3f(0.0f, 0.1f, 0.0f);
+            for (int s = 0; s < 8; s++) {
+                float t = (float)s / 8.0f;
+                float a = t * 6.2831853f;
+                float r = 1.65f * open;
+                glVertex3f(0.0f, 0.0f, 0.0f);
+                glVertex3f(cosf(a) * r, -0.1f - 0.18f * open, sinf(a) * r);
+            }
+            glEnd();
+            glPopMatrix();
+        }
     }
     glPopMatrix();
 }
@@ -1080,14 +1120,20 @@ void draw_hud(PlayerState *p) {
         draw_string(style_buf, 50, 108, 6);
     }
 
-    if (p->storm_charges > 0) {
-        char storm_buf[32];
-        sprintf(storm_buf, "STORM ARROWS: %d", p->storm_charges);
-        glColor3f(1.0f, 0.2f, 0.2f);
-        draw_string(storm_buf, 50, 140, 8);
-    } else if (p->ability_cooldown == 0) {
+    if (p->umbrella_state == UMBRELLA_STATE_DEPLOY) {
+        glColor3f(0.8f, 0.95f, 1.0f);
+        draw_string("E: UMBRELLA DEPLOY", 50, 140, 8);
+    } else if (p->umbrella_state == UMBRELLA_STATE_GLIDE) {
+        glColor3f(0.5f, 0.9f, 1.0f);
+        draw_string("E: GLIDING", 50, 140, 8);
+    } else if (p->umbrella_cooldown == 0) {
         glColor3f(0.0f, 0.8f, 1.0f);
-        draw_string("E: STORM ARROWS READY", 50, 140, 8);
+        draw_string("E: UMBRELLA READY", 50, 140, 8);
+    } else {
+        char umb_buf[48];
+        snprintf(umb_buf, sizeof(umb_buf), "E: UMBRELLA CD %d", p->umbrella_cooldown / 60);
+        glColor3f(0.7f, 0.8f, 1.0f);
+        draw_string(umb_buf, 50, 140, 8);
     }
     
     float raw_speed = sqrtf(p->vx*p->vx + p->vz*p->vz);
@@ -1260,8 +1306,21 @@ void draw_scene(PlayerState *render_p) {
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT); glLoadIdentity();
     local_state.scene_id = render_p->scene_id;
     phys_set_scene(render_p->scene_id);
-    float cam_y = render_p->in_vehicle ? 8.0f : (render_p->crouching ? 2.5f : EYE_HEIGHT);
-    float cam_z_off = render_p->in_vehicle ? 10.0f : 0.0f;
+    int umbrella_cam_active = (render_p->umbrella_state == UMBRELLA_STATE_DEPLOY || render_p->umbrella_state == UMBRELLA_STATE_GLIDE);
+    float umbrella_target_blend = umbrella_cam_active ? 1.0f : 0.0f;
+    float umbrella_blend_step = 1.0f / (float)UMBRELLA_DEPLOY_TICKS;
+    if (render_p->umbrella_cam_blend < umbrella_target_blend) {
+        render_p->umbrella_cam_blend += umbrella_blend_step;
+        if (render_p->umbrella_cam_blend > umbrella_target_blend) render_p->umbrella_cam_blend = umbrella_target_blend;
+    } else if (render_p->umbrella_cam_blend > umbrella_target_blend) {
+        render_p->umbrella_cam_blend -= umbrella_blend_step;
+        if (render_p->umbrella_cam_blend < umbrella_target_blend) render_p->umbrella_cam_blend = umbrella_target_blend;
+    }
+
+    float vehicle_cam_y = render_p->in_vehicle ? 8.0f : (render_p->crouching ? 2.5f : EYE_HEIGHT);
+    float vehicle_cam_off = render_p->in_vehicle ? 10.0f : 0.0f;
+    float cam_y = vehicle_cam_y + (render_p->umbrella_cam_blend * 2.0f);
+    float cam_z_off = vehicle_cam_off + (render_p->umbrella_cam_blend * 7.4f);
     
     float rad = -cam_yaw * 0.01745f;
     float cx = sinf(rad) * cam_z_off;
@@ -1285,7 +1344,7 @@ void draw_scene(PlayerState *render_p) {
     draw_garage_vehicle_pads();
     draw_garage_portal_frame();
     draw_projectiles();
-    if (render_p->in_vehicle) draw_player_3rd(render_p);
+    if (render_p->in_vehicle || render_p->umbrella_cam_blend > 0.01f) draw_player_3rd(render_p);
     for(int i=0; i<MAX_CLIENTS; i++) {
         PlayerState *p = &local_state.players[i];
         if (!p->active || p->scene_id != render_p->scene_id) continue;
@@ -1728,6 +1787,10 @@ void net_process_snapshot(char *buffer, int len) {
         p->in_vehicle = np->in_vehicle;
         p->storm_charges = np->storm_charges;
         p->hit_feedback = np->hit_feedback;
+        p->umbrella_state = np->umbrella_state;
+        p->umbrella_active = (p->umbrella_state != UMBRELLA_STATE_NONE);
+        p->umbrella_deploy_ticks = np->umbrella_deploy_ticks;
+        p->umbrella_anim = ((float)np->umbrella_anim_q) / 255.0f;
         p->ammo[p->current_weapon] = np->ammo;
 
         if (now_shooting && !was_shooting) p->recoil_anim = 1.0f;
@@ -2113,13 +2176,16 @@ int main(int argc, char* argv[]) {
                             p0->scene_id = dest_scene;
                             p0->x = sx; p0->y = sy; p0->z = sz;
                             p0->vx = 0.0f; p0->vy = 0.0f; p0->vz = 0.0f;
+                            umbrella_clear_state(p0);
                             scene_request_transition(dest_scene);
                         }
                     } else if (in_garage && scene_near_vehicle_pad(local_state.scene_id, p0->x, p0->z, 6.0f, NULL)) {
                         p0->in_vehicle = !p0->in_vehicle;
+                        if (p0->in_vehicle) umbrella_clear_state(p0);
                         p0->vehicle_cooldown = 30;
                     } else if (!in_garage) {
                         p0->in_vehicle = !p0->in_vehicle;
+                        if (p0->in_vehicle) umbrella_clear_state(p0);
                         p0->vehicle_cooldown = 30;
                     }
                 }

--- a/apps/server/src/main.c
+++ b/apps/server/src/main.c
@@ -399,6 +399,12 @@ void server_broadcast() {
             np.in_vehicle = (unsigned char)p->in_vehicle;
             np.hit_feedback = (unsigned char)p->hit_feedback;
             np.storm_charges = (unsigned char)p->storm_charges;
+            np.umbrella_state = (unsigned char)p->umbrella_state;
+            np.umbrella_deploy_ticks = (unsigned char)((p->umbrella_deploy_ticks < 0) ? 0 : p->umbrella_deploy_ticks);
+            int anim_q = (int)(p->umbrella_anim * 255.0f);
+            if (anim_q < 0) anim_q = 0;
+            if (anim_q > 255) anim_q = 255;
+            np.umbrella_anim_q = (unsigned char)anim_q;
 
             p->accumulated_reward = 0;
             memcpy(buffer + cursor, &np, sizeof(NetPlayer)); cursor += (int)sizeof(NetPlayer);
@@ -491,6 +497,7 @@ int main(int argc, char *argv[]) {
                         p->x = sx; p->y = sy; p->z = sz;
                         p->vx = 0.0f; p->vy = 0.0f; p->vz = 0.0f;
                         p->in_vehicle = 0;
+                        umbrella_clear_state(p);
                         p->portal_cooldown_until_ms = now + 1000;
                         p->in_use = 0;
                         printf("PORTAL_TRAVEL client=%d from=%d to=%d\n", i, from_scene, dest_scene);
@@ -499,10 +506,12 @@ int main(int argc, char *argv[]) {
                     int in_garage = p->scene_id == SCENE_GARAGE_OSAKA;
                     if (in_garage && scene_near_vehicle_pad(p->scene_id, p->x, p->z, 6.0f, NULL)) {
                         p->in_vehicle = !p->in_vehicle;
+                        if (p->in_vehicle) umbrella_clear_state(p);
                         p->vehicle_cooldown = 30;
                         printf("Client %d Toggle Vehicle: %d\n", i, p->in_vehicle);
                     } else if (!in_garage) {
                         p->in_vehicle = !p->in_vehicle;
+                        if (p->in_vehicle) umbrella_clear_state(p);
                         p->vehicle_cooldown = 30;
                         printf("Client %d Toggle Vehicle: %d\n", i, p->in_vehicle);
                     }

--- a/packages/common/net_sim.h
+++ b/packages/common/net_sim.h
@@ -54,18 +54,27 @@ static inline void shankpit_simulate_movement_tick(PlayerState *p, unsigned int 
         .forward = p->in_fwd,
         .strafe = p->in_vehicle ? 0.0f : p->in_strafe,
         .control_yaw_deg = p->yaw,
-        .wants_jump = p->in_jump,
+        .wants_jump = (p->umbrella_state == UMBRELLA_STATE_GLIDE) ? 0 : p->in_jump,
         .wants_sprint = 0
     };
     MoveWish move_wish = shankpit_move_wish_from_intent(move_intent);
 
     float max_spd = p->in_vehicle ? BUGGY_MAX_SPEED : MAX_SPEED;
     float acc = p->in_vehicle ? BUGGY_ACCEL : ACCEL;
+    if (p->umbrella_state == UMBRELLA_STATE_GLIDE) {
+        acc = UMBRELLA_GLIDE_AIR_ACCEL;
+    }
     float wish_speed = move_wish.magnitude * max_spd;
     accelerate(p, move_wish.dir_x, move_wish.dir_z, wish_speed, acc);
 
     float g = p->in_vehicle ? BUGGY_GRAVITY : (p->in_jump ? GRAVITY_FLOAT : GRAVITY_DROP);
+    if (p->umbrella_state == UMBRELLA_STATE_GLIDE) {
+        g *= UMBRELLA_GLIDE_GRAVITY_SCALE;
+    }
     p->vy -= g;
+    if (p->umbrella_state == UMBRELLA_STATE_GLIDE && p->vy < UMBRELLA_GLIDE_MAX_FALL_SPEED) {
+        p->vy = UMBRELLA_GLIDE_MAX_FALL_SPEED;
+    }
     if (p->in_jump && p->on_ground) {
         p->y += 0.1f;
         p->vy += JUMP_FORCE;

--- a/packages/common/physics.h
+++ b/packages/common/physics.h
@@ -3,6 +3,7 @@
 #include <math.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include "protocol.h"
 
 // --- TUNING ---
@@ -15,6 +16,16 @@
 #define STOP_SPEED 0.1f     
 #define SLIDE_FRICTION 0.01f 
 #define CROUCH_SPEED 0.35f  
+#define UMBRELLA_DEPLOY_TICKS 12
+#define UMBRELLA_COOLDOWN_TICKS 150
+#define UMBRELLA_POP_VELOCITY_GROUNDED 4.6f
+#define UMBRELLA_POP_VELOCITY_AIR 1.6f
+#define UMBRELLA_GLIDE_MAX_FALL_SPEED -1.6f
+#define UMBRELLA_GLIDE_GRAVITY_SCALE 0.2f
+#define UMBRELLA_GLIDE_AIR_ACCEL 0.75f
+#define UMBRELLA_HIT_RADIUS 2.35f
+#define UMBRELLA_HIT_REHIT_MS 60
+#define UMBRELLA_HIT_MAX_PER_TARGET 4
 
 // --- BUGGY TUNING ---
 #define BUGGY_MAX_SPEED 2.5f    
@@ -575,12 +586,138 @@ void phys_respawn(PlayerState *p, unsigned int now) {
     for(int i=0; i<MAX_WEAPONS; i++) p->ammo[i] = WPN_STATS[i].ammo_max;
     p->storm_charges = 0;
     p->ability_cooldown = 0;
+    p->umbrella_active = 0;
+    p->umbrella_state = UMBRELLA_STATE_NONE;
+    p->umbrella_deploy_ticks = 0;
+    p->umbrella_cooldown = 0;
+    p->umbrella_anim = 0.0f;
+    p->umbrella_cam_blend = 0.0f;
+    p->umbrella_cancel_lock_ticks = 0;
+    p->umbrella_yaw = 0.0f;
+    memset(p->umbrella_hit_next_ms, 0, sizeof(p->umbrella_hit_next_ms));
+    memset(p->umbrella_hit_count, 0, sizeof(p->umbrella_hit_count));
     p->portal_cooldown_until_ms = 0;
     p->stunned_until_ms = 0;
     p->stun_immune_until_ms = 0;
     if (p->is_bot) {
         PlayerState *winner = get_best_bot();
         if (winner && winner != p) evolve_bot(p, winner);
+    }
+}
+
+static inline void umbrella_clear_state(PlayerState *p) {
+    p->umbrella_active = 0;
+    p->umbrella_state = UMBRELLA_STATE_NONE;
+    p->umbrella_deploy_ticks = 0;
+    p->umbrella_anim = 0.0f;
+    p->umbrella_cancel_lock_ticks = 0;
+    memset(p->umbrella_hit_next_ms, 0, sizeof(p->umbrella_hit_next_ms));
+    memset(p->umbrella_hit_count, 0, sizeof(p->umbrella_hit_count));
+}
+
+static inline int try_activate_umbrella(PlayerState *p, unsigned int now_ms) {
+    if (!p || !p->active || p->state != STATE_ALIVE) return 0;
+    if (now_ms < p->stunned_until_ms) return 0;
+    if (p->in_vehicle) return 0;
+    if (p->umbrella_active) return 0;
+    if (p->umbrella_cooldown > 0) return 0;
+
+    p->umbrella_active = 1;
+    p->umbrella_state = UMBRELLA_STATE_DEPLOY;
+    p->umbrella_deploy_ticks = UMBRELLA_DEPLOY_TICKS;
+    p->umbrella_cooldown = UMBRELLA_COOLDOWN_TICKS;
+    p->umbrella_anim = 0.0f;
+    p->umbrella_cam_blend = 0.0f;
+    p->umbrella_cancel_lock_ticks = 6;
+    p->umbrella_yaw = p->yaw;
+    memset(p->umbrella_hit_next_ms, 0, sizeof(p->umbrella_hit_next_ms));
+    memset(p->umbrella_hit_count, 0, sizeof(p->umbrella_hit_count));
+
+    if (p->on_ground) {
+        p->y += 0.1f;
+        p->vy = UMBRELLA_POP_VELOCITY_GROUNDED;
+    } else {
+        if (p->vy < -3.0f) p->vy = -3.0f;
+        p->vy += UMBRELLA_POP_VELOCITY_AIR;
+        if (p->vy > UMBRELLA_POP_VELOCITY_GROUNDED) p->vy = UMBRELLA_POP_VELOCITY_GROUNDED;
+    }
+    p->on_ground = 0;
+    return 1;
+}
+
+static inline void umbrella_apply_hit(PlayerState *owner, PlayerState *target, int final_hit, unsigned int now_ms) {
+    if (!owner || !target) return;
+    int damage = final_hit ? 12 : 4;
+    float kb_h = final_hit ? 4.8f : 1.5f;
+    float kb_v = final_hit ? 5.1f : 1.4f;
+
+    float dx = target->x - owner->x;
+    float dz = target->z - owner->z;
+    float d2 = dx * dx + dz * dz;
+    if (d2 > 0.0001f) {
+        float inv = 1.0f / sqrtf(d2);
+        dx *= inv;
+        dz *= inv;
+    } else {
+        float r = -owner->yaw * 0.0174533f;
+        dx = sinf(r);
+        dz = -cosf(r);
+    }
+
+    target->vx += dx * kb_h;
+    target->vz += dz * kb_h;
+    target->vy = kb_v;
+    target->on_ground = 0;
+    target->shield_regen_timer = SHIELD_REGEN_DELAY;
+    owner->hit_feedback = final_hit ? 20 : 10;
+
+    if (target->shield > 0) {
+        if (target->shield >= damage) { target->shield -= damage; damage = 0; }
+        else { damage -= target->shield; target->shield = 0; }
+    }
+    target->health -= damage;
+    if (target->health <= 0) {
+        owner->kills++;
+        target->deaths++;
+        owner->hit_feedback = 30;
+        phys_respawn(target, now_ms);
+        return;
+    }
+    if (now_ms >= target->stun_immune_until_ms) {
+        unsigned int stun_end = now_ms + (final_hit ? 170 : 85);
+        if (stun_end > target->stunned_until_ms) target->stunned_until_ms = stun_end;
+        target->stun_immune_until_ms = now_ms + (final_hit ? 260 : 180);
+    }
+}
+
+static inline void update_umbrella_attack(PlayerState *owner, PlayerState *targets, unsigned int now_ms) {
+    if (!owner || !targets) return;
+    if (!owner->umbrella_active || owner->umbrella_state != UMBRELLA_STATE_DEPLOY) return;
+
+    float hit_y_min = owner->y + 1.3f;
+    float hit_y_max = owner->y + 5.2f;
+    int final_hit = owner->umbrella_deploy_ticks <= 2;
+
+    for (int i = 0; i < MAX_CLIENTS; i++) {
+        PlayerState *target = &targets[i];
+        if (target == owner) continue;
+        if (!target->active || target->state == STATE_DEAD) continue;
+        if (target->scene_id != owner->scene_id) continue;
+        if (owner->umbrella_hit_count[i] >= UMBRELLA_HIT_MAX_PER_TARGET) continue;
+        if (now_ms < owner->umbrella_hit_next_ms[i]) continue;
+
+        float tx = target->x;
+        float ty = target->y + (PLAYER_HEIGHT * 0.45f);
+        float tz = target->z;
+        float dx = tx - owner->x;
+        float dz = tz - owner->z;
+        float dist2 = dx * dx + dz * dz;
+        if (dist2 > (UMBRELLA_HIT_RADIUS * UMBRELLA_HIT_RADIUS)) continue;
+        if (ty < hit_y_min || ty > hit_y_max) continue;
+
+        umbrella_apply_hit(owner, target, final_hit, now_ms);
+        owner->umbrella_hit_count[i]++;
+        owner->umbrella_hit_next_ms[i] = now_ms + UMBRELLA_HIT_REHIT_MS;
     }
 }
 
@@ -607,16 +744,48 @@ static inline void spawn_projectile(Projectile *projectiles, PlayerState *p, int
     }
 }
 
-void update_weapons(PlayerState *p, PlayerState *targets, Projectile *projectiles, int shoot, int reload, int ability_press) {
-    if (p->in_vehicle) return; 
+void update_weapons(PlayerState *p, PlayerState *targets, Projectile *projectiles, int shoot, int reload, int ability_press, unsigned int now_ms) {
+    if (p->state != STATE_ALIVE) {
+        umbrella_clear_state(p);
+        return;
+    }
+    if (p->umbrella_cooldown > 0) p->umbrella_cooldown--;
+    if (p->ability_cooldown > 0) p->ability_cooldown--;
+    if (p->in_vehicle) {
+        umbrella_clear_state(p);
+        return;
+    }
     if (p->reload_timer > 0) p->reload_timer--;
     if (p->attack_cooldown > 0) p->attack_cooldown--;
     if (p->is_shooting > 0) p->is_shooting--;
-    if (p->ability_cooldown > 0) p->ability_cooldown--;
+    p->storm_charges = 0;
 
-    if (ability_press && p->ability_cooldown == 0 && p->storm_charges == 0) {
-        p->storm_charges = 5;
-        p->ability_cooldown = 480;
+    if (p->umbrella_cancel_lock_ticks > 0) p->umbrella_cancel_lock_ticks--;
+    if (ability_press && !p->umbrella_active) {
+        try_activate_umbrella(p, now_ms);
+    } else if (ability_press && p->umbrella_state == UMBRELLA_STATE_GLIDE && p->umbrella_cancel_lock_ticks == 0) {
+        umbrella_clear_state(p);
+    }
+
+    if (p->umbrella_active) {
+        if (now_ms < p->stunned_until_ms) umbrella_clear_state(p);
+        else if (p->on_ground && p->umbrella_state == UMBRELLA_STATE_GLIDE) umbrella_clear_state(p);
+        else if (p->umbrella_state == UMBRELLA_STATE_DEPLOY) {
+            if (p->umbrella_deploy_ticks > 0) p->umbrella_deploy_ticks--;
+            p->umbrella_anim = 1.0f - ((float)p->umbrella_deploy_ticks / (float)UMBRELLA_DEPLOY_TICKS);
+            if (p->umbrella_anim < 0.0f) p->umbrella_anim = 0.0f;
+            if (p->umbrella_anim > 1.0f) p->umbrella_anim = 1.0f;
+            update_umbrella_attack(p, targets, now_ms);
+            if (p->umbrella_deploy_ticks <= 0) {
+                p->umbrella_state = UMBRELLA_STATE_GLIDE;
+                p->umbrella_anim = 1.0f;
+            }
+        } else if (p->umbrella_state == UMBRELLA_STATE_GLIDE) {
+            p->umbrella_anim = 1.0f;
+            if (p->crouching) {
+                umbrella_clear_state(p);
+            }
+        }
     }
 
     int w = p->current_weapon;
@@ -628,14 +797,6 @@ void update_weapons(PlayerState *p, PlayerState *targets, Projectile *projectile
     }
     if (p->reload_timer == 1) p->ammo[w] = WPN_STATS[w].ammo_max;
     if (shoot && p->attack_cooldown == 0 && p->reload_timer == 0) {
-        if (p->storm_charges > 0 && w == WPN_SNIPER) {
-            int storm_damage = (int)(WPN_STATS[w].dmg * 0.7f);
-            spawn_projectile(projectiles, p, storm_damage, 1, 1.5f);
-            p->storm_charges--;
-            p->attack_cooldown = 8;
-            p->recoil_anim = 0.5f;
-            return;
-        }
         if (w != WPN_KNIFE && p->ammo[w] <= 0) p->reload_timer = RELOAD_TIME_FULL;
         else {
             p->is_shooting = 5; p->recoil_anim = 1.0f;

--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -30,6 +30,9 @@
 #define RELOAD_TIME_FULL 60      
 #define RELOAD_TIME_TACTICAL 42  
 #define SHIELD_REGEN_DELAY 180 
+#define UMBRELLA_STATE_NONE 0
+#define UMBRELLA_STATE_DEPLOY 1
+#define UMBRELLA_STATE_GLIDE 2
 
 typedef struct {
     int active;
@@ -103,6 +106,9 @@ typedef struct {
     unsigned char in_vehicle;
     unsigned char hit_feedback; 
     unsigned char storm_charges;
+    unsigned char umbrella_state;
+    unsigned char umbrella_deploy_ticks;
+    unsigned char umbrella_anim_q;
 } NetPlayer;
 
 typedef struct {
@@ -142,6 +148,16 @@ typedef struct {
     unsigned int respawn_time;
     int storm_charges;
     int ability_cooldown;
+    int umbrella_active;
+    int umbrella_state;
+    int umbrella_deploy_ticks;
+    int umbrella_cooldown;
+    float umbrella_anim;
+    float umbrella_cam_blend;
+    unsigned int umbrella_hit_next_ms[MAX_CLIENTS];
+    unsigned char umbrella_hit_count[MAX_CLIENTS];
+    int umbrella_cancel_lock_ticks;
+    float umbrella_yaw;
     unsigned int stunned_until_ms;
     unsigned int stun_immune_until_ms;
     float run_phase;

--- a/packages/simulation/local_game.h
+++ b/packages/simulation/local_game.h
@@ -140,11 +140,22 @@ void update_entity(PlayerState *p, float dt, void *server_context, unsigned int 
         p->in_ability = 0;
         p->vx = 0.0f;
         p->vz = 0.0f;
+        umbrella_clear_state(p);
+    }
+
+    if (p->in_vehicle) {
+        umbrella_clear_state(p);
     }
 
     apply_friction(p);
     float g = (p->in_jump) ? GRAVITY_FLOAT : GRAVITY_DROP;
+    if (p->umbrella_state == UMBRELLA_STATE_GLIDE) {
+        g *= UMBRELLA_GLIDE_GRAVITY_SCALE;
+    }
     p->vy -= g; 
+    if (p->umbrella_state == UMBRELLA_STATE_GLIDE && p->vy < UMBRELLA_GLIDE_MAX_FALL_SPEED) {
+        p->vy = UMBRELLA_GLIDE_MAX_FALL_SPEED;
+    }
     p->y += p->vy;
     
     resolve_collision(p);
@@ -155,7 +166,7 @@ void update_entity(PlayerState *p, float dt, void *server_context, unsigned int 
     if (p->recoil_anim < 0) p->recoil_anim = 0;
     if (p->hit_feedback > 0) p->hit_feedback--;
 
-    update_weapons(p, local_state.players, local_state.projectiles, p->in_shoot > 0, p->in_reload > 0, p->in_ability > 0);
+    update_weapons(p, local_state.players, local_state.projectiles, p->in_shoot > 0, p->in_reload > 0, p->in_ability > 0, cmd_time);
     scene_safety_check(p);
 }
 
@@ -248,15 +259,16 @@ void local_update(float fwd, float str, float yaw, float pitch, int shoot, int w
         .forward = fwd,
         .strafe = str,
         .control_yaw_deg = yaw,
-        .wants_jump = jump,
+        .wants_jump = (p0->umbrella_state == UMBRELLA_STATE_GLIDE) ? 0 : jump,
         .wants_sprint = 0
     };
     MoveWish move_wish = shankpit_move_wish_from_intent(move_intent);
-    accelerate(p0, move_wish.dir_x, move_wish.dir_z, move_wish.magnitude * MAX_SPEED, ACCEL);
+    float move_accel = (p0->umbrella_state == UMBRELLA_STATE_GLIDE) ? UMBRELLA_GLIDE_AIR_ACCEL : ACCEL;
+    accelerate(p0, move_wish.dir_x, move_wish.dir_z, move_wish.magnitude * MAX_SPEED, move_accel);
     
     int fresh_jump_press = (jump && !was_holding_jump);
     // --- PHASE 485: TUNED SLIDE JUMP ---
-    if (jump && p0->on_ground) {
+    if (jump && p0->on_ground && p0->umbrella_state != UMBRELLA_STATE_GLIDE) {
         float speed = sqrtf(p0->vx*p0->vx + p0->vz*p0->vz);
         if (p0->crouching && speed > 0.5f && fresh_jump_press) {
             float boost_mult = 1.0f + (0.25f / speed);
@@ -290,7 +302,7 @@ void local_update(float fwd, float str, float yaw, float pitch, int shoot, int w
             p->in_reload = (b_btns & BTN_RELOAD);
             p->crouching = (b_btns & BTN_CROUCH);
             p->in_ability = 0;
-            if ((b_btns & BTN_JUMP) && p->on_ground) { p->y += 0.1f; p->vy += JUMP_FORCE; }
+            if ((b_btns & BTN_JUMP) && p->on_ground && p->umbrella_state != UMBRELLA_STATE_GLIDE) { p->y += 0.1f; p->vy += JUMP_FORCE; }
         }
         phys_set_scene(p->scene_id);
         update_entity(p, 0.016f, server_context, cmd_time);


### PR DESCRIPTION
### Motivation
- Replace the Storm Arrows behavior bound to `E` with an authoritative Umbrella Glide ability featuring a short deploy ascent (with active melee hit volume) that transitions into a floaty glide, while preserving the existing SHANKPIT simulation and netcode architecture.
- Implement a dedicated umbrella state machine (NONE → DEPLOY → GLIDE) that is owned by the authoritative sim and replicated to clients for correct remote visuals and camera blending.
- Keep changes surgical and compatible with the existing input/command/snapshot flow and the legacy OpenGL immediate-mode render path.

### Description
- Added umbrella runtime and protocol fields and constants: new `UMBRELLA_*` tuning constants and PlayerState/NetPlayer fields (`umbrella_state`, `umbrella_deploy_ticks`, `umbrella_anim_q`, `umbrella_anim`, `umbrella_cam_blend`, per-target rehit arrays, cooldowns, etc.) in `packages/common/protocol.h` and constants in `packages/common/physics.h`.
- Implemented authoritative umbrella activation and state machine in `packages/common/physics.h`: `try_activate_umbrella(...)`, `umbrella_clear_state(...)`, `update_umbrella_attack(...)`, and `umbrella_apply_hit(...)` providing immediate pop velocity, per-target rehit delay and hit cap, light early hits and stronger final launcher hit, hit feedback, and stun windows.
- Integrated umbrella into weapon/ability flow by extending `update_weapons(...)` to accept `now_ms`, gating activation on cooldown/stun/vehicle, decrementing deploy ticks and anim, and transitioning to GLIDE; removed the active Storm Arrows activation hot-path and zeroed `storm_charges` during the live path.
- Updated simulation/prediction and local sim movement to implement glide physics and controls: suppressed jump while gliding, reduced gravity scale and fall-speed clamp, floaty air accel (`packages/common/net_sim.h` and `packages/simulation/local_game.h`).
- Network/replication: server snapshot writer now emits `umbrella_state`, `umbrella_deploy_ticks`, and a quantized `umbrella_anim_q`; client snapshot reader applies those fields to remote `PlayerState` so remote players and clients render accurate open/ glide visuals (`apps/server/src/main.c`, `apps/lobby/src/main.c`).
- Rendering / HUD / Camera: added an immediate-mode umbrella canopy + ribs + pole with deploy open amount and sway in `draw_player_3rd(...)`, HUD lines for umbrella ready/deploy/glide/cooldown, and camera blend from FP → third-person chase while DEPLOY/GLIDE in `draw_scene(...)` (`apps/lobby/src/main.c`).
- Robustness / cleanup: umbrella state cleared on respawn, stun, portal travel, vehicle entry, on death, and when entering vehicle or when sim forces state changes to avoid stale umbrella states (server and local paths updated).

### Testing
- `make -j4` (full lobby + server build) failed in this environment due to missing SDL2 development headers, specifically `SDL2/SDL.h` and `SDL2/SDL_opengl.h` which are required for the lobby build.
- Server-only compile succeeded using `gcc -O2 -Wall -D_REENTRANT -Ipackages/common -Ipackages/simulation -Ipackages/render apps/server/src/main.c -o /tmp/shank_server_test -lm` indicating the server/simulation changes compile cleanly on a headless toolchain.
- Running the project test runner failed in this environment because `./run_tests` is not executable here (`permission denied` / wrapper environment issue), so automated tests could not be executed end-to-end in this session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb5af9edb48327932808b60476bba6)