### PR TITLE
Authoritative Voxworld helicopter spawns + multiplayer snapshot plumbing fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,35 @@
 
 SHANKPIT is a fast-paced 3D multiplayer first-person shooter built with C, SDL2, and OpenGL. The game features physics-based movement, multiple weapons, shield mechanics, and support for both human players and AI bots (including neural network-powered agents).
 
+## Controls (Keyboard + Mouse)
+
+### On-foot controls
+- `W / A / S / D` — move
+- `Mouse` — look/aim
+- `Left Mouse` — fire
+- `Right Mouse` — ADS/zoom (sniper zoom when sniper is equipped)
+- `Space` — jump
+- `Left Ctrl` — crouch
+- `R` — reload (on foot)
+- `F` — use/interact (enter/exit vehicles, trigger portals)
+- `E` — ability 1
+- `1..6` — weapon select
+
+### Helicopter controls
+- `W / S` — pitch forward/back (forward flight / braking)
+- `A / D` — yaw left/right
+- `Space` — ascend
+- `Left Ctrl` — descend
+- `F` — enter/exit helicopter
+- `E` — strafe left (bound to ability input path)
+- `Q` — currently reserved in helicopter mode (bound through reload input path)
+
+### Debug / misc
+- `F8` — toggle renderer mode
+- `F9` — toggle vehicle worklights
+- `F11` — toggle Voxworld scene debug points
+- `F12` — toggle VS0 art-direction debug
+
 ## System Architecture
 
 ### High-Level Components

--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -2310,9 +2310,22 @@ void net_process_snapshot(char *buffer, int len) {
         }
     }
 
-    for (int hi = 0; hi < MAX_HELICOPTERS; hi++) local_state.helicopters[hi].active = 0;
+    static int heli_diag_throttle = 0;
+    int snapshot_scene = local_state.players[my_client_id].scene_id;
+    unsigned char heli_seen[MAX_HELICOPTERS];
+    memset(heli_seen, 0, sizeof(heli_seen));
+
+    for (int hi = 0; hi < MAX_HELICOPTERS; hi++) {
+        HelicopterState *h = &local_state.helicopters[hi];
+        if (h->active && h->scene_id == snapshot_scene) {
+            h->active = 0;
+            h->occupant_player_id = -1;
+        }
+    }
+
+    unsigned char heli_count = 0;
     if (cursor < len) {
-        unsigned char heli_count = *(unsigned char *)(buffer + cursor);
+        heli_count = *(unsigned char *)(buffer + cursor);
         cursor++;
         for (int hi = 0; hi < heli_count; hi++) {
             if (cursor + (int)sizeof(NetHelicopter) > len) break;
@@ -2333,12 +2346,25 @@ void net_process_snapshot(char *buffer, int len) {
             h->rotor_speed = nh->rotor_speed;
             h->health = nh->health;
             h->occupant_player_id = nh->occupant_player_id;
+            heli_seen[nh->id] = 1;
             if (h->occupant_player_id > 0 && h->occupant_player_id < MAX_CLIENTS) {
                 PlayerState *occ = &local_state.players[h->occupant_player_id];
                 occ->in_vehicle = 1;
                 occ->vehicle_type = VEH_HELICOPTER;
             }
         }
+    }
+
+    for (int hi = 0; hi < MAX_HELICOPTERS; hi++) {
+        HelicopterState *h = &local_state.helicopters[hi];
+        if (h->active && h->scene_id == snapshot_scene && !heli_seen[hi]) {
+            h->active = 0;
+            h->occupant_player_id = -1;
+        }
+    }
+
+    if ((heli_diag_throttle++ % 120) == 0) {
+        printf("[HELI_NET][C] scene=%d heli_count=%u\n", snapshot_scene, heli_count);
     }
     for (int i = 1; i < MAX_CLIENTS; i++) {
         PlayerState *p = &local_state.players[i];

--- a/apps/server/src/main.c
+++ b/apps/server/src/main.c
@@ -426,85 +426,103 @@ void server_handle_packet(struct sockaddr_in *sender, char *buffer, int size) {
 }
 
 void server_broadcast() {
-    char buffer[4096];
-    int cursor = 0;
-    NetHeader head;
-    head.type = PACKET_SNAPSHOT;
-    head.client_id = 0;
-    head.sequence = local_state.server_tick;
-    head.timestamp = get_server_time();
-    head.scene_id = 0;
+    static int heli_diag_throttle = 0;
 
-    unsigned char count = 0;
-    for(int i=1; i<MAX_CLIENTS; i++) if (slots[i].active && slots[i].welcomed && slots[i].cmd_seen && local_state.players[i].active) count++;
-    head.entity_count = count;
+    for (int slot = 1; slot < MAX_CLIENTS; slot++) {
+        if (!slots[slot].active) continue;
 
-    memcpy(buffer + cursor, &head, sizeof(NetHeader)); cursor += (int)sizeof(NetHeader);
-    memcpy(buffer + cursor, &count, 1); cursor += 1;
+        char buffer[4096];
+        int cursor = 0;
 
-    for(int i=1; i<MAX_CLIENTS; i++) {
-        PlayerState *p = &local_state.players[i];
-        if (slots[i].active && slots[i].welcomed && slots[i].cmd_seen && p->active) {
-            NetPlayer np;
-            np.id = (unsigned char)i;
-            np.scene_id = (unsigned char)p->scene_id;
-            np.last_seq = client_last_seq[i];
-            np.x = p->x; np.y = p->y; np.z = p->z;
-            np.yaw = norm_yaw_deg(p->yaw); np.pitch = clamp_pitch_deg(p->pitch);
-            np.current_weapon = (unsigned char)p->current_weapon;
-            np.state = (unsigned char)p->state;
-            np.health = (unsigned char)p->health;
-            np.shield = (unsigned char)p->shield;
-            np.is_shooting = (unsigned char)p->is_shooting;
-            np.crouching = (unsigned char)p->crouching;
-            np.reward_feedback = p->accumulated_reward;
-            np.ammo = (unsigned char)p->ammo[p->current_weapon];
-            np.in_vehicle = (unsigned char)p->in_vehicle;
-            np.hit_feedback = (unsigned char)p->hit_feedback;
-            np.storm_charges = (unsigned char)p->storm_charges;
-            np.kills = (unsigned short)(p->kills < 0 ? 0 : p->kills);
-            np.deaths = (unsigned short)(p->deaths < 0 ? 0 : p->deaths);
+        NetHeader head;
+        head.type = PACKET_SNAPSHOT;
+        head.client_id = 0;
+        head.sequence = local_state.server_tick;
+        head.timestamp = get_server_time();
+        head.scene_id = 0;
 
-            p->accumulated_reward = 0;
-            memcpy(buffer + cursor, &np, sizeof(NetPlayer)); cursor += (int)sizeof(NetPlayer);
+        unsigned char count = 0;
+        for (int i = 1; i < MAX_CLIENTS; i++) {
+            if (slots[i].active && slots[i].welcomed && slots[i].cmd_seen && local_state.players[i].active) count++;
+        }
+        head.entity_count = count;
+
+        memcpy(buffer + cursor, &head, sizeof(NetHeader)); cursor += (int)sizeof(NetHeader);
+        memcpy(buffer + cursor, &count, 1); cursor += 1;
+
+        for (int i = 1; i < MAX_CLIENTS; i++) {
+            PlayerState *p = &local_state.players[i];
+            if (slots[i].active && slots[i].welcomed && slots[i].cmd_seen && p->active) {
+                NetPlayer np;
+                np.id = (unsigned char)i;
+                np.scene_id = (unsigned char)p->scene_id;
+                np.last_seq = client_last_seq[i];
+                np.x = p->x; np.y = p->y; np.z = p->z;
+                np.yaw = norm_yaw_deg(p->yaw); np.pitch = clamp_pitch_deg(p->pitch);
+                np.current_weapon = (unsigned char)p->current_weapon;
+                np.state = (unsigned char)p->state;
+                np.health = (unsigned char)p->health;
+                np.shield = (unsigned char)p->shield;
+                np.is_shooting = (unsigned char)p->is_shooting;
+                np.crouching = (unsigned char)p->crouching;
+                np.reward_feedback = p->accumulated_reward;
+                np.ammo = (unsigned char)p->ammo[p->current_weapon];
+                np.in_vehicle = (unsigned char)p->in_vehicle;
+                np.hit_feedback = (unsigned char)p->hit_feedback;
+                np.storm_charges = (unsigned char)p->storm_charges;
+                np.kills = (unsigned short)(p->kills < 0 ? 0 : p->kills);
+                np.deaths = (unsigned short)(p->deaths < 0 ? 0 : p->deaths);
+
+                memcpy(buffer + cursor, &np, sizeof(NetPlayer)); cursor += (int)sizeof(NetPlayer);
+            }
+        }
+
+        int target_scene = local_state.players[slot].scene_id;
+        unsigned char heli_count = 0;
+        for (int i = 0; i < MAX_HELICOPTERS; i++) {
+            HelicopterState *h = &local_state.helicopters[i];
+            if (!h->active) continue;
+            if (h->scene_id != target_scene) continue;
+            heli_count++;
+        }
+        memcpy(buffer + cursor, &heli_count, 1); cursor += 1;
+
+        for (int i = 0; i < MAX_HELICOPTERS; i++) {
+            HelicopterState *h = &local_state.helicopters[i];
+            if (!h->active || h->scene_id != target_scene) continue;
+            NetHelicopter nh;
+            memset(&nh, 0, sizeof(nh));
+            nh.id = (unsigned char)h->id;
+            nh.scene_id = (unsigned char)h->scene_id;
+            nh.active = (unsigned char)h->active;
+            nh.grounded = (unsigned char)h->grounded;
+            nh.x = h->x; nh.y = h->y; nh.z = h->z;
+            nh.vx = h->vx; nh.vy = h->vy; nh.vz = h->vz;
+            nh.yaw = h->yaw;
+            nh.pitch_visual = h->pitch_visual;
+            nh.roll_visual = h->roll_visual;
+            nh.rotor_angle = h->rotor_angle;
+            nh.rotor_speed = h->rotor_speed;
+            nh.health = (unsigned char)(h->health < 0 ? 0 : (h->health > 255 ? 255 : h->health));
+            nh.occupant_player_id = (signed char)h->occupant_player_id;
+            memcpy(buffer + cursor, &nh, sizeof(NetHelicopter)); cursor += (int)sizeof(NetHelicopter);
+        }
+
+        sendto(sock, buffer, cursor, 0, (struct sockaddr*)&slots[slot].addr, sizeof(struct sockaddr_in));
+
+        if ((heli_diag_throttle++ % 120) == 0) {
+            printf("[HELI_NET][S] slot=%d scene=%d heli_count=%u\n", slot, target_scene, heli_count);
         }
     }
 
-    unsigned char heli_count = 0;
-    for (int i = 0; i < MAX_HELICOPTERS; i++) {
-        HelicopterState *h = &local_state.helicopters[i];
-        if (h->active) heli_count++;
-    }
-    memcpy(buffer + cursor, &heli_count, 1); cursor += 1;
-    for (int i = 0; i < MAX_HELICOPTERS; i++) {
-        HelicopterState *h = &local_state.helicopters[i];
-        if (!h->active) continue;
-        NetHelicopter nh;
-        memset(&nh, 0, sizeof(nh));
-        nh.id = (unsigned char)h->id;
-        nh.scene_id = (unsigned char)h->scene_id;
-        nh.active = (unsigned char)h->active;
-        nh.grounded = (unsigned char)h->grounded;
-        nh.x = h->x; nh.y = h->y; nh.z = h->z;
-        nh.vx = h->vx; nh.vy = h->vy; nh.vz = h->vz;
-        nh.yaw = h->yaw;
-        nh.pitch_visual = h->pitch_visual;
-        nh.roll_visual = h->roll_visual;
-        nh.rotor_angle = h->rotor_angle;
-        nh.rotor_speed = h->rotor_speed;
-        nh.health = (unsigned char)(h->health < 0 ? 0 : (h->health > 255 ? 255 : h->health));
-        nh.occupant_player_id = (signed char)h->occupant_player_id;
-        memcpy(buffer + cursor, &nh, sizeof(NetHelicopter)); cursor += (int)sizeof(NetHelicopter);
-    }
-
-    for(int i=1; i<MAX_CLIENTS; i++) {
-        if (slots[i].active) {
-            sendto(sock, buffer, cursor, 0,
-                   (struct sockaddr*)&slots[i].addr,
-                   sizeof(struct sockaddr_in));
+    for (int i = 1; i < MAX_CLIENTS; i++) {
+        PlayerState *p = &local_state.players[i];
+        if (slots[i].active && slots[i].welcomed && slots[i].cmd_seen && p->active) {
+            p->accumulated_reward = 0.0f;
         }
     }
 }
+
 
 int main(int argc, char *argv[]) {
     for (int i = 1; i < argc; i++) {

--- a/packages/common/physics.h
+++ b/packages/common/physics.h
@@ -147,6 +147,10 @@ static int map_count = 0;
 #define VOXWORLD_BASE_RED_X -1040.0f
 #define VOXWORLD_BASE_BLUE_X 1040.0f
 #define VOXWORLD_BASE_Z 0.0f
+#define VOXWORLD_HELI_RED_X -1170.0f
+#define VOXWORLD_HELI_RED_Z -165.0f
+#define VOXWORLD_HELI_BLUE_X (-(VOXWORLD_HELI_RED_X))
+#define VOXWORLD_HELI_BLUE_Z (-(VOXWORLD_HELI_RED_Z))
 #define DUST_KILL_Y -90.0f
 #define DUST_TERRAIN_W 92
 #define DUST_TERRAIN_H 92
@@ -683,6 +687,8 @@ static inline void init_voxworld_bloodgulch_terrain(void) {
     vox_terrain_stamp(&g_scene_terrain, VOXWORLD_BASE_BLUE_X, 0.0f, 220.0f, 20.0f, 1.0f);
     vox_terrain_stamp(&g_scene_terrain, VOXWORLD_BASE_RED_X + 130.0f, 0.0f, 140.0f, 14.0f, 1.0f);
     vox_terrain_stamp(&g_scene_terrain, VOXWORLD_BASE_BLUE_X - 130.0f, 0.0f, 140.0f, 14.0f, 1.0f);
+    vox_terrain_stamp(&g_scene_terrain, VOXWORLD_HELI_RED_X, VOXWORLD_HELI_RED_Z, 58.0f, 18.0f, 0.9f);
+    vox_terrain_stamp(&g_scene_terrain, VOXWORLD_HELI_BLUE_X, VOXWORLD_HELI_BLUE_Z, 58.0f, 18.0f, 0.9f);
     vox_terrain_stamp(&g_scene_terrain, -260.0f, -500.0f, 130.0f, -6.0f, 0.75f);
     vox_terrain_stamp(&g_scene_terrain, 260.0f, -500.0f, 130.0f, -6.0f, 0.75f);
     vox_terrain_stamp(&g_scene_terrain, -260.0f, 480.0f, 140.0f, 28.0f, 0.75f);

--- a/packages/simulation/local_game.h
+++ b/packages/simulation/local_game.h
@@ -4,6 +4,7 @@
 #include "../common/protocol.h"
 #include "../common/physics.h"
 #include "../common/shared_movement.h"
+#include <stdio.h>
 #include <string.h>
 
 ServerState local_state;
@@ -47,17 +48,7 @@ PlayerState* get_best_bot() {
     return best;
 }
 
-static inline void scene_load(int scene_id) {
-    local_state.scene_id = scene_id;
-    phys_set_scene(scene_id);
-    for (int i = 0; i < MAX_CLIENTS; i++) {
-        if (!local_state.players[i].active) continue;
-        local_state.players[i].scene_id = scene_id;
-        scene_force_spawn(&local_state.players[i]);
-    }
-}
-
-static inline void heli_spawn_defaults(HelicopterState *h, int id, int scene_id, float x, float y, float z) {
+static inline void heli_spawn_defaults(HelicopterState *h, int id, int scene_id, float x, float y, float z, float yaw) {
     memset(h, 0, sizeof(*h));
     h->active = 1;
     h->id = id;
@@ -66,7 +57,43 @@ static inline void heli_spawn_defaults(HelicopterState *h, int id, int scene_id,
     h->health = 250;
     h->occupant_player_id = -1;
     h->rotor_speed = 8.0f;
-    h->yaw = 180.0f;
+    h->yaw = yaw;
+    h->grounded = 1;
+}
+
+static inline void scene_init_helicopters(int scene_id) {
+    for (int i = 0; i < MAX_HELICOPTERS; i++) {
+        memset(&local_state.helicopters[i], 0, sizeof(local_state.helicopters[i]));
+        local_state.helicopters[i].occupant_player_id = -1;
+    }
+
+    if (scene_id != SCENE_VOXWORLD) return;
+
+    phys_set_scene(scene_id);
+    const float skid_offset = g_heli_tuning.collider_height * 0.5f + 0.05f;
+    const float red_ground = phys_sample_ground_height(VOXWORLD_HELI_RED_X, VOXWORLD_HELI_RED_Z, NULL);
+    const float blue_ground = phys_sample_ground_height(VOXWORLD_HELI_BLUE_X, VOXWORLD_HELI_BLUE_Z, NULL);
+
+    heli_spawn_defaults(&local_state.helicopters[0], 0, scene_id,
+                       VOXWORLD_HELI_RED_X, red_ground + skid_offset, VOXWORLD_HELI_RED_Z, 270.0f);
+    heli_spawn_defaults(&local_state.helicopters[1], 1, scene_id,
+                       VOXWORLD_HELI_BLUE_X, blue_ground + skid_offset, VOXWORLD_HELI_BLUE_Z, 90.0f);
+
+    printf("[HELI_INIT] scene=%d count=2 red=(%.1f,%.1f,%.1f) blue=(%.1f,%.1f,%.1f)\n",
+           scene_id,
+           local_state.helicopters[0].x, local_state.helicopters[0].y, local_state.helicopters[0].z,
+           local_state.helicopters[1].x, local_state.helicopters[1].y, local_state.helicopters[1].z);
+}
+
+static inline void scene_load(int scene_id) {
+    local_state.scene_id = scene_id;
+    phys_set_scene(scene_id);
+    scene_init_helicopters(scene_id);
+    for (int i = 0; i < MAX_CLIENTS; i++) {
+        if (!local_state.players[i].active) continue;
+        local_state.players[i].scene_id = scene_id;
+        scene_force_spawn(&local_state.players[i]);
+    }
 }
 
 static inline HelicopterState *heli_find_nearby(int scene_id, float x, float y, float z, float radius) {
@@ -394,6 +421,6 @@ void local_init_match(int num_players, int mode) {
         phys_respawn(&local_state.players[i], i*100);
         init_genome(&local_state.players[i].brain);
     }
-    heli_spawn_defaults(&local_state.helicopters[0], 0, local_state.scene_id, 16.0f, 4.0f, 12.0f);
+    scene_init_helicopters(local_state.scene_id);
 }
 #endif


### PR DESCRIPTION
### Motivation
- Add two mirrored, usable helicopters to Blood Gulch (Voxworld) and ensure they are server-authoritative so all clients see the same helicopters in multiplayer.
- Ground helicopters correctly using terrain sampling and a small symmetric hardstand so they rest stably and do not clip.
- Fix missing snapshot plumbing so helicopter state (transform, occupancy, visual fields) is replicated and decoded correctly and stale helicopters do not persist across scene transitions.

### Description
- Added authored helicopter anchors and symmetric hardstands in `packages/common/physics.h` as `VOXWORLD_HELI_RED_X`, `VOXWORLD_HELI_RED_Z` and mirrored `VOXWORLD_HELI_BLUE_*`, and stamped small landing pads in `init_voxworld_bloodgulch_terrain()`.
- Implemented scene-authoritative helicopter initialization in `packages/simulation/local_game.h` via `scene_init_helicopters(scene_id)` which clears stale slots and spawns exactly two helicopters only for `SCENE_VOXWORLD` using `phys_sample_ground_height(...)` + skid offset and sane defaults (active=1, occupant=-1, grounded, rotor defaults, yaw facing midfield).
- Made server snapshot emission scene-aware and per-recipient in `apps/server/src/main.c` so the server writes only helicopters relevant to the receiving client’s scene and includes a compact `NetHelicopter` for each active heli (id, scene_id, active, grounded, x/y/z, vx/vy/vz, yaw, visuals, rotor, occupant, health). A throttled diagnostic log reports emitted heli counts.
- Fixed client snapshot decoding in `apps/lobby/src/main.c` (`net_process_snapshot(...)`) to clear stale helicopters for the active scene, decode the `NetHelicopter` entries into `local_state.helicopters[]`, apply authoritative `occupant_player_id` (mark occupant player `in_vehicle`), and clean up any helicopter slots not present in the snapshot; added a throttled client-side heli diagnostic print.
- Preserved existing client render/interaction/camera hooks that read from `local_state.helicopters[]` and added a Controls section to `README.md` documenting on-foot and helicopter controls plus debug hotkeys.

### Testing
- Built server object: `gcc -O2 -Wall -D_REENTRANT -Ipackages/common -Ipackages/simulation -Ipackages/render -Ipackages/world -c apps/server/src/main.c -o /tmp/server_main.o` succeeded.
- Full parallel build: `make -j2` failed in this environment due to missing SDL2 development headers (client/lobby compile blocked), so client binary not produced here.
- Ran repository searches and static checks to confirm snapshot/layout alignment and ensured both server and client snapshot writer/reader were updated together; no runtime network integration tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc0aa936588327b3e5d94a9a57768c)