### PR TITLE
Add first-pass heightfield terrain system and Voxworld integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           set -euo pipefail
           test -f apps/lobby/src/main.c
 
-          x86_64-w64-mingw32-gcc apps/lobby/src/main.c packages/render/proc_tex.c \
+          x86_64-w64-mingw32-gcc apps/lobby/src/main.c packages/render/proc_tex.c packages/world/terrain.c \
             -o ShankPit.exe \
             -O2 -static-libgcc \
             -I./sdl2_mingw/include \
@@ -78,6 +78,7 @@ jobs:
             -Ipackages/common \
             -Ipackages/simulation \
             -Ipackages/render \
+            -Ipackages/world \
             -L./sdl2_mingw/lib \
             -lmingw32 -lSDL2main -lSDL2 \
             -lopengl32 -lglu32 -lws2_32 -lwinmm -lgdi32 -lm
@@ -88,12 +89,13 @@ jobs:
           set -euo pipefail
           test -f apps/server/src/main.c
 
-          gcc apps/server/src/main.c \
+          gcc apps/server/src/main.c packages/world/terrain.c \
             -o ShankServer_Linux \
             -O2 -static \
             -I. \
             -Ipackages/common \
             -Ipackages/simulation \
+            -Ipackages/world \
             -lm
 
       - name: Build Server Control (ncurses)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,7 @@ jobs:
           set -euo pipefail
           test -f apps/lobby/src/main.c
 
-          x86_64-w64-mingw32-gcc apps/lobby/src/main.c packages/render/proc_tex.c \
+          x86_64-w64-mingw32-gcc apps/lobby/src/main.c packages/render/proc_tex.c packages/world/terrain.c \
             -o ShankPit.exe \
             -O2 -static-libgcc \
             -I./sdl2_mingw/include \
@@ -78,6 +78,7 @@ jobs:
             -Ipackages/common \
             -Ipackages/simulation \
             -Ipackages/render \
+            -Ipackages/world \
             -L./sdl2_mingw/lib \
             -lmingw32 -lSDL2main -lSDL2 \
             -lopengl32 -lglu32 -lws2_32 -lwinmm -lgdi32 -lm
@@ -88,12 +89,13 @@ jobs:
           set -euo pipefail
           test -f apps/server/src/main.c
 
-          gcc apps/server/src/main.c \
+          gcc apps/server/src/main.c packages/world/terrain.c \
             -o ShankServer_Linux \
             -O2 -static \
             -I. \
             -Ipackages/common \
             -Ipackages/simulation \
+            -Ipackages/world \
             -lm
 
       - name: Build Server Control (ncurses)

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,14 @@ BIN_DIR  := bin
 
 # ---- Flags ----
 CFLAGS   := -O2 -Wall -D_REENTRANT
-INCLUDES := -Ipackages/common -Ipackages/simulation -Ipackages/render
+INCLUDES := -Ipackages/common -Ipackages/simulation -Ipackages/render -Ipackages/world
 
 LIBS_GL  := -lSDL2 -lGL -lGLU -lm
 LIBS_M   := -lm
 
 # ---- Sources ----
-LOBBY_SRC    := apps/lobby/src/main.c packages/render/proc_tex.c
-SERVER_SRC   := apps/server/src/main.c
+LOBBY_SRC    := apps/lobby/src/main.c packages/render/proc_tex.c packages/world/terrain.c
+SERVER_SRC   := apps/server/src/main.c packages/world/terrain.c
 SERVERCTL_SRC:= apps/server/serverctl.c
 
 # ---- Outputs ----
@@ -44,7 +44,7 @@ server: $(SERVER_BIN)
 
 $(SERVER_BIN): $(SERVER_SRC) | $(BIN_DIR)
 	@echo "🔨 Building Game Server..."
-	$(CC) $(CFLAGS) $(INCLUDES) $< -o $@ $(LIBS_M)
+	$(CC) $(CFLAGS) $(INCLUDES) $(SERVER_SRC) -o $@ $(LIBS_M)
 
 # ---- SERVER CONTROL (OPTIONAL, LOCAL ONLY) ----
 serverctl: $(SERVERCTL_BIN)

--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -1212,6 +1212,20 @@ static void draw_garage_portal_frame() {
     glVertex3f(-pr, 6.0f, 0.0f);
     glEnd();
     glPopMatrix();
+
+    if (local_state.scene_id == SCENE_GARAGE_OSAKA) {
+        glPushMatrix();
+        glTranslatef(GARAGE_VOX_PORTAL_X, GARAGE_VOX_PORTAL_Y, GARAGE_VOX_PORTAL_Z);
+        glColor3f(0.95f, 0.2f, 0.95f);
+        glLineWidth(3.0f);
+        glBegin(GL_LINE_LOOP);
+        glVertex3f(-GARAGE_VOX_PORTAL_RADIUS, -2.0f, 0.0f);
+        glVertex3f(GARAGE_VOX_PORTAL_RADIUS, -2.0f, 0.0f);
+        glVertex3f(GARAGE_VOX_PORTAL_RADIUS, 6.0f, 0.0f);
+        glVertex3f(-GARAGE_VOX_PORTAL_RADIUS, 6.0f, 0.0f);
+        glEnd();
+        glPopMatrix();
+    }
 }
 
 static void draw_garage_vehicle_pads() {
@@ -1244,6 +1258,7 @@ static void draw_garage_overlay(PlayerState *p) {
     draw_string("OSAKA GARAGE", 40, 670, 10);
     glColor3f(0.9f, 0.9f, 0.9f);
     draw_string("PORTAL -> STADIUM", 40, 640, 6);
+    draw_string("PORTAL -> VOXWORLD TERRAIN", 40, 620, 6);
 
     int pad_count = 0;
     const VehiclePad *pads = scene_vehicle_pads(local_state.scene_id, &pad_count);
@@ -1270,6 +1285,7 @@ static void draw_garage_overlay(PlayerState *p) {
     float portal_x = 0.0f, portal_y = 0.0f, portal_z = 0.0f, portal_r = 0.0f;
     scene_portal_info(local_state.scene_id, &portal_x, &portal_y, &portal_z, &portal_r);
     int portal_target = target_in_view(p, portal_x, portal_y, portal_z, 30.0f, 0.75f);
+    int vox_portal_target = target_in_view(p, GARAGE_VOX_PORTAL_X, GARAGE_VOX_PORTAL_Y, GARAGE_VOX_PORTAL_Z, 30.0f, 0.75f);
     int pad_target = 0;
     if (scene_near_vehicle_pad(local_state.scene_id, p->x, p->z, 12.0f, NULL)) {
         int pad_idx = -1;
@@ -1279,7 +1295,7 @@ static void draw_garage_overlay(PlayerState *p) {
     }
 
     glColor3f(1.0f, 1.0f, 0.0f);
-    if (portal_target) {
+    if (portal_target || vox_portal_target) {
         draw_string("TRAVEL", 600, 350, 8);
     } else if (pad_target) {
         draw_string(p->in_vehicle ? "EXIT VEHICLE" : "ENTER VEHICLE", 560, 350, 8);

--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -79,6 +79,9 @@ static VehicleStyle g_vehicle_style = {0.85f, 0.15f, 0.25f, 0.45f, 0.2f, 0.18f, 
 static int vehicle_style_enabled = 1;
 static int vehicle_underglow_enabled = 1;
 static int vehicle_worklights_enabled = 1;
+static int terrain_wireframe_debug = 0;
+static int terrain_normals_debug = 0;
+static unsigned int terrain_debug_last_log_ms = 0;
 static ProcTexture g_vehicle_noise_tex = {0};
 static ProcTexture g_vehicle_glitch_tex = {0};
 
@@ -663,6 +666,77 @@ void draw_map() {
     }
 }
 
+void draw_terrain() {
+    TerrainHeightfield *t = scene_active_terrain();
+    if (!t || !t->active || !t->heights || t->width < 2 || t->height < 2) return;
+
+    glDisable(GL_LIGHTING);
+    for (int gz = 0; gz < t->height - 1; gz++) {
+        glBegin(GL_TRIANGLE_STRIP);
+        for (int gx = 0; gx < t->width; gx++) {
+            float x = t->origin_x + gx * t->cell_size;
+            float z0 = t->origin_z + gz * t->cell_size;
+            float z1 = t->origin_z + (gz + 1) * t->cell_size;
+            float h0 = terrain_get_height(t, gx, gz);
+            float h1 = terrain_get_height(t, gx, gz + 1);
+            float shade0 = 0.14f + 0.02f * sinf((x + z0) * 0.01f) + h0 * 0.0015f;
+            float shade1 = 0.14f + 0.02f * sinf((x + z1) * 0.01f) + h1 * 0.0015f;
+            if (shade0 < 0.06f) shade0 = 0.06f;
+            if (shade1 < 0.06f) shade1 = 0.06f;
+            if (shade0 > 0.26f) shade0 = 0.26f;
+            if (shade1 > 0.26f) shade1 = 0.26f;
+            glColor3f(shade0 * 0.4f, shade0, shade0 * 0.5f);
+            glVertex3f(x, h0, z0);
+            glColor3f(shade1 * 0.4f, shade1, shade1 * 0.5f);
+            glVertex3f(x, h1, z1);
+        }
+        glEnd();
+    }
+
+    if (terrain_wireframe_debug) {
+        glLineWidth(1.0f);
+        glColor3f(0.15f, 0.9f, 0.9f);
+        glBegin(GL_LINES);
+        for (int gz = 0; gz < t->height; gz++) {
+            for (int gx = 0; gx < t->width - 1; gx++) {
+                float x0 = t->origin_x + gx * t->cell_size;
+                float x1 = t->origin_x + (gx + 1) * t->cell_size;
+                float z = t->origin_z + gz * t->cell_size;
+                glVertex3f(x0, terrain_get_height(t, gx, gz) + 0.05f, z);
+                glVertex3f(x1, terrain_get_height(t, gx + 1, gz) + 0.05f, z);
+            }
+        }
+        for (int gx = 0; gx < t->width; gx++) {
+            for (int gz = 0; gz < t->height - 1; gz++) {
+                float x = t->origin_x + gx * t->cell_size;
+                float z0 = t->origin_z + gz * t->cell_size;
+                float z1 = t->origin_z + (gz + 1) * t->cell_size;
+                glVertex3f(x, terrain_get_height(t, gx, gz) + 0.05f, z0);
+                glVertex3f(x, terrain_get_height(t, gx, gz + 1) + 0.05f, z1);
+            }
+        }
+        glEnd();
+    }
+
+    if (terrain_normals_debug) {
+        glLineWidth(1.0f);
+        glColor3f(0.95f, 0.2f, 0.95f);
+        glBegin(GL_LINES);
+        for (int gz = 1; gz < t->height - 1; gz += 4) {
+            for (int gx = 1; gx < t->width - 1; gx += 4) {
+                float x = t->origin_x + gx * t->cell_size;
+                float z = t->origin_z + gz * t->cell_size;
+                float y = terrain_get_height(t, gx, gz);
+                float nx = 0.0f, ny = 1.0f, nz = 0.0f;
+                terrain_sample_normal(t, x, z, &nx, &ny, &nz);
+                glVertex3f(x, y + 0.4f, z);
+                glVertex3f(x + nx * 5.0f, y + 0.4f + ny * 5.0f, z + nz * 5.0f);
+            }
+        }
+        glEnd();
+    }
+}
+
 static void draw_box_solid(float hx, float hy, float hz) {
     glBegin(GL_QUADS);
     glNormal3f(0, 1, 0);
@@ -1071,14 +1145,18 @@ void draw_hud(PlayerState *p) {
     if (p->in_vehicle) {
         glColor3f(0.0f, 1.0f, 0.0f);
         draw_string("BUGGY ONLINE", 50, 120, 12);
-        char style_buf[96];
-        snprintf(style_buf, sizeof(style_buf), "F6 STYLE:%s F7 GLOW:%s F8 LIGHT:%s",
+        char style_buf[128];
+        snprintf(style_buf, sizeof(style_buf), "F8 STYLE:%s F9 GLOW:%s F10 LIGHT:%s",
                  vehicle_style_enabled ? "ON" : "OFF",
                  vehicle_underglow_enabled ? "ON" : "OFF",
                  vehicle_worklights_enabled ? "ON" : "OFF");
         glColor3f(0.95f, 0.55f, 0.1f);
         draw_string(style_buf, 50, 108, 6);
     }
+    glColor3f(0.4f, 0.95f, 0.8f);
+    draw_string(terrain_wireframe_debug ? "F6 TERRAIN WIRE:ON" : "F6 TERRAIN WIRE:OFF", 50, 26, 5);
+    glColor3f(0.9f, 0.4f, 0.95f);
+    draw_string(terrain_normals_debug ? "F7 TERRAIN NORMALS:ON" : "F7 TERRAIN NORMALS:OFF", 220, 26, 5);
 
     if (p->storm_charges > 0) {
         char storm_buf[32];
@@ -1281,6 +1359,7 @@ void draw_scene(PlayerState *render_p) {
     
     draw_grid(); 
     update_and_draw_trails();
+    draw_terrain();
     draw_map();
     draw_garage_vehicle_pads();
     draw_garage_portal_frame();
@@ -2014,10 +2093,16 @@ int main(int argc, char* argv[]) {
                         SDL_SetRelativeMouseMode(SDL_FALSE);
                         setup_lobby_2d();
                     } else if (e.key.keysym.sym == SDLK_F6) {
-                        vehicle_style_enabled = !vehicle_style_enabled;
+                        terrain_wireframe_debug = !terrain_wireframe_debug;
+                        printf("[TERRAIN] wireframe=%s\n", terrain_wireframe_debug ? "on" : "off");
                     } else if (e.key.keysym.sym == SDLK_F7) {
-                        vehicle_underglow_enabled = !vehicle_underglow_enabled;
+                        terrain_normals_debug = !terrain_normals_debug;
+                        printf("[TERRAIN] normals=%s\n", terrain_normals_debug ? "on" : "off");
                     } else if (e.key.keysym.sym == SDLK_F8) {
+                        vehicle_style_enabled = !vehicle_style_enabled;
+                    } else if (e.key.keysym.sym == SDLK_F9) {
+                        vehicle_underglow_enabled = !vehicle_underglow_enabled;
+                    } else if (e.key.keysym.sym == SDLK_F10) {
                         vehicle_worklights_enabled = !vehicle_worklights_enabled;
                     }
                 }
@@ -2153,6 +2238,22 @@ int main(int argc, char* argv[]) {
             if (app_state == STATE_GAME_NET && !net_have_initial_local_snapshot_sync) {
                 render_pid = 0;
                 render_p = &local_state.players[render_pid];
+            }
+            phys_set_scene(render_p->scene_id);
+            unsigned int terrain_now_ms = SDL_GetTicks();
+            if (terrain_now_ms - terrain_debug_last_log_ms >= 1000) {
+                terrain_debug_last_log_ms = terrain_now_ms;
+                TerrainHeightfield *terrain = scene_active_terrain();
+                printf("[TERRAIN] active=%s scene=%d\n", (terrain && terrain->active) ? "yes" : "no", render_p->scene_id);
+                if (terrain && terrain->active) {
+                    float th = terrain_sample_height(terrain, render_p->x, render_p->z);
+                    int ground_source_terrain = 0;
+                    float gh = phys_sample_ground_height(render_p->x, render_p->z, &ground_source_terrain);
+                    printf("[TERRAIN] sample x=%.2f z=%.2f h=%.2f ground=%.2f source=%s last=%s\n",
+                           render_p->x, render_p->z, th, gh,
+                           ground_source_terrain ? "terrain" : "box",
+                           phys_last_grounded_on_terrain() ? "terrain" : "box");
+                }
             }
             draw_scene(render_p);
             SDL_GL_SwapWindow(win);

--- a/packages/common/physics.h
+++ b/packages/common/physics.h
@@ -120,6 +120,10 @@ static int map_count = 0;
 #define GARAGE_PORTAL_Y 6.0f
 #define GARAGE_PORTAL_Z 56.0f
 #define GARAGE_PORTAL_RADIUS 6.0f
+#define GARAGE_VOX_PORTAL_X 48.0f
+#define GARAGE_VOX_PORTAL_Y 6.0f
+#define GARAGE_VOX_PORTAL_Z 0.0f
+#define GARAGE_VOX_PORTAL_RADIUS 6.5f
 #define STADIUM_PORTAL_X 0.0f
 #define STADIUM_PORTAL_Y 2.0f
 #define STADIUM_PORTAL_Z 0.0f
@@ -138,6 +142,7 @@ static int map_count = 0;
 #define PORTAL_ID_GARAGE_EXIT 0
 #define PORTAL_ID_STADIUM_TO_VOXWORLD 1
 #define PORTAL_ID_VOXWORLD_TO_STADIUM 2
+#define PORTAL_ID_GARAGE_TO_VOXWORLD 3
 
 typedef struct {
     float x;
@@ -328,6 +333,13 @@ static inline int portal_resolve_destination(int current_scene, int portal_id, i
         scene_spawn_point(*out_scene, slot, out_x, out_y, out_z);
         return 1;
     }
+    if (current_scene == SCENE_GARAGE_OSAKA && portal_id == PORTAL_ID_GARAGE_TO_VOXWORLD) {
+        *out_scene = SCENE_VOXWORLD;
+        *out_x = -420.0f;
+        *out_y = 8.0f;
+        *out_z = 180.0f;
+        return 1;
+    }
     if (current_scene == SCENE_STADIUM && portal_id == PORTAL_ID_STADIUM_TO_VOXWORLD) {
         *out_scene = SCENE_VOXWORLD;
         *out_x = STADIUM_EDGE_TELEPORT_X;
@@ -377,6 +389,16 @@ static inline const VehiclePad *scene_vehicle_pads(int scene_id, int *out_count)
 
 static inline int scene_portal_triggered(PlayerState *p, int *out_portal_id) {
     if (!scene_portal_active(p->scene_id)) return 0;
+
+    if (p->scene_id == SCENE_GARAGE_OSAKA) {
+        float dx_vox = p->x - GARAGE_VOX_PORTAL_X;
+        float dz_vox = p->z - GARAGE_VOX_PORTAL_Z;
+        float dist_sq_vox = dx_vox * dx_vox + dz_vox * dz_vox;
+        if (dist_sq_vox <= (GARAGE_VOX_PORTAL_RADIUS * GARAGE_VOX_PORTAL_RADIUS)) {
+            if (out_portal_id) *out_portal_id = PORTAL_ID_GARAGE_TO_VOXWORLD;
+            return 1;
+        }
+    }
 
     if (p->scene_id == SCENE_STADIUM) {
         float dx_main = p->x - STADIUM_PORTAL_X;

--- a/packages/common/physics.h
+++ b/packages/common/physics.h
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "protocol.h"
+#include "../world/terrain.h"
 
 // --- TUNING ---
 #define GRAVITY_FLOAT 0.025f 
@@ -190,19 +191,58 @@ static inline void init_voxworld_city_geo() {
 }
 
 static int phys_scene_id = SCENE_STADIUM;
+static TerrainHeightfield g_scene_terrain = {0};
+static int g_last_ground_source_terrain = 0;
+static inline void init_voxworld_terrain(void);
 
 static inline void phys_set_scene(int scene_id) {
     phys_scene_id = scene_id;
     if (scene_id == SCENE_GARAGE_OSAKA) {
         map_geo = map_geo_garage;
         map_count = (int)(sizeof(map_geo_garage) / sizeof(Box));
+        g_scene_terrain.active = 0;
     } else if (scene_id == SCENE_VOXWORLD) {
         init_voxworld_city_geo();
         map_geo = map_geo_voxworld;
         map_count = map_geo_voxworld_count;
+        init_voxworld_terrain();
+        g_scene_terrain.active = (g_scene_terrain.heights != NULL);
     } else {
         map_geo = map_geo_stadium;
         map_count = (int)(sizeof(map_geo_stadium) / sizeof(Box));
+        g_scene_terrain.active = 0;
+    }
+}
+
+static inline TerrainHeightfield* scene_active_terrain(void) {
+    return g_scene_terrain.active ? &g_scene_terrain : NULL;
+}
+
+static inline int phys_last_grounded_on_terrain(void) {
+    return g_last_ground_source_terrain;
+}
+
+static inline void init_voxworld_terrain(void) {
+    if (g_scene_terrain.active) return;
+    if (!terrain_init(&g_scene_terrain, 72, 72, 16.0f, -576.0f, -576.0f)) return;
+    terrain_clear(&g_scene_terrain, 0.0f);
+    for (int gz = 0; gz < g_scene_terrain.height; gz++) {
+        for (int gx = 0; gx < g_scene_terrain.width; gx++) {
+            float wx = g_scene_terrain.origin_x + gx * g_scene_terrain.cell_size;
+            float wz = g_scene_terrain.origin_z + gz * g_scene_terrain.cell_size;
+            float hill = 22.0f * expf(-((wx + 260.0f) * (wx + 260.0f) + (wz - 140.0f) * (wz - 140.0f)) / (2.0f * 260.0f * 260.0f));
+            float runup = 0.05f * (wx + 360.0f);
+            float bowl_r = sqrtf((wx - 240.0f) * (wx - 240.0f) + (wz + 180.0f) * (wz + 180.0f));
+            float bowl = 0.0f;
+            if (bowl_r < 200.0f) {
+                float t = 1.0f - (bowl_r / 200.0f);
+                bowl = -16.0f * t * t;
+            }
+            float berm = 10.0f * expf(-((wx - 40.0f) * (wx - 40.0f)) / (2.0f * 120.0f * 120.0f))
+                       * expf(-((wz - 260.0f) * (wz - 260.0f)) / (2.0f * 70.0f * 70.0f));
+            float und = 2.8f * sinf(wx * 0.012f) * cosf(wz * 0.011f);
+            terrain_set_height(&g_scene_terrain, gx, gz, hill + runup + bowl + berm + und);
+        }
     }
 }
 
@@ -454,9 +494,17 @@ static inline int trace_map_boxes(float x1, float y1, float z1, float x2, float 
             return 1;
         }
     }
-    if (y2 < 0.0f) {
+    float terrain_ground = 0.0f;
+    int terrain_ok = 0;
+    if (g_scene_terrain.active && terrain_contains_world(&g_scene_terrain, x2, z2)) {
+        terrain_ground = terrain_sample_height(&g_scene_terrain, x2, z2);
+        terrain_ok = 1;
+    }
+    if (y2 < 0.0f || (terrain_ok && y2 < terrain_ground)) {
         *nx = 0.0f; *ny = 1.0f; *nz = 0.0f;
-        *out_x = x2; *out_y = 0.1f; *out_z = z2;
+        *out_x = x2;
+        *out_y = (terrain_ok ? terrain_ground : 0.0f) + 0.1f;
+        *out_z = z2;
         return 1;
     }
     return 0;
@@ -465,6 +513,27 @@ static inline int trace_map_boxes(float x1, float y1, float z1, float x2, float 
 int trace_map(float x1, float y1, float z1, float x2, float y2, float z2,
               float *out_x, float *out_y, float *out_z, float *nx, float *ny, float *nz) {
     return trace_map_boxes(x1, y1, z1, x2, y2, z2, out_x, out_y, out_z, nx, ny, nz);
+}
+
+static inline float phys_sample_ground_height(float x, float z, int *out_source_terrain) {
+    float h = 0.0f;
+    int source_terrain = 0;
+    if (g_scene_terrain.active && terrain_contains_world(&g_scene_terrain, x, z)) {
+        h = terrain_sample_height(&g_scene_terrain, x, z);
+        source_terrain = 1;
+    }
+    for (int i = 1; i < map_count; i++) {
+        Box b = map_geo[i];
+        if (x > b.x - b.w/2 && x < b.x + b.w/2 && z > b.z - b.d/2 && z < b.z + b.d/2) {
+            float top = b.y + b.h / 2.0f;
+            if (top > h || !source_terrain) {
+                h = top;
+                source_terrain = 0;
+            }
+        }
+    }
+    if (out_source_terrain) *out_source_terrain = source_terrain;
+    return h;
 }
 
 int check_hit_location(float ox, float oy, float oz, float dx, float dy, float dz, PlayerState *target) {
@@ -539,7 +608,21 @@ void resolve_collision(PlayerState *p) {
     float pw = p->in_vehicle ? 3.0f : PLAYER_WIDTH;
     float ph = p->in_vehicle ? 3.0f : (p->crouching ? (PLAYER_HEIGHT / 2.0f) : PLAYER_HEIGHT);
     p->on_ground = 0;
-    if (p->y < 0) { p->y = 0; p->vy = 0; p->on_ground = 1; }
+    g_last_ground_source_terrain = 0;
+
+    float ground_floor = 0.0f;
+    int terrain_ok = 0;
+    if (g_scene_terrain.active && terrain_contains_world(&g_scene_terrain, p->x, p->z)) {
+        terrain_ok = 1;
+        ground_floor = terrain_sample_height(&g_scene_terrain, p->x, p->z);
+        if (ground_floor < 0.0f) ground_floor = 0.0f;
+    }
+    if (p->y < 0.0f || (terrain_ok && p->y < ground_floor)) {
+        p->y = terrain_ok ? ground_floor : 0.0f;
+        p->vy = 0.0f;
+        p->on_ground = 1;
+        g_last_ground_source_terrain = terrain_ok ? 1 : 0;
+    }
     for(int i=1; i<map_count; i++) {
         Box b = map_geo[i];
         if (p->x + pw > b.x - b.w/2 && p->x - pw < b.x + b.w/2 &&
@@ -548,6 +631,7 @@ void resolve_collision(PlayerState *p) {
                 float prev_y = p->y - p->vy;
                 if (prev_y >= b.y + b.h/2) {
                     p->y = b.y + b.h/2; p->vy = 0; p->on_ground = 1;
+                    g_last_ground_source_terrain = 0;
                 } else {
                     float dx = p->x - b.x; float dz = p->z - b.z;
                     float w = (b.w > 0.1f) ? b.w : 1.0f;

--- a/packages/world/terrain.c
+++ b/packages/world/terrain.c
@@ -1,0 +1,123 @@
+#include "terrain.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+static int terrain_index(const TerrainHeightfield *t, int gx, int gz) {
+    return gz * t->width + gx;
+}
+
+static float terrain_get_height_clamped(const TerrainHeightfield *t, int gx, int gz) {
+    if (!t || !t->active || !t->heights || t->width <= 0 || t->height <= 0) return 0.0f;
+    if (gx < 0) gx = 0;
+    if (gz < 0) gz = 0;
+    if (gx >= t->width) gx = t->width - 1;
+    if (gz >= t->height) gz = t->height - 1;
+    return t->heights[terrain_index(t, gx, gz)];
+}
+
+int terrain_init(TerrainHeightfield *t, int width, int height, float cell_size, float origin_x, float origin_z) {
+    if (!t || width <= 1 || height <= 1 || cell_size <= 0.0f) return 0;
+    terrain_free(t);
+    t->width = width;
+    t->height = height;
+    t->cell_size = cell_size;
+    t->origin_x = origin_x;
+    t->origin_z = origin_z;
+    t->active = 0;
+    t->heights = (float*)malloc((size_t)width * (size_t)height * sizeof(float));
+    if (!t->heights) {
+        t->width = 0;
+        t->height = 0;
+        t->cell_size = 1.0f;
+        return 0;
+    }
+    memset(t->heights, 0, (size_t)width * (size_t)height * sizeof(float));
+    t->active = 1;
+    return 1;
+}
+
+void terrain_free(TerrainHeightfield *t) {
+    if (!t) return;
+    free(t->heights);
+    t->heights = NULL;
+    t->width = 0;
+    t->height = 0;
+    t->cell_size = 1.0f;
+    t->origin_x = 0.0f;
+    t->origin_z = 0.0f;
+    t->active = 0;
+}
+
+void terrain_clear(TerrainHeightfield *t, float h) {
+    if (!t || !t->heights) return;
+    int count = t->width * t->height;
+    for (int i = 0; i < count; i++) {
+        t->heights[i] = h;
+    }
+}
+
+void terrain_set_height(TerrainHeightfield *t, int gx, int gz, float h) {
+    if (!t || !t->active || !t->heights) return;
+    if (gx < 0 || gz < 0 || gx >= t->width || gz >= t->height) return;
+    t->heights[terrain_index(t, gx, gz)] = h;
+}
+
+float terrain_get_height(const TerrainHeightfield *t, int gx, int gz) {
+    if (!t || !t->active || !t->heights) return 0.0f;
+    if (gx < 0 || gz < 0 || gx >= t->width || gz >= t->height) return 0.0f;
+    return t->heights[terrain_index(t, gx, gz)];
+}
+
+int terrain_contains_world(const TerrainHeightfield *t, float x, float z) {
+    if (!t || !t->active || !t->heights || t->width < 2 || t->height < 2) return 0;
+    float local_x = (x - t->origin_x) / t->cell_size;
+    float local_z = (z - t->origin_z) / t->cell_size;
+    return local_x >= 0.0f && local_z >= 0.0f &&
+           local_x <= (float)(t->width - 1) && local_z <= (float)(t->height - 1);
+}
+
+float terrain_sample_height(const TerrainHeightfield *t, float x, float z) {
+    if (!t || !t->active || !t->heights || t->width < 2 || t->height < 2) return 0.0f;
+
+    float local_x = (x - t->origin_x) / t->cell_size;
+    float local_z = (z - t->origin_z) / t->cell_size;
+
+    int ix = (int)floorf(local_x);
+    int iz = (int)floorf(local_z);
+    float fx = local_x - (float)ix;
+    float fz = local_z - (float)iz;
+
+    float h00 = terrain_get_height_clamped(t, ix, iz);
+    float h10 = terrain_get_height_clamped(t, ix + 1, iz);
+    float h01 = terrain_get_height_clamped(t, ix, iz + 1);
+    float h11 = terrain_get_height_clamped(t, ix + 1, iz + 1);
+
+    float hx0 = h00 + (h10 - h00) * fx;
+    float hx1 = h01 + (h11 - h01) * fx;
+    return hx0 + (hx1 - hx0) * fz;
+}
+
+void terrain_sample_normal(const TerrainHeightfield *t, float x, float z, float *nx, float *ny, float *nz) {
+    if (nx) *nx = 0.0f;
+    if (ny) *ny = 1.0f;
+    if (nz) *nz = 0.0f;
+    if (!t || !t->active || !t->heights) return;
+
+    const float step = (t->cell_size > 0.001f) ? t->cell_size : 1.0f;
+    float h_l = terrain_sample_height(t, x - step, z);
+    float h_r = terrain_sample_height(t, x + step, z);
+    float h_d = terrain_sample_height(t, x, z - step);
+    float h_u = terrain_sample_height(t, x, z + step);
+
+    float sx = h_l - h_r;
+    float sy = 2.0f * step;
+    float sz = h_d - h_u;
+    float len = sqrtf(sx * sx + sy * sy + sz * sz);
+    if (len < 0.0001f) return;
+
+    if (nx) *nx = sx / len;
+    if (ny) *ny = sy / len;
+    if (nz) *nz = sz / len;
+}

--- a/packages/world/terrain.h
+++ b/packages/world/terrain.h
@@ -1,0 +1,31 @@
+#ifndef SHANKPIT_TERRAIN_H
+#define SHANKPIT_TERRAIN_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    int width;
+    int height;
+    float cell_size;
+    float origin_x;
+    float origin_z;
+    float *heights;
+    int active;
+} TerrainHeightfield;
+
+int terrain_init(TerrainHeightfield *t, int width, int height, float cell_size, float origin_x, float origin_z);
+void terrain_free(TerrainHeightfield *t);
+void terrain_clear(TerrainHeightfield *t, float h);
+void terrain_set_height(TerrainHeightfield *t, int gx, int gz, float h);
+float terrain_get_height(const TerrainHeightfield *t, int gx, int gz);
+float terrain_sample_height(const TerrainHeightfield *t, float x, float z);
+void terrain_sample_normal(const TerrainHeightfield *t, float x, float z, float *nx, float *ny, float *nz);
+int terrain_contains_world(const TerrainHeightfield *t, float x, float z);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
### Motivation
- Enable organic outdoor ground (hills, slopes, bowls, berms) while preserving the existing fast immediate-mode, box/brush world model.
- Provide a minimal, reusable heightfield API that other systems (vehicles, editors) can use later without rewriting the engine.
- Integrate terrain as a parallel world primitive so box geometry remains authoritative for built structures and collisions.

### Description
- Added a reusable terrain module with `packages/world/terrain.h` and `packages/world/terrain.c` implementing `TerrainHeightfield` and functions `terrain_init`, `terrain_free`, `terrain_clear`, `terrain_set_height`, `terrain_get_height`, `terrain_sample_height` (bilinear), `terrain_sample_normal`, and `terrain_contains_world`.
- Procedural demo terrain is generated in `packages/common/physics.h::init_voxworld_terrain()` for `SCENE_VOXWORLD` (72x72, `cell_size=16`, origin `(-576,-576)`) combining a Gaussian hill, linear run-up, radial bowl, berm ridge, and low-frequency undulation.
- Integrated terrain into physics as an additional ground source without removing existing box logic by updating `trace_map_boxes`, `resolve_collision`, and adding `phys_sample_ground_height` and helpers `scene_active_terrain` / `phys_last_grounded_on_terrain` so boxes still override terrain when higher.
- Added immediate-mode rendering in `apps/lobby/src/main.c` with `draw_terrain()` (triangle strips filled matte, optional neon wire overlay and sparse normal lines), inserted before `draw_map()`; HUD hints and debug toggles `F6` (wireframe) and `F7` (normals) were added and vehicle toggles moved to `F8/F9/F10`.
- Updated `Makefile` to include `packages/world` include path and to compile/link `packages/world/terrain.c` into lobby and server builds.

### Testing
- `make server` completed successfully with the new terrain module linked into the server binary.
- `make lobby` failed to build in this environment due to missing SDL2/OpenGL development headers (`SDL2/SDL.h` and `SDL2/SDL_opengl.h`), which prevents compiling the client here (error shown by `gcc`); server build confirmed the new C files compile cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69cb01747e488327865121c6e9db6500)