### PR TITLE
Add Oil Tanker scene, garage tanker portal, DM rotation, and Tab scoreboard

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -463,6 +463,10 @@ static void lobby_apply_scene_id(const char *scene_id) {
         scene_load(SCENE_GARAGE_OSAKA);
     } else if (strcmp(scene_id, "STADIUM") == 0) {
         scene_load(SCENE_STADIUM);
+    } else if (strcmp(scene_id, "VOXWORLD") == 0) {
+        scene_load(SCENE_VOXWORLD);
+    } else if (strcmp(scene_id, "OIL_TANKER") == 0) {
+        scene_load(SCENE_OIL_TANKER);
     }
 }
 
@@ -1438,6 +1442,83 @@ void draw_hud(PlayerState *p) {
     glEnable(GL_DEPTH_TEST); glMatrixMode(GL_PROJECTION); glPopMatrix(); glMatrixMode(GL_MODELVIEW); glPopMatrix();
 }
 
+static const char *scene_name_ui(int scene_id) {
+    switch (scene_id) {
+        case SCENE_GARAGE_OSAKA: return "GARAGE_OSAKA";
+        case SCENE_STADIUM: return "STADIUM";
+        case SCENE_VOXWORLD: return "VOXWORLD";
+        case SCENE_DUST_COMPOUND: return "DUST_COMPOUND";
+        case SCENE_OIL_TANKER: return "OIL_TANKER";
+        default: return "UNKNOWN";
+    }
+}
+
+typedef struct {
+    int id;
+    int kills;
+    int deaths;
+} ScoreRow;
+
+static int score_row_cmp_desc(const void *a, const void *b) {
+    const ScoreRow *ra = (const ScoreRow*)a;
+    const ScoreRow *rb = (const ScoreRow*)b;
+    if (ra->kills != rb->kills) return rb->kills - ra->kills;
+    if (ra->deaths != rb->deaths) return ra->deaths - rb->deaths;
+    return ra->id - rb->id;
+}
+
+static void draw_tab_scoreboard(PlayerState *self) {
+    const Uint8 *keys = SDL_GetKeyboardState(NULL);
+    if (!keys[SDL_SCANCODE_TAB]) return;
+
+    ScoreRow rows[MAX_CLIENTS];
+    int row_count = 0;
+    for (int i = 0; i < MAX_CLIENTS; i++) {
+        if (!local_state.players[i].active) continue;
+        rows[row_count].id = i;
+        rows[row_count].kills = local_state.players[i].kills;
+        rows[row_count].deaths = local_state.players[i].deaths;
+        row_count++;
+    }
+    qsort(rows, (size_t)row_count, sizeof(rows[0]), score_row_cmp_desc);
+
+    glDisable(GL_DEPTH_TEST);
+    glMatrixMode(GL_PROJECTION); glPushMatrix(); glLoadIdentity(); gluOrtho2D(0, 1280, 0, 720);
+    glMatrixMode(GL_MODELVIEW); glPushMatrix(); glLoadIdentity();
+
+    glColor4f(0.05f, 0.07f, 0.10f, 0.82f);
+    glBegin(GL_QUADS);
+    glVertex2f(290.0f, 150.0f); glVertex2f(990.0f, 150.0f); glVertex2f(990.0f, 600.0f); glVertex2f(290.0f, 600.0f);
+    glEnd();
+
+    char header[128];
+    snprintf(header, sizeof(header), "SCOREBOARD - %s", scene_name_ui(local_state.scene_id));
+    glColor3f(0.95f, 0.95f, 0.2f);
+    draw_string(header, 330, 566, 8);
+    glColor3f(0.75f, 0.9f, 1.0f);
+    draw_string("PLAYER", 330, 536, 6);
+    draw_string("K", 760, 536, 6);
+    draw_string("D", 860, 536, 6);
+
+    float y = 510.0f;
+    for (int i = 0; i < row_count && i < 16; i++) {
+        PlayerState *row_p = &local_state.players[rows[i].id];
+        int is_self = (row_p == self);
+        glColor3f(is_self ? 1.0f : 0.82f, is_self ? 0.95f : 0.82f, is_self ? 0.35f : 0.90f);
+        char name_buf[64];
+        snprintf(name_buf, sizeof(name_buf), "%s%02d", is_self ? "YOU-" : "P", rows[i].id);
+        draw_string(name_buf, 330, y, 6);
+        char score_buf[64];
+        snprintf(score_buf, sizeof(score_buf), "%d", rows[i].kills);
+        draw_string(score_buf, 760, y, 6);
+        snprintf(score_buf, sizeof(score_buf), "%d", rows[i].deaths);
+        draw_string(score_buf, 860, y, 6);
+        y -= 24.0f;
+    }
+
+    glEnable(GL_DEPTH_TEST); glMatrixMode(GL_PROJECTION); glPopMatrix(); glMatrixMode(GL_MODELVIEW); glPopMatrix();
+}
+
 static int target_in_view(PlayerState *p, float tx, float ty, float tz, float max_dist, float min_dot) {
     float rad_yaw = cam_yaw * 0.0174533f;
     float rad_pitch = cam_pitch * 0.0174533f;
@@ -1490,6 +1571,18 @@ static void draw_garage_portal_frame() {
         glPopMatrix();
 
         glPushMatrix();
+        glTranslatef(GARAGE_TANKER_PORTAL_X, GARAGE_TANKER_PORTAL_Y, GARAGE_TANKER_PORTAL_Z);
+        glColor3f(1.0f, 0.55f, 0.15f);
+        glLineWidth(3.0f);
+        glBegin(GL_LINE_LOOP);
+        glVertex3f(-GARAGE_TANKER_PORTAL_RADIUS, -2.0f, 0.0f);
+        glVertex3f(GARAGE_TANKER_PORTAL_RADIUS, -2.0f, 0.0f);
+        glVertex3f(GARAGE_TANKER_PORTAL_RADIUS, 6.0f, 0.0f);
+        glVertex3f(-GARAGE_TANKER_PORTAL_RADIUS, 6.0f, 0.0f);
+        glEnd();
+        glPopMatrix();
+
+        glPushMatrix();
         glTranslatef(GARAGE_DUST_PORTAL_X, GARAGE_DUST_PORTAL_Y, GARAGE_DUST_PORTAL_Z);
         glColor3f(1.0f, 0.82f, 0.35f);
         glLineWidth(3.0f);
@@ -1534,7 +1627,7 @@ static void draw_garage_overlay(PlayerState *p) {
     glColor3f(0.9f, 0.9f, 0.9f);
     draw_string("PORTAL -> STADIUM", 40, 640, 6);
     draw_string("PORTAL -> VOXWORLD TERRAIN", 40, 620, 6);
-    draw_string("PORTAL -> DUST COMPOUND", 40, 600, 6);
+    draw_string("PORTAL -> OIL TANKER", 40, 600, 6);
 
     int pad_count = 0;
     const VehiclePad *pads = scene_vehicle_pads(local_state.scene_id, &pad_count);
@@ -1562,6 +1655,7 @@ static void draw_garage_overlay(PlayerState *p) {
     scene_portal_info(local_state.scene_id, &portal_x, &portal_y, &portal_z, &portal_r);
     int portal_target = target_in_view(p, portal_x, portal_y, portal_z, 30.0f, 0.75f);
     int vox_portal_target = target_in_view(p, GARAGE_VOX_PORTAL_X, GARAGE_VOX_PORTAL_Y, GARAGE_VOX_PORTAL_Z, 30.0f, 0.75f);
+    int tanker_portal_target = target_in_view(p, GARAGE_TANKER_PORTAL_X, GARAGE_TANKER_PORTAL_Y, GARAGE_TANKER_PORTAL_Z, 30.0f, 0.75f);
     int dust_portal_target = target_in_view(p, GARAGE_DUST_PORTAL_X, GARAGE_DUST_PORTAL_Y, GARAGE_DUST_PORTAL_Z, 30.0f, 0.75f);
     int pad_target = 0;
     int heli_target = 0;
@@ -1584,7 +1678,7 @@ static void draw_garage_overlay(PlayerState *p) {
     }
 
     glColor3f(1.0f, 1.0f, 0.0f);
-    if (portal_target || vox_portal_target || dust_portal_target) {
+    if (portal_target || vox_portal_target || tanker_portal_target || dust_portal_target) {
         draw_string("TRAVEL", 600, 350, 8);
     } else if (heli_target || (p->in_vehicle && p->vehicle_type == VEH_HELICOPTER)) {
         draw_string(p->in_vehicle ? "PRESS F TO EXIT HELICOPTER" : "PRESS F TO ENTER HELICOPTER", 460, 350, 8);
@@ -1712,7 +1806,7 @@ void draw_scene(PlayerState *render_p) {
         if (p == render_p) continue;
         draw_player_3rd(p);
     }
-    draw_weapon_p(render_p); draw_hud(render_p); draw_garage_overlay(render_p);
+    draw_weapon_p(render_p); draw_hud(render_p); draw_garage_overlay(render_p); draw_tab_scoreboard(render_p);
     draw_travel_overlay();
 }
 
@@ -2148,6 +2242,8 @@ void net_process_snapshot(char *buffer, int len) {
         p->in_vehicle = np->in_vehicle;
         p->storm_charges = np->storm_charges;
         p->hit_feedback = np->hit_feedback;
+        p->kills = (int)np->kills;
+        p->deaths = (int)np->deaths;
         p->ammo[p->current_weapon] = np->ammo;
 
         if (now_shooting && !was_shooting) p->recoil_anim = 1.0f;

--- a/apps/server/src/main.c
+++ b/apps/server/src/main.c
@@ -55,6 +55,13 @@ typedef struct {
 static RecorderState recorder = {0};
 
 #define SERVER_SNAPSHOT_INTERVAL_TICKS 3
+#define SERVER_DM_FRAG_LIMIT 25
+#define SERVER_DM_ROUND_MS (6 * 60 * 1000)
+
+static const int g_dm_rotation[] = { SCENE_STADIUM, SCENE_VOXWORLD, SCENE_OIL_TANKER };
+static int g_dm_rotation_idx = 0;
+static int g_server_match_scene = SCENE_GARAGE_OSAKA;
+static unsigned int g_round_start_ms = 0;
 
 #define RECORDER_SHAKE_POS 0.08f
 #define RECORDER_SHAKE_ANGLE 0.35f
@@ -72,6 +79,27 @@ unsigned int get_server_time() {
 
 static double now_seconds(void) {
     return (double)get_server_time() / 1000.0;
+}
+
+static int server_scene_is_dm_map(int scene_id) {
+    return scene_id == SCENE_STADIUM || scene_id == SCENE_VOXWORLD || scene_id == SCENE_OIL_TANKER;
+}
+
+static void server_advance_dm_rotation(unsigned int now_ms) {
+    g_dm_rotation_idx = (g_dm_rotation_idx + 1) % (int)(sizeof(g_dm_rotation) / sizeof(g_dm_rotation[0]));
+    g_server_match_scene = g_dm_rotation[g_dm_rotation_idx];
+    scene_load(g_server_match_scene);
+    g_round_start_ms = now_ms;
+    for (int i = 0; i < MAX_CLIENTS; i++) {
+        PlayerState *p = &local_state.players[i];
+        if (!p->active) continue;
+        p->kills = 0;
+        p->deaths = 0;
+        p->state = STATE_ALIVE;
+        p->health = 100;
+        p->shield = 100;
+    }
+    printf("[ROUND] next_map=%d rotation_idx=%d\n", g_server_match_scene, g_dm_rotation_idx);
 }
 
 static int addr_equal(const struct sockaddr_in *a, const struct sockaddr_in *b) {
@@ -92,7 +120,7 @@ static int alloc_slot(const struct sockaddr_in *addr) {
         if (!slots[i].active) {
             memset(&local_state.players[i], 0, sizeof(PlayerState));
             local_state.players[i].id = i;
-            local_state.players[i].scene_id = SCENE_GARAGE_OSAKA;
+            local_state.players[i].scene_id = g_server_match_scene;
             local_state.players[i].active = 0;
             phys_respawn(&local_state.players[i], get_server_time());
             local_state.players[i].yaw = 0.0f;
@@ -434,6 +462,8 @@ void server_broadcast() {
             np.in_vehicle = (unsigned char)p->in_vehicle;
             np.hit_feedback = (unsigned char)p->hit_feedback;
             np.storm_charges = (unsigned char)p->storm_charges;
+            np.kills = (unsigned short)(p->kills < 0 ? 0 : p->kills);
+            np.deaths = (unsigned short)(p->deaths < 0 ? 0 : p->deaths);
 
             p->accumulated_reward = 0;
             memcpy(buffer + cursor, &np, sizeof(NetPlayer)); cursor += (int)sizeof(NetPlayer);
@@ -497,6 +527,13 @@ int main(int argc, char *argv[]) {
     server_net_init();
     int mode = parse_server_mode(argc, argv);
     local_init_match(1, mode);
+    if (mode == MODE_DEATHMATCH || mode == MODE_TDM) {
+        g_server_match_scene = g_dm_rotation[g_dm_rotation_idx];
+        scene_load(g_server_match_scene);
+        g_round_start_ms = get_server_time();
+    } else {
+        g_server_match_scene = SCENE_GARAGE_OSAKA;
+    }
     local_state.players[0].active = 0;
     local_state.players[0].health = 0;
     local_state.players[0].state = STATE_DEAD;
@@ -616,6 +653,18 @@ int main(int argc, char *argv[]) {
                 occ->x = h->x; occ->y = h->y; occ->z = h->z;
                 occ->yaw = h->yaw;
                 occ->vx = occ->vy = occ->vz = 0.0f;
+            }
+        }
+
+        if ((mode == MODE_DEATHMATCH || mode == MODE_TDM) && server_scene_is_dm_map(g_server_match_scene)) {
+            int top_frags = 0;
+            for (int i = 1; i < MAX_CLIENTS; i++) {
+                PlayerState *p = &local_state.players[i];
+                if (!p->active || p->scene_id != g_server_match_scene) continue;
+                if (p->kills > top_frags) top_frags = p->kills;
+            }
+            if ((now - g_round_start_ms) >= SERVER_DM_ROUND_MS || top_frags >= SERVER_DM_FRAG_LIMIT) {
+                server_advance_dm_rotation(now);
             }
         }
 

--- a/packages/common/physics.h
+++ b/packages/common/physics.h
@@ -117,6 +117,9 @@ static int map_geo_voxworld_init = 0;
 static Box map_geo_dust[CITY_MAX_BOXES];
 static int map_geo_dust_count = 0;
 static int map_geo_dust_init = 0;
+static Box map_geo_tanker[CITY_MAX_BOXES];
+static int map_geo_tanker_count = 0;
+static int map_geo_tanker_init = 0;
 
 static const Box *map_geo = map_geo_stadium;
 static int map_count = 0;
@@ -167,6 +170,10 @@ static int map_count = 0;
 #define DUST_BRIDGE_X 20.0f
 #define DUST_BRIDGE_Z -20.0f
 
+#define TANKER_KILL_Y -70.0f
+#define TANKER_BOUNDS_X 360.0f
+#define TANKER_BOUNDS_Z 240.0f
+
 #define GARAGE_PORTAL_X 0.0f
 #define GARAGE_PORTAL_Y 6.0f
 #define GARAGE_PORTAL_Z 56.0f
@@ -179,6 +186,10 @@ static int map_count = 0;
 #define GARAGE_DUST_PORTAL_Y 6.0f
 #define GARAGE_DUST_PORTAL_Z -12.0f
 #define GARAGE_DUST_PORTAL_RADIUS 6.0f
+#define GARAGE_TANKER_PORTAL_X -48.0f
+#define GARAGE_TANKER_PORTAL_Y 6.0f
+#define GARAGE_TANKER_PORTAL_Z 0.0f
+#define GARAGE_TANKER_PORTAL_RADIUS 6.0f
 #define STADIUM_PORTAL_X 0.0f
 #define STADIUM_PORTAL_Y 2.0f
 #define STADIUM_PORTAL_Z 0.0f
@@ -198,12 +209,18 @@ static int map_count = 0;
 #define DUST_PORTAL_Y 6.0f
 #define DUST_PORTAL_Z -210.0f
 #define DUST_PORTAL_RADIUS 14.0f
+#define TANKER_PORTAL_X 292.0f
+#define TANKER_PORTAL_Y 6.0f
+#define TANKER_PORTAL_Z 0.0f
+#define TANKER_PORTAL_RADIUS 13.0f
 #define PORTAL_ID_GARAGE_EXIT 0
 #define PORTAL_ID_STADIUM_TO_VOXWORLD 1
 #define PORTAL_ID_VOXWORLD_TO_STADIUM 2
 #define PORTAL_ID_GARAGE_TO_VOXWORLD 3
 #define PORTAL_ID_GARAGE_TO_DUST 4
 #define PORTAL_ID_DUST_TO_GARAGE 5
+#define PORTAL_ID_GARAGE_TO_TANKER 6
+#define PORTAL_ID_TANKER_TO_GARAGE 7
 
 typedef struct {
     float x;
@@ -271,6 +288,11 @@ static const Vec2 dust_spawn_points_dm[] = {
     {-430.0f, -210.0f}, {-290.0f, -150.0f}, {-180.0f, -190.0f}, {-90.0f, -70.0f},
     {40.0f, -210.0f}, {120.0f, -20.0f}, {210.0f, -140.0f}, {290.0f, -10.0f},
     {-210.0f, 180.0f}, {-60.0f, 140.0f}, {110.0f, 200.0f}, {260.0f, 170.0f}
+};
+static const Vec2 tanker_spawn_points_dm[] = {
+    {-260.0f, 0.0f}, {-210.0f, -90.0f}, {-205.0f, 92.0f}, {-120.0f, -140.0f},
+    {-110.0f, 140.0f}, {-30.0f, -72.0f}, {-20.0f, 82.0f}, {80.0f, -155.0f},
+    {90.0f, 155.0f}, {150.0f, -30.0f}, {155.0f, 35.0f}, {220.0f, 0.0f}
 };
 static const VoxRouteAnchor dust_route_anchors[] = {
     {DUST_MID_X, DUST_MID_Z, "MID"},
@@ -507,6 +529,50 @@ static inline void init_dust_compound_geo(void) {
     printf("[DUST] authored geo boxes=%d ramp_steps=%d\n", map_geo_dust_count, 23);
 }
 
+
+static inline void tanker_add_box(float x, float y, float z, float w, float h, float d) {
+    if (map_geo_tanker_count >= CITY_MAX_BOXES) return;
+    map_geo_tanker[map_geo_tanker_count++] = (Box){x, y, z, w, h, d};
+}
+
+static inline void init_oil_tanker_geo(void) {
+    if (map_geo_tanker_init) return;
+    map_geo_tanker_init = 1;
+    map_geo_tanker_count = 0;
+
+    tanker_add_box(0.0f, -3.0f, 0.0f, 620.0f, 6.0f, 420.0f);
+    tanker_add_box(0.0f, 2.0f, 0.0f, 560.0f, 4.0f, 220.0f);
+    tanker_add_box(0.0f, 2.0f, -145.0f, 520.0f, 4.0f, 44.0f);
+    tanker_add_box(0.0f, 2.0f, 145.0f, 520.0f, 4.0f, 44.0f);
+
+    tanker_add_box(-190.0f, 8.0f, 0.0f, 170.0f, 4.0f, 72.0f);
+    tanker_add_box(-100.0f, 8.0f, 0.0f, 24.0f, 4.0f, 72.0f);
+    tanker_add_box(-145.0f, 11.0f, 0.0f, 18.0f, 2.0f, 72.0f);
+
+    tanker_add_box(190.0f, 11.0f, 0.0f, 120.0f, 6.0f, 96.0f);
+    tanker_add_box(210.0f, 17.0f, 0.0f, 70.0f, 6.0f, 54.0f);
+    tanker_add_box(225.0f, 22.0f, 0.0f, 34.0f, 4.0f, 30.0f);
+
+    tanker_add_box(-260.0f, 2.0f, -110.0f, 58.0f, 4.0f, 58.0f);
+    tanker_add_box(-230.0f, 2.0f, 120.0f, 58.0f, 4.0f, 58.0f);
+    tanker_add_box(-90.0f, 2.0f, -100.0f, 66.0f, 4.0f, 40.0f);
+    tanker_add_box(-40.0f, 2.0f, 105.0f, 66.0f, 4.0f, 40.0f);
+    tanker_add_box(70.0f, 2.0f, -112.0f, 58.0f, 4.0f, 58.0f);
+    tanker_add_box(95.0f, 2.0f, 98.0f, 58.0f, 4.0f, 58.0f);
+
+    tanker_add_box(0.0f, 4.0f, -195.0f, 620.0f, 8.0f, 6.0f);
+    tanker_add_box(0.0f, 4.0f, 195.0f, 620.0f, 8.0f, 6.0f);
+    tanker_add_box(-305.0f, 4.0f, 0.0f, 6.0f, 8.0f, 420.0f);
+    tanker_add_box(305.0f, 4.0f, 0.0f, 6.0f, 8.0f, 420.0f);
+
+    tanker_add_box(-260.0f, 7.0f, -65.0f, 16.0f, 8.0f, 50.0f);
+    tanker_add_box(-260.0f, 8.0f, -45.0f, 16.0f, 10.0f, 30.0f);
+    tanker_add_box(-230.0f, 7.0f, 65.0f, 16.0f, 8.0f, 50.0f);
+    tanker_add_box(-230.0f, 8.0f, 45.0f, 16.0f, 10.0f, 30.0f);
+
+    printf("[OIL_TANKER] authored geo boxes=%d\n", map_geo_tanker_count);
+}
+
 static int phys_scene_id = SCENE_STADIUM;
 static TerrainHeightfield g_scene_terrain = {0};
 static int g_last_ground_source_terrain = 0;
@@ -514,6 +580,7 @@ static int g_scene_terrain_scene_id = -1;
 static inline void init_voxworld_bloodgulch_terrain(void);
 static inline void init_dust_compound_terrain(void);
 static inline void init_dust_compound_geo(void);
+static inline void init_oil_tanker_geo(void);
 
 static inline void phys_set_scene(int scene_id) {
     phys_scene_id = scene_id;
@@ -527,6 +594,11 @@ static inline void phys_set_scene(int scene_id) {
         map_geo = map_geo_dust;
         map_count = map_geo_dust_count;
         g_scene_terrain.active = (g_scene_terrain.heights != NULL);
+    } else if (scene_id == SCENE_OIL_TANKER) {
+        init_oil_tanker_geo();
+        map_geo = map_geo_tanker;
+        map_count = map_geo_tanker_count;
+        g_scene_terrain.active = 0;
     } else if (scene_id == SCENE_VOXWORLD) {
         init_voxworld_bloodgulch_terrain();
         init_voxworld_bloodgulch_geo();
@@ -687,6 +759,14 @@ static inline void scene_spawn_point(int scene_id, int slot, float *out_x, float
         *out_y = dust_height_at(*out_x, *out_z) + 5.5f;
         return;
     }
+    if (scene_id == SCENE_OIL_TANKER) {
+        int count = (int)(sizeof(tanker_spawn_points_dm) / sizeof(Vec2));
+        int idx = slot % count;
+        *out_x = tanker_spawn_points_dm[idx].x;
+        *out_z = tanker_spawn_points_dm[idx].y;
+        *out_y = 6.0f;
+        return;
+    }
     if (slot % 2 == 0) {
         *out_x = 0.0f; *out_z = 0.0f; *out_y = 80.0f;
     } else {
@@ -698,14 +778,16 @@ static inline void scene_spawn_point(int scene_id, int slot, float *out_x, float
 }
 
 static inline void scene_spawn_for_player(PlayerState *p, float *out_x, float *out_y, float *out_z) {
-    if (p->scene_id != SCENE_VOXWORLD && p->scene_id != SCENE_DUST_COMPOUND) {
+    if (p->scene_id != SCENE_VOXWORLD && p->scene_id != SCENE_DUST_COMPOUND && p->scene_id != SCENE_OIL_TANKER) {
         scene_spawn_point(p->scene_id, p->id, out_x, out_y, out_z);
         return;
     }
-    const Vec2 *pts = (p->scene_id == SCENE_DUST_COMPOUND) ? dust_spawn_points_dm : voxworld_spawn_points_ffa;
+    const Vec2 *pts = (p->scene_id == SCENE_DUST_COMPOUND) ? dust_spawn_points_dm
+                    : (p->scene_id == SCENE_OIL_TANKER ? tanker_spawn_points_dm : voxworld_spawn_points_ffa);
     int count = (p->scene_id == SCENE_DUST_COMPOUND)
         ? (int)(sizeof(dust_spawn_points_dm) / sizeof(Vec2))
-        : (int)(sizeof(voxworld_spawn_points_ffa) / sizeof(Vec2));
+        : (p->scene_id == SCENE_OIL_TANKER ? (int)(sizeof(tanker_spawn_points_dm) / sizeof(Vec2))
+                                           : (int)(sizeof(voxworld_spawn_points_ffa) / sizeof(Vec2)));
     int team_mode = (g_phys_game_mode == MODE_TDM || g_phys_game_mode == MODE_CTF);
     int team = p->team_id;
     if (team_mode && (team != 0 && team != 1)) team = (p->id % 2);
@@ -731,7 +813,7 @@ static inline void scene_spawn_for_player(PlayerState *p, float *out_x, float *o
     *out_z = pts[idx].y;
     *out_y = (p->scene_id == SCENE_DUST_COMPOUND)
         ? (dust_height_at(*out_x, *out_z) + 5.5f)
-        : (voxworld_height_at(*out_x, *out_z) + 6.0f);
+        : (p->scene_id == SCENE_OIL_TANKER ? 6.0f : (voxworld_height_at(*out_x, *out_z) + 6.0f));
 }
 
 static inline void scene_force_spawn(PlayerState *p) {
@@ -777,12 +859,20 @@ static inline void scene_safety_check(PlayerState *p) {
             p->z < -DUST_BOUNDS_Z || p->z > DUST_BOUNDS_Z) {
             scene_force_spawn(p);
         }
+        return;
+    }
+    if (p->scene_id == SCENE_OIL_TANKER) {
+        if (p->y < TANKER_KILL_Y ||
+            p->x < -TANKER_BOUNDS_X || p->x > TANKER_BOUNDS_X ||
+            p->z < -TANKER_BOUNDS_Z || p->z > TANKER_BOUNDS_Z) {
+            scene_force_spawn(p);
+        }
     }
 }
 
 static inline int scene_portal_active(int scene_id) {
     return scene_id == SCENE_GARAGE_OSAKA || scene_id == SCENE_STADIUM ||
-           scene_id == SCENE_VOXWORLD || scene_id == SCENE_DUST_COMPOUND;
+           scene_id == SCENE_VOXWORLD || scene_id == SCENE_DUST_COMPOUND || scene_id == SCENE_OIL_TANKER;
 }
 
 static inline int portal_resolve_destination(int current_scene, int portal_id, int slot,
@@ -812,6 +902,13 @@ static inline int portal_resolve_destination(int current_scene, int portal_id, i
         *out_z = DUST_ATTACK_SPAWN_Z;
         return 1;
     }
+    if (current_scene == SCENE_GARAGE_OSAKA && portal_id == PORTAL_ID_GARAGE_TO_TANKER) {
+        *out_scene = SCENE_OIL_TANKER;
+        *out_x = -265.0f;
+        *out_y = 6.0f;
+        *out_z = 0.0f;
+        return 1;
+    }
     if (current_scene == SCENE_STADIUM && portal_id == PORTAL_ID_STADIUM_TO_VOXWORLD) {
         *out_scene = SCENE_VOXWORLD;
         *out_x = STADIUM_EDGE_TELEPORT_X;
@@ -831,6 +928,13 @@ static inline int portal_resolve_destination(int current_scene, int portal_id, i
         *out_x = GARAGE_DUST_PORTAL_X + 10.0f;
         *out_y = GARAGE_DUST_PORTAL_Y;
         *out_z = GARAGE_DUST_PORTAL_Z;
+        return 1;
+    }
+    if (current_scene == SCENE_OIL_TANKER && portal_id == PORTAL_ID_TANKER_TO_GARAGE) {
+        *out_scene = SCENE_GARAGE_OSAKA;
+        *out_x = GARAGE_TANKER_PORTAL_X + 10.0f;
+        *out_y = GARAGE_TANKER_PORTAL_Y;
+        *out_z = GARAGE_TANKER_PORTAL_Z;
         return 1;
     }
     return 0;
@@ -857,6 +961,11 @@ static inline void scene_portal_info(int scene_id, float *out_x, float *out_y, f
         *out_y = DUST_PORTAL_Y;
         *out_z = DUST_PORTAL_Z;
         *out_radius = DUST_PORTAL_RADIUS;
+    } else if (scene_id == SCENE_OIL_TANKER) {
+        *out_x = TANKER_PORTAL_X;
+        *out_y = TANKER_PORTAL_Y;
+        *out_z = TANKER_PORTAL_Z;
+        *out_radius = TANKER_PORTAL_RADIUS;
     } else {
         *out_x = 0.0f; *out_y = 0.0f; *out_z = 0.0f; *out_radius = 0.0f;
     }
@@ -922,6 +1031,13 @@ static inline int scene_portal_triggered(PlayerState *p, int *out_portal_id) {
             if (out_portal_id) *out_portal_id = PORTAL_ID_GARAGE_TO_VOXWORLD;
             return 1;
         }
+        float dx_tanker = p->x - GARAGE_TANKER_PORTAL_X;
+        float dz_tanker = p->z - GARAGE_TANKER_PORTAL_Z;
+        float dist_sq_tanker = dx_tanker * dx_tanker + dz_tanker * dz_tanker;
+        if (dist_sq_tanker <= (GARAGE_TANKER_PORTAL_RADIUS * GARAGE_TANKER_PORTAL_RADIUS)) {
+            if (out_portal_id) *out_portal_id = PORTAL_ID_GARAGE_TO_TANKER;
+            return 1;
+        }
         float dx_dust = p->x - GARAGE_DUST_PORTAL_X;
         float dz_dust = p->z - GARAGE_DUST_PORTAL_Z;
         float dist_sq_dust = dx_dust * dx_dust + dz_dust * dz_dust;
@@ -960,7 +1076,7 @@ static inline int scene_portal_triggered(PlayerState *p, int *out_portal_id) {
         if (out_portal_id) {
             *out_portal_id = (p->scene_id == SCENE_VOXWORLD)
                 ? PORTAL_ID_VOXWORLD_TO_STADIUM
-                : (p->scene_id == SCENE_DUST_COMPOUND ? PORTAL_ID_DUST_TO_GARAGE : PORTAL_ID_GARAGE_EXIT);
+                : (p->scene_id == SCENE_DUST_COMPOUND ? PORTAL_ID_DUST_TO_GARAGE : (p->scene_id == SCENE_OIL_TANKER ? PORTAL_ID_TANKER_TO_GARAGE : PORTAL_ID_GARAGE_EXIT));
         }
         return 1;
     }

--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -12,6 +12,7 @@
 #define SCENE_VOXWORLD 2
 #define SCENE_DUST_COMPOUND 3
 #define SCENE_CITY 4
+#define SCENE_OIL_TANKER 5
 
 #define PACKET_CONNECT 0
 #define PACKET_USERCMD 1
@@ -108,6 +109,8 @@ typedef struct {
     unsigned char in_vehicle;
     unsigned char hit_feedback; 
     unsigned char storm_charges;
+    unsigned short kills;
+    unsigned short deaths;
 } NetPlayer;
 
 typedef struct {


### PR DESCRIPTION
### Motivation
- Add a new playable deathmatch map (oil tanker) and expose it as an additional destination from the Osaka garage while preserving all existing worlds and portal flows. 
- Provide basic deathmatch essentials (scoreboard) and include the new map in server map rotation so matches can cycle Stadium -> Voxworld -> Oil Tanker.

### Description
- Added a new scene id `SCENE_OIL_TANKER` and network fields for `kills`/`deaths` in `NetPlayer` so the scoreboard can be populated over the network (edited `packages/common/protocol.h`).
- Implemented tanker geometry, spawn points, safety bounds, and scene activation in the physics layer and map geometry (`packages/common/physics.h`) and added `PORTAL_ID_GARAGE_TO_TANKER` / `PORTAL_ID_TANKER_TO_GARAGE` plus garage/tanker portal constants.
- Extended portal plumbing additively: updated `scene_portal_active`, `scene_portal_info`, `scene_portal_triggered`, and `portal_resolve_destination` to handle garage <-> tanker travel without changing existing routes.
- Updated lobby/client UI (`apps/lobby/src/main.c`) to recognize `OIL_TANKER` in `lobby_apply_scene_id`, render a new tanker portal frame and overlay label in the Osaka garage, detect tanker portal targeting, and draw a hold-Tab scoreboard showing player, kills, and deaths sorted by kills desc / deaths asc with self-highlight.
- Propagated `kills`/`deaths` in server snapshots and client snapshot handling: server now packs `np.kills`/`np.deaths` and client applies them to `local_state.players` so the Tab scoreboard is accurate in net games (`apps/server/src/main.c`, `apps/lobby/src/main.c`).
- Added server-authoritative DM rotation logic and round end conditions (time or frag limit) and ensure new joiners spawn into the current active DM map (`apps/server/src/main.c`).

### Testing
- Built the server target with `gcc -O2 ... apps/server/src/main.c packages/world/terrain.c -o /tmp/shank_server_test -lm` which compiled successfully.
- Ran `make -j2` for a full build which failed in this environment due to missing SDL2 headers (`SDL2/SDL.h`, `SDL2/SDL_opengl.h`) required for the client build, so full client/runtime verification could not be completed here.
- Verified code compiles for the server and ran basic static checks (no runtime tests were executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbfce2de88832788037aeffce50e08)