### PR TITLE
Add first-pass authoritative helicopter vehicle support

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -1049,6 +1049,37 @@ void draw_player_3rd(PlayerState *p) {
     glPopMatrix();
 }
 
+static void draw_helicopter_model(const HelicopterState *h) {
+    if (!h || !h->active) return;
+    glPushMatrix();
+    glTranslatef(h->x, h->y, h->z);
+    glRotatef(180.0f - norm_yaw_deg(h->yaw), 0, 1, 0);
+    glRotatef(h->roll_visual, 0, 0, 1);
+    glRotatef(h->pitch_visual, 1, 0, 0);
+
+    glColor3f(0.25f, 0.7f, 0.25f); draw_box(3.8f, 1.2f, 6.0f);
+    glPushMatrix(); glTranslatef(0.0f, 0.4f, -3.5f); glColor3f(0.2f, 0.6f, 0.2f); draw_box(0.5f, 0.4f, 6.0f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.0f, 0.7f, 1.4f); glColor3f(0.35f, 0.85f, 0.35f); draw_box(2.2f, 0.5f, 1.6f); glPopMatrix();
+    glPushMatrix(); glTranslatef(-1.4f, -0.8f, 0.9f); glColor3f(0.4f, 0.4f, 0.4f); draw_box(0.2f, 0.2f, 4.8f); glPopMatrix();
+    glPushMatrix(); glTranslatef(1.4f, -0.8f, 0.9f); glColor3f(0.4f, 0.4f, 0.4f); draw_box(0.2f, 0.2f, 4.8f); glPopMatrix();
+
+    glPushMatrix();
+    glTranslatef(0.0f, 1.1f, 0.0f);
+    glRotatef(h->rotor_angle, 0, 1, 0);
+    glColor3f(0.05f, 0.05f, 0.05f);
+    draw_box(8.0f, 0.08f, 0.18f);
+    draw_box(0.18f, 0.08f, 8.0f);
+    glPopMatrix();
+
+    glPushMatrix();
+    glTranslatef(0.0f, 0.5f, -6.2f);
+    glRotatef(h->rotor_angle * 2.5f, 0, 0, 1);
+    glColor3f(0.1f, 0.1f, 0.1f);
+    draw_box(1.4f, 0.05f, 0.16f);
+    glPopMatrix();
+    glPopMatrix();
+}
+
 // --- NEW HELPER: Wireframe Circle ---
 void draw_circle(float x, float y, float r, int segments) {
     glBegin(GL_LINE_LOOP);
@@ -1090,12 +1121,16 @@ void draw_hud(PlayerState *p) {
     
     if (p->in_vehicle) {
         glColor3f(0.0f, 1.0f, 0.0f);
-        draw_string("BUGGY ONLINE", 50, 120, 12);
+        draw_string(p->vehicle_type == VEH_HELICOPTER ? "HELI ONLINE" : "BUGGY ONLINE", 50, 120, 12);
         char style_buf[96];
-        snprintf(style_buf, sizeof(style_buf), "F6 STYLE:%s F7 GLOW:%s F8 LIGHT:%s",
-                 vehicle_style_enabled ? "ON" : "OFF",
-                 vehicle_underglow_enabled ? "ON" : "OFF",
-                 vehicle_worklights_enabled ? "ON" : "OFF");
+        if (p->vehicle_type == VEH_HELICOPTER) {
+            snprintf(style_buf, sizeof(style_buf), "HP:%d ALT:%.1f", p->health, p->y);
+        } else {
+            snprintf(style_buf, sizeof(style_buf), "F6 STYLE:%s F7 GLOW:%s F8 LIGHT:%s",
+                     vehicle_style_enabled ? "ON" : "OFF",
+                     vehicle_underglow_enabled ? "ON" : "OFF",
+                     vehicle_worklights_enabled ? "ON" : "OFF");
+        }
         glColor3f(0.95f, 0.55f, 0.1f);
         draw_string(style_buf, 50, 108, 6);
     }
@@ -1224,6 +1259,7 @@ static void draw_garage_overlay(PlayerState *p) {
     scene_portal_info(local_state.scene_id, &portal_x, &portal_y, &portal_z, &portal_r);
     int portal_target = target_in_view(p, portal_x, portal_y, portal_z, 30.0f, 0.75f);
     int pad_target = 0;
+    int heli_target = 0;
     if (scene_near_vehicle_pad(local_state.scene_id, p->x, p->z, 12.0f, NULL)) {
         int pad_idx = -1;
         if (scene_near_vehicle_pad(local_state.scene_id, p->x, p->z, 12.0f, &pad_idx)) {
@@ -1231,9 +1267,22 @@ static void draw_garage_overlay(PlayerState *p) {
         }
     }
 
+    for (int hi = 0; hi < MAX_HELICOPTERS; hi++) {
+        HelicopterState *h = &local_state.helicopters[hi];
+        if (!h->active || h->scene_id != p->scene_id || h->occupant_player_id >= 0) continue;
+        float dx = h->x - p->x, dy = h->y - p->y, dz = h->z - p->z;
+        if ((dx * dx + dy * dy + dz * dz) <= (g_heli_tuning.enter_radius * g_heli_tuning.enter_radius)) {
+            if (target_in_view(p, h->x, h->y + 1.0f, h->z, 25.0f, 0.65f)) {
+                heli_target = 1;
+            }
+        }
+    }
+
     glColor3f(1.0f, 1.0f, 0.0f);
     if (portal_target) {
         draw_string("TRAVEL", 600, 350, 8);
+    } else if (heli_target || (p->in_vehicle && p->vehicle_type == VEH_HELICOPTER)) {
+        draw_string(p->in_vehicle ? "PRESS F TO EXIT HELICOPTER" : "PRESS F TO ENTER HELICOPTER", 460, 350, 8);
     } else if (pad_target) {
         draw_string(p->in_vehicle ? "EXIT VEHICLE" : "ENTER VEHICLE", 560, 350, 8);
     }
@@ -1291,12 +1340,38 @@ void draw_scene(PlayerState *render_p) {
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT); glLoadIdentity();
     local_state.scene_id = render_p->scene_id;
     phys_set_scene(render_p->scene_id);
-    float cam_y = render_p->in_vehicle ? 8.0f : (render_p->crouching ? 2.5f : EYE_HEIGHT);
-    float cam_z_off = render_p->in_vehicle ? 10.0f : 0.0f;
-    
-    float rad = -cam_yaw * 0.01745f;
-    float cx = sinf(rad) * cam_z_off;
-    float cz = cosf(rad) * cam_z_off;
+    float cam_y = (render_p->crouching ? 2.5f : EYE_HEIGHT);
+    float cx = 0.0f, cz = 0.0f;
+    static float heli_cam_x = 0.0f, heli_cam_y = 0.0f, heli_cam_z = 0.0f;
+    if (render_p->in_vehicle && render_p->vehicle_type == VEH_HELICOPTER) {
+        HelicopterState *hh = NULL;
+        for (int i = 0; i < MAX_HELICOPTERS; i++) {
+            if (local_state.helicopters[i].active && local_state.helicopters[i].occupant_player_id == render_p->id) {
+                hh = &local_state.helicopters[i]; break;
+            }
+        }
+        if (hh) {
+            cam_yaw = hh->yaw;
+            float rr = -cam_yaw * 0.01745f;
+            float tx = render_p->x - sinf(rr) * 18.0f;
+            float ty = render_p->y + 7.0f;
+            float tz = render_p->z - cosf(rr) * 18.0f;
+            if (heli_cam_x == 0.0f && heli_cam_y == 0.0f && heli_cam_z == 0.0f) {
+                heli_cam_x = tx; heli_cam_y = ty; heli_cam_z = tz;
+            }
+            heli_cam_x += (tx - heli_cam_x) * 0.14f;
+            heli_cam_y += (ty - heli_cam_y) * 0.14f;
+            heli_cam_z += (tz - heli_cam_z) * 0.14f;
+            glRotatef(-18.0f, 1, 0, 0);
+            glRotatef(-cam_yaw, 0, 1, 0);
+            glTranslatef(-heli_cam_x, -heli_cam_y, -heli_cam_z);
+        }
+    } else {
+        float cam_z_off = render_p->in_vehicle ? 10.0f : 0.0f;
+        float rad = -cam_yaw * 0.01745f;
+        cx = sinf(rad) * cam_z_off;
+        cz = cosf(rad) * cam_z_off;
+    }
     
     float reconcile_x = 0.0f;
     float reconcile_y = 0.0f;
@@ -1307,14 +1382,21 @@ void draw_scene(PlayerState *render_p) {
         reconcile_z = reconcile_corr_z;
     }
 
-    glRotatef(-cam_pitch, 1, 0, 0); glRotatef(-cam_yaw, 0, 1, 0);
-    glTranslatef(-((render_p->x + reconcile_x) - cx), -((render_p->y + reconcile_y) + cam_y), -((render_p->z + reconcile_z) - cz));
+    if (!(render_p->in_vehicle && render_p->vehicle_type == VEH_HELICOPTER)) {
+        glRotatef(-cam_pitch, 1, 0, 0); glRotatef(-cam_yaw, 0, 1, 0);
+        glTranslatef(-((render_p->x + reconcile_x) - cx), -((render_p->y + reconcile_y) + cam_y), -((render_p->z + reconcile_z) - cz));
+    }
     
     draw_grid(); 
     update_and_draw_trails();
     draw_map();
     draw_garage_vehicle_pads();
     draw_garage_portal_frame();
+    for (int hi = 0; hi < MAX_HELICOPTERS; hi++) {
+        HelicopterState *h = &local_state.helicopters[hi];
+        if (!h->active || h->scene_id != render_p->scene_id) continue;
+        draw_helicopter_model(h);
+    }
     draw_projectiles();
     if (render_p->in_vehicle) draw_player_3rd(render_p);
     for(int i=0; i<MAX_CLIENTS; i++) {
@@ -1825,6 +1907,43 @@ void net_process_snapshot(char *buffer, int len) {
         }
     }
 
+    for (int hi = 0; hi < MAX_HELICOPTERS; hi++) local_state.helicopters[hi].active = 0;
+    if (cursor < len) {
+        unsigned char heli_count = *(unsigned char *)(buffer + cursor);
+        cursor++;
+        for (int hi = 0; hi < heli_count; hi++) {
+            if (cursor + (int)sizeof(NetHelicopter) > len) break;
+            NetHelicopter *nh = (NetHelicopter *)(buffer + cursor);
+            cursor += (int)sizeof(NetHelicopter);
+            if (nh->id >= MAX_HELICOPTERS) continue;
+            HelicopterState *h = &local_state.helicopters[nh->id];
+            h->active = nh->active;
+            h->id = nh->id;
+            h->scene_id = nh->scene_id;
+            h->grounded = nh->grounded;
+            h->x = nh->x; h->y = nh->y; h->z = nh->z;
+            h->vx = nh->vx; h->vy = nh->vy; h->vz = nh->vz;
+            h->yaw = nh->yaw;
+            h->pitch_visual = nh->pitch_visual;
+            h->roll_visual = nh->roll_visual;
+            h->rotor_angle = nh->rotor_angle;
+            h->rotor_speed = nh->rotor_speed;
+            h->health = nh->health;
+            h->occupant_player_id = nh->occupant_player_id;
+            if (h->occupant_player_id > 0 && h->occupant_player_id < MAX_CLIENTS) {
+                PlayerState *occ = &local_state.players[h->occupant_player_id];
+                occ->in_vehicle = 1;
+                occ->vehicle_type = VEH_HELICOPTER;
+            }
+        }
+    }
+    for (int i = 1; i < MAX_CLIENTS; i++) {
+        PlayerState *p = &local_state.players[i];
+        if (!p->active) continue;
+        if (!p->in_vehicle) p->vehicle_type = VEH_NONE;
+        else if (p->vehicle_type != VEH_HELICOPTER) p->vehicle_type = VEH_BUGGY;
+    }
+
     int render_id = (my_client_id > 0 && my_client_id < MAX_CLIENTS && local_state.players[my_client_id].active)
         ? my_client_id
         : 0;
@@ -2093,9 +2212,16 @@ int main(int argc, char* argv[]) {
         } 
         else {
             const Uint8 *k = SDL_GetKeyboardState(NULL);
+            int control_pid = (app_state == STATE_GAME_NET && my_client_id > 0 && my_client_id < MAX_CLIENTS) ? my_client_id : 0;
+            int in_heli = local_state.players[control_pid].in_vehicle && local_state.players[control_pid].vehicle_type == VEH_HELICOPTER;
             float fwd=0, str=0;
             if(k[SDL_SCANCODE_W]) fwd+=1; if(k[SDL_SCANCODE_S]) fwd-=1;
-            if(k[SDL_SCANCODE_D]) str+=1; if(k[SDL_SCANCODE_A]) str-=1;
+            if (in_heli) {
+                if(k[SDL_SCANCODE_A]) str-=1;
+                if(k[SDL_SCANCODE_D]) str+=1;
+            } else {
+                if(k[SDL_SCANCODE_D]) str+=1; if(k[SDL_SCANCODE_A]) str-=1;
+            }
             float move_len = sqrtf(fwd * fwd + str * str);
             if (move_len > 1.0f) {
                 fwd /= move_len;
@@ -2103,9 +2229,9 @@ int main(int argc, char* argv[]) {
             }
             int jump = k[SDL_SCANCODE_SPACE]; int crouch = k[SDL_SCANCODE_LCTRL];
             int shoot = (SDL_GetMouseState(NULL, NULL) & SDL_BUTTON(SDL_BUTTON_LEFT));
-            int reload = k[SDL_SCANCODE_R];
+            int reload = in_heli ? k[SDL_SCANCODE_Q] : k[SDL_SCANCODE_R];
             int use = k[SDL_SCANCODE_F];
-            int ability = k[SDL_SCANCODE_E];
+            int ability = in_heli ? k[SDL_SCANCODE_E] : k[SDL_SCANCODE_E];
             if(k[SDL_SCANCODE_1]) wpn_req=0; if(k[SDL_SCANCODE_2]) wpn_req=1;
             if(k[SDL_SCANCODE_3]) wpn_req=2; if(k[SDL_SCANCODE_4]) wpn_req=3; if(k[SDL_SCANCODE_5]) wpn_req=4; if(k[SDL_SCANCODE_6]) wpn_req=5;
 
@@ -2135,6 +2261,15 @@ int main(int argc, char* argv[]) {
                 local_state.players[0].in_use = use;
                 if (use && local_state.players[0].vehicle_cooldown == 0 && local_state.transition_timer == 0) {
                     PlayerState *p0 = &local_state.players[0];
+                    HelicopterState *near_h = NULL;
+                    for (int hi = 0; hi < MAX_HELICOPTERS; hi++) {
+                        HelicopterState *h = &local_state.helicopters[hi];
+                        if (!h->active || h->scene_id != p0->scene_id) continue;
+                        float dx = h->x - p0->x, dy = h->y - p0->y, dz = h->z - p0->z;
+                        if ((dx*dx + dy*dy + dz*dz) <= (g_heli_tuning.enter_radius * g_heli_tuning.enter_radius)) {
+                            near_h = h; break;
+                        }
+                    }
                     int in_garage = local_state.scene_id == SCENE_GARAGE_OSAKA;
                     int portal_id = -1;
                     if (scene_portal_triggered(p0, &portal_id)) {
@@ -2146,6 +2281,26 @@ int main(int argc, char* argv[]) {
                             p0->vx = 0.0f; p0->vy = 0.0f; p0->vz = 0.0f;
                             scene_request_transition(dest_scene);
                         }
+                    } else if (p0->in_vehicle && p0->vehicle_type == VEH_HELICOPTER) {
+                        for (int hi = 0; hi < MAX_HELICOPTERS; hi++) {
+                            HelicopterState *h = &local_state.helicopters[hi];
+                            if (!h->active || h->occupant_player_id != 0) continue;
+                            if (heli_try_place_player(p0, h, g_heli_tuning.exit_offset, 0.0f) ||
+                                heli_try_place_player(p0, h, -g_heli_tuning.exit_offset, 0.0f) ||
+                                heli_try_place_player(p0, h, 0.0f, -g_heli_tuning.exit_offset)) {
+                                p0->in_vehicle = 0;
+                                p0->vehicle_type = VEH_NONE;
+                                h->occupant_player_id = -1;
+                                p0->vehicle_cooldown = 30;
+                            }
+                            break;
+                        }
+                    } else if (near_h && near_h->occupant_player_id < 0) {
+                        near_h->occupant_player_id = 0;
+                        p0->in_vehicle = 1;
+                        p0->vehicle_type = VEH_HELICOPTER;
+                        p0->x = near_h->x; p0->y = near_h->y; p0->z = near_h->z;
+                        p0->vehicle_cooldown = 30;
                     } else if (in_garage && scene_near_vehicle_pad(local_state.scene_id, p0->x, p0->z, 6.0f, NULL)) {
                         p0->in_vehicle = !p0->in_vehicle;
                         p0->vehicle_cooldown = 30;

--- a/apps/server/src/main.c
+++ b/apps/server/src/main.c
@@ -118,6 +118,11 @@ static int alloc_slot(const struct sockaddr_in *addr) {
 
 static void free_slot(int slot) {
     if (slot <= 0 || slot >= MAX_CLIENTS) return;
+    for (int i = 0; i < MAX_HELICOPTERS; i++) {
+        if (local_state.helicopters[i].active && local_state.helicopters[i].occupant_player_id == slot) {
+            local_state.helicopters[i].occupant_player_id = -1;
+        }
+    }
     slots[slot].active = 0;
     slots[slot].welcomed = 0;
     slots[slot].cmd_seen = 0;
@@ -125,6 +130,36 @@ static void free_slot(int slot) {
     slots[slot].last_heard = 0.0;
     slots[slot].player_id = -1;
     server_disconnect(slot, client_last_seq);
+}
+
+static HelicopterState *server_find_nearby_heli(int scene_id, float x, float y, float z, float radius) {
+    float rr = radius * radius;
+    for (int i = 0; i < MAX_HELICOPTERS; i++) {
+        HelicopterState *h = &local_state.helicopters[i];
+        if (!h->active || h->scene_id != scene_id) continue;
+        float dx = h->x - x, dy = h->y - y, dz = h->z - z;
+        if ((dx * dx + dy * dy + dz * dz) <= rr) return h;
+    }
+    return NULL;
+}
+
+static int server_try_exit_heli(PlayerState *p, HelicopterState *h) {
+    float yaw_rad = -h->yaw * 0.0174533f;
+    float rx = cosf(yaw_rad), rz = sinf(yaw_rad);
+    float bx = -sinf(yaw_rad), bz = cosf(yaw_rad);
+    float ox[3] = { rx * g_heli_tuning.exit_offset, -rx * g_heli_tuning.exit_offset, bx * g_heli_tuning.exit_offset };
+    float oz[3] = { rz * g_heli_tuning.exit_offset, -rz * g_heli_tuning.exit_offset, bz * g_heli_tuning.exit_offset };
+    for (int i = 0; i < 3; i++) {
+        float px = h->x + ox[i], pz = h->z + oz[i];
+        if (!heli_point_collides(px, h->y + 1.0f, pz) && !heli_point_collides(px, h->y + 2.0f, pz)) {
+            p->x = px; p->y = h->y; p->z = pz;
+            p->in_vehicle = 0;
+            p->vehicle_type = VEH_NONE;
+            h->occupant_player_id = -1;
+            return 1;
+        }
+    }
+    return 0;
 }
 
 static void send_welcome(const struct sockaddr_in *addr, int client_id) {
@@ -405,6 +440,33 @@ void server_broadcast() {
         }
     }
 
+    unsigned char heli_count = 0;
+    for (int i = 0; i < MAX_HELICOPTERS; i++) {
+        HelicopterState *h = &local_state.helicopters[i];
+        if (h->active) heli_count++;
+    }
+    memcpy(buffer + cursor, &heli_count, 1); cursor += 1;
+    for (int i = 0; i < MAX_HELICOPTERS; i++) {
+        HelicopterState *h = &local_state.helicopters[i];
+        if (!h->active) continue;
+        NetHelicopter nh;
+        memset(&nh, 0, sizeof(nh));
+        nh.id = (unsigned char)h->id;
+        nh.scene_id = (unsigned char)h->scene_id;
+        nh.active = (unsigned char)h->active;
+        nh.grounded = (unsigned char)h->grounded;
+        nh.x = h->x; nh.y = h->y; nh.z = h->z;
+        nh.vx = h->vx; nh.vy = h->vy; nh.vz = h->vz;
+        nh.yaw = h->yaw;
+        nh.pitch_visual = h->pitch_visual;
+        nh.roll_visual = h->roll_visual;
+        nh.rotor_angle = h->rotor_angle;
+        nh.rotor_speed = h->rotor_speed;
+        nh.health = (unsigned char)(h->health < 0 ? 0 : (h->health > 255 ? 255 : h->health));
+        nh.occupant_player_id = (signed char)h->occupant_player_id;
+        memcpy(buffer + cursor, &nh, sizeof(NetHelicopter)); cursor += (int)sizeof(NetHelicopter);
+    }
+
     for(int i=1; i<MAX_CLIENTS; i++) {
         if (slots[i].active) {
             sendto(sock, buffer, cursor, 0,
@@ -491,28 +553,69 @@ int main(int argc, char *argv[]) {
                         p->x = sx; p->y = sy; p->z = sz;
                         p->vx = 0.0f; p->vy = 0.0f; p->vz = 0.0f;
                         p->in_vehicle = 0;
+                        p->vehicle_type = VEH_NONE;
                         p->portal_cooldown_until_ms = now + 1000;
                         p->in_use = 0;
                         printf("PORTAL_TRAVEL client=%d from=%d to=%d\n", i, from_scene, dest_scene);
                     }
                 } else if (use_pressed && p->vehicle_cooldown == 0) {
-                    int in_garage = p->scene_id == SCENE_GARAGE_OSAKA;
-                    if (in_garage && scene_near_vehicle_pad(p->scene_id, p->x, p->z, 6.0f, NULL)) {
-                        p->in_vehicle = !p->in_vehicle;
+                    if (p->in_vehicle && p->vehicle_type == VEH_HELICOPTER) {
+                        for (int hi = 0; hi < MAX_HELICOPTERS; hi++) {
+                            HelicopterState *h = &local_state.helicopters[hi];
+                            if (!h->active || h->occupant_player_id != i) continue;
+                            if (!server_try_exit_heli(p, h)) {
+                                printf("[HELI] exit failed client=%d\n", i);
+                            }
+                            break;
+                        }
                         p->vehicle_cooldown = 30;
-                        printf("Client %d Toggle Vehicle: %d\n", i, p->in_vehicle);
-                    } else if (!in_garage) {
-                        p->in_vehicle = !p->in_vehicle;
-                        p->vehicle_cooldown = 30;
-                        printf("Client %d Toggle Vehicle: %d\n", i, p->in_vehicle);
+                    } else {
+                        HelicopterState *h = server_find_nearby_heli(p->scene_id, p->x, p->y, p->z, g_heli_tuning.enter_radius);
+                        if (h && h->occupant_player_id < 0) {
+                            h->occupant_player_id = i;
+                            p->in_vehicle = 1;
+                            p->vehicle_type = VEH_HELICOPTER;
+                            p->x = h->x; p->y = h->y; p->z = h->z;
+                            p->vx = p->vy = p->vz = 0.0f;
+                            p->vehicle_cooldown = 30;
+                            printf("[HELI] enter client=%d heli=%d\n", i, h->id);
+                        }
                     }
                 }
                 p->use_was_down = p->in_use;
                 if (p->vehicle_cooldown > 0) p->vehicle_cooldown--;
 
-                shankpit_simulate_movement_tick(p, now);
+                if (!(p->in_vehicle && p->vehicle_type == VEH_HELICOPTER)) {
+                    shankpit_simulate_movement_tick(p, now);
+                }
             } else {
                 update_entity(p, SHANKPIT_NET_FIXED_DT, NULL, now);
+            }
+        }
+
+        for (int hi = 0; hi < MAX_HELICOPTERS; hi++) {
+            HelicopterState *h = &local_state.helicopters[hi];
+            if (!h->active) continue;
+            if (h->occupant_player_id >= 0 && h->occupant_player_id < MAX_CLIENTS) {
+                PlayerState *occ = &local_state.players[h->occupant_player_id];
+                h->scene_id = occ->scene_id;
+                h->input.forward = occ->in_fwd;
+                h->input.yaw = occ->in_strafe;
+                h->input.strafe = occ->in_ability ? -1.0f : (occ->in_bike ? 1.0f : 0.0f);
+                h->input.ascend = occ->in_jump;
+                h->input.descend = occ->crouching;
+            } else {
+                h->occupant_player_id = -1;
+                h->input.forward = 0.0f; h->input.yaw = 0.0f; h->input.strafe = 0.0f;
+                h->input.ascend = 0; h->input.descend = 0;
+            }
+            phys_set_scene(h->scene_id);
+            heli_simulate_step(h, SHANKPIT_NET_FIXED_DT);
+            if (h->occupant_player_id >= 0 && h->occupant_player_id < MAX_CLIENTS) {
+                PlayerState *occ = &local_state.players[h->occupant_player_id];
+                occ->x = h->x; occ->y = h->y; occ->z = h->z;
+                occ->yaw = h->yaw;
+                occ->vx = occ->vy = occ->vz = 0.0f;
             }
         }
 

--- a/packages/common/net_sim.h
+++ b/packages/common/net_sim.h
@@ -7,6 +7,115 @@
 
 #define SHANKPIT_NET_FIXED_DT 0.016f
 
+typedef struct {
+    float hover_lift;
+    float ascend_accel;
+    float descend_accel;
+    float forward_accel;
+    float strafe_accel;
+    float drag;
+    float vertical_damping;
+    float max_hspeed;
+    float max_vspeed_up;
+    float max_vspeed_down;
+    float yaw_rate;
+    float pitch_visual_max;
+    float roll_visual_max;
+    float enter_radius;
+    float exit_offset;
+    float collider_radius;
+    float collider_height;
+} HelicopterTuning;
+
+static const HelicopterTuning g_heli_tuning = {
+    0.018f, 0.026f, 0.030f, 0.040f, 0.032f,
+    0.08f, 0.16f, 0.95f, 0.42f, 0.58f, 95.0f,
+    14.0f, 16.0f, 7.0f, 4.5f, 3.4f, 2.6f
+};
+
+static inline int heli_point_collides(float x, float y, float z) {
+    for (int i = 1; i < map_count; i++) {
+        Box b = map_geo[i];
+        if (x > b.x - b.w * 0.5f && x < b.x + b.w * 0.5f &&
+            y > b.y - b.h * 0.5f && y < b.y + b.h * 0.5f &&
+            z > b.z - b.d * 0.5f && z < b.z + b.d * 0.5f) {
+            return 1;
+        }
+    }
+    return (y < 0.0f);
+}
+
+static inline void heli_simulate_step(HelicopterState *h, float dt) {
+    if (!h || !h->active) return;
+    const HelicopterTuning *t = &g_heli_tuning;
+
+    h->yaw = norm_yaw_deg(h->yaw + h->input.yaw * t->yaw_rate * dt);
+    float yaw_rad = -h->yaw * 0.0174533f;
+    float fx = sinf(yaw_rad), fz = -cosf(yaw_rad);
+    float rx = cosf(yaw_rad), rz = sinf(yaw_rad);
+
+    h->vx += fx * (h->input.forward * t->forward_accel);
+    h->vz += fz * (h->input.forward * t->forward_accel);
+    h->vx += rx * (h->input.strafe * t->strafe_accel);
+    h->vz += rz * (h->input.strafe * t->strafe_accel);
+    h->vy += t->hover_lift - GRAVITY_DROP;
+    if (h->input.ascend) h->vy += t->ascend_accel;
+    if (h->input.descend) h->vy -= t->descend_accel;
+    if (!h->input.ascend && !h->input.descend) h->vy *= (1.0f - t->vertical_damping);
+
+    h->vx *= (1.0f - t->drag);
+    h->vz *= (1.0f - t->drag);
+    float hs = sqrtf(h->vx * h->vx + h->vz * h->vz);
+    if (hs > t->max_hspeed && hs > 0.0001f) {
+        float s = t->max_hspeed / hs;
+        h->vx *= s; h->vz *= s;
+    }
+    if (h->vy > t->max_vspeed_up) h->vy = t->max_vspeed_up;
+    if (h->vy < -t->max_vspeed_down) h->vy = -t->max_vspeed_down;
+
+    h->x += h->vx;
+    h->y += h->vy;
+    h->z += h->vz;
+
+    h->grounded = 0;
+    float floor_y = g_heli_tuning.collider_height * 0.5f;
+    if (h->y < floor_y) {
+        if (h->vy < -0.45f) h->health -= 1;
+        h->y = floor_y;
+        if (h->vy < 0.0f) h->vy = 0.0f;
+        h->grounded = 1;
+    }
+
+    float pts[8][3] = {
+        {h->x + t->collider_radius, h->y, h->z}, {h->x - t->collider_radius, h->y, h->z},
+        {h->x, h->y, h->z + t->collider_radius}, {h->x, h->y, h->z - t->collider_radius},
+        {h->x, h->y + t->collider_height * 0.5f, h->z}, {h->x, h->y - t->collider_height * 0.5f, h->z},
+        {h->x + t->collider_radius * 0.7f, h->y + t->collider_height * 0.25f, h->z + t->collider_radius * 0.7f},
+        {h->x - t->collider_radius * 0.7f, h->y + t->collider_height * 0.25f, h->z - t->collider_radius * 0.7f},
+    };
+    for (int i = 0; i < 8; i++) {
+        if (heli_point_collides(pts[i][0], pts[i][1], pts[i][2])) {
+            h->x -= h->vx; h->z -= h->vz; h->vx *= -0.15f; h->vz *= -0.15f;
+            if (heli_point_collides(h->x, h->y + t->collider_height * 0.4f, h->z)) {
+                h->y -= h->vy;
+                if (h->vy > 0.0f) h->vy = 0.0f;
+            }
+            break;
+        }
+    }
+
+    h->pitch_visual = -h->input.forward * t->pitch_visual_max;
+    h->roll_visual = (-h->input.strafe + h->input.yaw * 0.45f) * t->roll_visual_max;
+    if (h->pitch_visual > t->pitch_visual_max) h->pitch_visual = t->pitch_visual_max;
+    if (h->pitch_visual < -t->pitch_visual_max) h->pitch_visual = -t->pitch_visual_max;
+    if (h->roll_visual > t->roll_visual_max) h->roll_visual = t->roll_visual_max;
+    if (h->roll_visual < -t->roll_visual_max) h->roll_visual = -t->roll_visual_max;
+
+    float target_rotor = h->occupant_player_id >= 0 ? 42.0f : 14.0f;
+    h->rotor_speed += (target_rotor - h->rotor_speed) * 0.1f;
+    h->rotor_angle = norm_yaw_deg(h->rotor_angle + h->rotor_speed);
+}
+
 void update_entity(PlayerState *p, float dt, void *server_context, unsigned int cmd_time);
 
 static inline void shankpit_apply_usercmd_inputs(PlayerState *p, const UserCmd *cmd) {
@@ -35,6 +144,7 @@ static inline void shankpit_apply_usercmd_inputs(PlayerState *p, const UserCmd *
     p->in_reload = (cmd->buttons & BTN_RELOAD) != 0;
     p->in_use = (cmd->buttons & BTN_USE) != 0;
     p->in_ability = (cmd->buttons & BTN_ABILITY_1) != 0;
+    p->in_bike = (cmd->buttons & BTN_VEHICLE_2) != 0;
 
     if (cmd->weapon_idx >= 0 && cmd->weapon_idx < MAX_WEAPONS) {
         p->current_weapon = cmd->weapon_idx;
@@ -43,6 +153,10 @@ static inline void shankpit_apply_usercmd_inputs(PlayerState *p, const UserCmd *
 
 static inline void shankpit_simulate_movement_tick(PlayerState *p, unsigned int now_ms) {
     if (!p) return;
+    if (p->in_vehicle && p->vehicle_type == VEH_HELICOPTER) {
+        p->vx = p->vy = p->vz = 0.0f;
+        return;
+    }
 
     // Net movement contract:
     // - Intent -> world-space wish conversion is shared (shankpit_move_wish_from_intent).

--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -4,6 +4,7 @@
 #define MAX_CLIENTS 70
 #define MAX_WEAPONS 6
 #define MAX_PROJECTILES 1024
+#define MAX_HELICOPTERS 8
 #define LAG_HISTORY 64
 
 #define SCENE_GARAGE_OSAKA 0
@@ -67,6 +68,7 @@ typedef struct {
 #define VEH_NONE  0
 #define VEH_BUGGY 1
 #define VEH_BIKE  2
+#define VEH_HELICOPTER 3
 
 typedef struct {
     int id;
@@ -106,6 +108,22 @@ typedef struct {
     unsigned char hit_feedback; 
     unsigned char storm_charges;
 } NetPlayer;
+
+typedef struct {
+    unsigned char id;
+    unsigned char scene_id;
+    unsigned char active;
+    unsigned char grounded;
+    float x, y, z;
+    float vx, vy, vz;
+    float yaw;
+    float pitch_visual;
+    float roll_visual;
+    float rotor_angle;
+    float rotor_speed;
+    unsigned char health;
+    signed char occupant_player_id;
+} NetHelicopter;
 
 typedef struct {
     int version;
@@ -163,11 +181,38 @@ typedef struct {
     float vx, vy, vz;
 } LagRecord;
 
+typedef struct {
+    float forward;
+    float yaw;
+    float strafe;
+    int ascend;
+    int descend;
+} HeliInputState;
+
+typedef struct {
+    int active;
+    int id;
+    int scene_id;
+    float x, y, z;
+    float vx, vy, vz;
+    float yaw;
+    float pitch_visual;
+    float roll_visual;
+    float rotor_angle;
+    float rotor_speed;
+    float collective;
+    int health;
+    int occupant_player_id;
+    int grounded;
+    HeliInputState input;
+} HelicopterState;
+
 typedef enum { MODE_DEATHMATCH=0, MODE_TDM=1, MODE_SURVIVAL=2, MODE_CTF=3, MODE_ODDBALL=4, MODE_LOCAL=98, MODE_NET=99, MODE_EVOLUTION=100 } GameMode;
 
 typedef struct {
     PlayerState players[MAX_CLIENTS];
     Projectile projectiles[MAX_PROJECTILES];
+    HelicopterState helicopters[MAX_HELICOPTERS];
     LagRecord history[MAX_CLIENTS][LAG_HISTORY];
     int server_tick;
     int game_mode;

--- a/packages/simulation/local_game.h
+++ b/packages/simulation/local_game.h
@@ -57,6 +57,39 @@ static inline void scene_load(int scene_id) {
     }
 }
 
+static inline void heli_spawn_defaults(HelicopterState *h, int id, int scene_id, float x, float y, float z) {
+    memset(h, 0, sizeof(*h));
+    h->active = 1;
+    h->id = id;
+    h->scene_id = scene_id;
+    h->x = x; h->y = y; h->z = z;
+    h->health = 250;
+    h->occupant_player_id = -1;
+    h->rotor_speed = 8.0f;
+    h->yaw = 180.0f;
+}
+
+static inline HelicopterState *heli_find_nearby(int scene_id, float x, float y, float z, float radius) {
+    float rr = radius * radius;
+    for (int i = 0; i < MAX_HELICOPTERS; i++) {
+        HelicopterState *h = &local_state.helicopters[i];
+        if (!h->active || h->scene_id != scene_id) continue;
+        float dx = h->x - x, dy = h->y - y, dz = h->z - z;
+        if ((dx * dx + dy * dy + dz * dz) <= rr) return h;
+    }
+    return NULL;
+}
+
+static inline int heli_try_place_player(PlayerState *p, HelicopterState *h, float ox, float oz) {
+    float px = h->x + ox;
+    float pz = h->z + oz;
+    if (!heli_point_collides(px, h->y + 1.0f, pz) && !heli_point_collides(px, h->y + 2.0f, pz)) {
+        p->x = px; p->y = h->y; p->z = pz;
+        return 1;
+    }
+    return 0;
+}
+
 static inline void scene_request_transition(int scene_id) {
     if (local_state.transition_timer > 0) return;
     local_state.pending_scene = scene_id;
@@ -262,15 +295,17 @@ void local_update(float fwd, float str, float yaw, float pitch, int shoot, int w
     }
     p0->yaw = yaw; p0->pitch = pitch;
     if (weapon_req >= 0 && weapon_req < MAX_WEAPONS) p0->current_weapon = weapon_req;
-    MoveIntent move_intent = {
-        .forward = fwd,
-        .strafe = str,
-        .control_yaw_deg = yaw,
-        .wants_jump = jump,
-        .wants_sprint = 0
-    };
-    MoveWish move_wish = shankpit_move_wish_from_intent(move_intent);
-    accelerate(p0, move_wish.dir_x, move_wish.dir_z, move_wish.magnitude * MAX_SPEED, ACCEL);
+    if (!(p0->in_vehicle && p0->vehicle_type == VEH_HELICOPTER)) {
+        MoveIntent move_intent = {
+            .forward = fwd,
+            .strafe = str,
+            .control_yaw_deg = yaw,
+            .wants_jump = jump,
+            .wants_sprint = 0
+        };
+        MoveWish move_wish = shankpit_move_wish_from_intent(move_intent);
+        accelerate(p0, move_wish.dir_x, move_wish.dir_z, move_wish.magnitude * MAX_SPEED, ACCEL);
+    }
     
     int fresh_jump_press = (jump && !was_holding_jump);
     // --- PHASE 485: TUNED SLIDE JUMP ---
@@ -291,9 +326,33 @@ void local_update(float fwd, float str, float yaw, float pitch, int shoot, int w
     p0->in_ability = ability;
     was_holding_jump = jump;
     
+    for (int hi = 0; hi < MAX_HELICOPTERS; hi++) {
+        HelicopterState *h = &local_state.helicopters[hi];
+        if (!h->active) continue;
+        if (h->occupant_player_id >= 0 && h->occupant_player_id < MAX_CLIENTS) {
+            PlayerState *occ = &local_state.players[h->occupant_player_id];
+            h->input.forward = occ->in_fwd;
+            h->input.yaw = occ->in_strafe;
+            h->input.strafe = occ->in_ability ? -1.0f : (occ->in_bike ? 1.0f : 0.0f);
+            h->input.ascend = occ->in_jump;
+            h->input.descend = occ->crouching;
+            heli_simulate_step(h, SHANKPIT_NET_FIXED_DT);
+            occ->x = h->x; occ->y = h->y; occ->z = h->z;
+            occ->yaw = h->yaw; occ->vx = occ->vy = occ->vz = 0.0f;
+            occ->on_ground = h->grounded;
+        } else {
+            h->input.forward = 0.0f; h->input.yaw = 0.0f; h->input.strafe = 0.0f;
+            h->input.ascend = 0; h->input.descend = 0;
+            heli_simulate_step(h, SHANKPIT_NET_FIXED_DT);
+        }
+    }
+
     for(int i=0; i<MAX_CLIENTS; i++) {
         PlayerState *p = &local_state.players[i];
         if (!p->active) continue;
+        if (p->in_vehicle && p->vehicle_type == VEH_HELICOPTER) {
+            continue;
+        }
         if (i > 0 && p->active && p->state != STATE_DEAD) {
             float b_fwd=0, b_yaw=p->yaw;
             int b_btns=0;
@@ -332,5 +391,6 @@ void local_init_match(int num_players, int mode) {
         phys_respawn(&local_state.players[i], i*100);
         init_genome(&local_state.players[i].brain);
     }
+    heli_spawn_defaults(&local_state.helicopters[0], 0, local_state.scene_id, 16.0f, 4.0f, 12.0f);
 }
 #endif


### PR DESCRIPTION
### Motivation
- Provide a simple, robust, server-authoritative helicopter vehicle so players can enter/exit, fly with arcade-style controls, collide with the world, and be replicated to clients for immediate testing and iteration.
- Integrate cleanly with the existing player/vehicle flags and network snapshot pipeline while keeping player movement and combat systems unchanged when not seated.

### Description
- Add helicopter types and state to shared protocol (`MAX_HELICOPTERS`, `VEH_HELICOPTER`, `NetHelicopter`, `HelicopterState`) and attach a `helicopters[]` array to `ServerState` for authoritative storage. (modified `packages/common/protocol.h`).
- Implement a centralized tuning block and server-side helicopter simulation (`heli_simulate_step`) with hover assist, ascend/descend, forward/strafe accel, yaw rate, drag/damping, simple multi-point collision against map boxes, visual pitch/roll, rotor spin behavior, and collider parameters. (modified `packages/common/net_sim.h`).
- Wire helicopter lifecycle into the local and server loops: spawn defaults, per-tick helicopter updates, occupancy routing (enter/exit, safe exit placement), occupant follow (disable normal player sim while seated), disconnect cleanup, and helicopter snapshot packing for network replication. (modified `packages/simulation/local_game.h`, `apps/server/src/main.c`).
- Add client integration: snapshot parsing of helicopters and occupants, immediate-mode helicopter rendering (fuselage, boom, rotors, skids), minimal HUD readout, enter/exit prompts, and a smoothed third-person chase camera for piloting; map a small set of in-heli controls (W/S forward, A/D yaw, Q/E strafe, Space ascend, Ctrl descend). (modified `apps/lobby/src/main.c`).

### Testing
- `make server` completed successfully and the server binary was built, demonstrating the server-side changes compile and link correctly on the Linux build path. (success)
- `make` / full build failed in this environment because the lobby client requires SDL2 development headers (`SDL2/SDL.h` and `SDL2/SDL_opengl.h`) which are absent here, preventing a full client/lobby binary test (no runtime client test performed). (blocked)
- Changes were committed locally and basic static inspection of snapshot packing/parsing and integration points were exercised by building and grepping sources during the rollout (no automated unit tests were added or executed for helicopter logic).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4159f8eb88327a85998b3eda528ca)