### PR TITLE
Arcade buggy: steering/drift sim, visual body yaw lag, and network parity

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -363,6 +363,10 @@ static void client_apply_spawn_transition_sync(PlayerState *p, const NetPlayer *
     p->z = np->z;
     p->yaw = cam_yaw;
     p->pitch = cam_pitch;
+    p->buggy_body_yaw = norm_yaw_deg(np->buggy_body_yaw);
+    p->buggy_yaw_rate = np->buggy_yaw_rate;
+    p->buggy_steer = np->buggy_steer;
+    p->buggy_slip_angle = np->buggy_slip_angle;
 
     reconcile_corr_x = 0.0f;
     reconcile_corr_y = 0.0f;
@@ -1136,6 +1140,12 @@ void draw_buggy_model(PlayerState *p) {
         glPopMatrix();
     }
 
+    float steer_vis = 0.0f;
+    if (p) {
+        steer_vis = p->buggy_steer * BUGGY_WHEEL_STEER_MAX;
+        if (steer_vis > BUGGY_WHEEL_STEER_MAX) steer_vis = BUGGY_WHEEL_STEER_MAX;
+        if (steer_vis < -BUGGY_WHEEL_STEER_MAX) steer_vis = -BUGGY_WHEEL_STEER_MAX;
+    }
     float wx[] = {-2.2f, 2.2f, -2.2f, 2.2f};
     float wz[] = {2.5f, 2.5f, -2.5f, -2.5f};
     glDisable(GL_TEXTURE_2D);
@@ -1144,6 +1154,7 @@ void draw_buggy_model(PlayerState *p) {
     for (int i = 0; i < 4; i++) {
         glPushMatrix();
         glTranslatef(wx[i], -0.5f, wz[i]);
+        if (i < 2) glRotatef(steer_vis, 0, 1, 0);
         glScalef(0.8f, 1.5f, 1.5f);
         glColor3f(0.10f, 0.10f, 0.10f);
         draw_box_solid(0.5f, 0.5f, 0.5f);
@@ -1540,12 +1551,24 @@ void draw_player_3rd(PlayerState *p) {
     float draw_yaw = norm_yaw_deg(p->yaw);
     float draw_pitch = clamp_pitch_deg(p->pitch);
     float draw_recoil = (p->is_shooting > 0) ? 1.0f : p->recoil_anim;
+    float buggy_roll = 0.0f;
+    float buggy_pitch = 0.0f;
+
+    if (p->in_vehicle && p->vehicle_type == VEH_BUGGY) {
+        draw_yaw = norm_yaw_deg(p->buggy_body_yaw);
+        buggy_roll = p->buggy_visual_roll;
+        buggy_pitch = p->buggy_visual_pitch;
+    }
 
     glPushMatrix();
     glTranslatef(p->x, p->y + 0.2f, p->z);
     // Simulation yaw assumes forward is -Z, but this model is authored facing +Z.
     glRotatef(180.0f - draw_yaw, 0, 1, 0);
     if (p->in_vehicle) {
+        if (p->vehicle_type == VEH_BUGGY) {
+            glRotatef(buggy_roll, 0, 0, 1);
+            glRotatef(buggy_pitch, 1, 0, 0);
+        }
         draw_buggy_model(p);
     } else {
         // TODO(net): replicate skin on player state (e.g. p->skin) so remote players can use per-player skins.
@@ -1653,6 +1676,13 @@ void draw_hud(PlayerState *p) {
         }
         glColor3f(0.95f, 0.55f, 0.1f);
         draw_string(style_buf, 50, 98, vs0_art_direction_enabled ? 4 : 6);
+        if (p->vehicle_type == VEH_BUGGY) {
+            char buggy_dbg[128];
+            snprintf(buggy_dbg, sizeof(buggy_dbg), "BUG FWD:%+.2f LAT:%+.2f SLIP:%+.1f YAWR:%+.2f STR:%+.2f",
+                     p->buggy_forward_speed, p->buggy_lateral_speed, p->buggy_slip_angle, p->buggy_yaw_rate, p->buggy_steer);
+            glColor3f(0.62f, 0.93f, 0.92f);
+            draw_string(buggy_dbg, 50, 146, vs0_art_direction_enabled ? 4 : 6);
+        }
     }
     glColor3f(0.58f, 0.75f, 0.76f);
     draw_string(terrain_wireframe_debug ? "F6 TERRAIN WIRE:ON" : "F6 TERRAIN WIRE:OFF", 50, 24, vs0_art_direction_enabled ? 3 : 5);
@@ -2299,7 +2329,8 @@ static void client_decay_pending_correction(unsigned int now_ms) {
     if (fabsf(reconcile_corr_pitch) < 0.01f) reconcile_corr_pitch = 0.0f;
 }
 
-static void client_reconcile_local_player(unsigned int ack_seq, float auth_x, float auth_y, float auth_z, float auth_yaw, float auth_pitch) {
+static void client_reconcile_local_player(unsigned int ack_seq, float auth_x, float auth_y, float auth_z, float auth_yaw, float auth_pitch,
+                                          float auth_buggy_body_yaw, float auth_buggy_yaw_rate, float auth_buggy_steer, float auth_buggy_slip_angle) {
     if (my_client_id <= 0 || my_client_id >= MAX_CLIENTS) return;
     if (ack_seq <= net_last_reconciled_ack) return;
 
@@ -2320,6 +2351,10 @@ static void client_reconcile_local_player(unsigned int ack_seq, float auth_x, fl
     p->x = auth_x; p->y = auth_y; p->z = auth_z;
     p->yaw = norm_yaw_deg(auth_yaw);
     p->pitch = clamp_pitch_deg(auth_pitch);
+    p->buggy_body_yaw = norm_yaw_deg(auth_buggy_body_yaw);
+    p->buggy_yaw_rate = auth_buggy_yaw_rate;
+    p->buggy_steer = auth_buggy_steer;
+    p->buggy_slip_angle = auth_buggy_slip_angle;
 
     int replayed = 0;
     for (unsigned int seq = ack_seq + 1; seq <= net_latest_seq_sent; seq++) {
@@ -2434,6 +2469,10 @@ static void net_apply_remote_interpolation(unsigned int now_ms) {
 #endif
             p->x = ri->a.x; p->y = ri->a.y; p->z = ri->a.z;
             p->yaw = norm_yaw_deg(ri->a.yaw); p->pitch = clamp_pitch_deg(ri->a.pitch);
+            p->buggy_body_yaw = norm_yaw_deg(ri->a.buggy_body_yaw);
+            p->buggy_yaw_rate = ri->a.buggy_yaw_rate;
+            p->buggy_steer = ri->a.buggy_steer;
+            p->buggy_slip_angle = ri->a.buggy_slip_angle;
             continue;
         }
 
@@ -2445,6 +2484,10 @@ static void net_apply_remote_interpolation(unsigned int now_ms) {
 #endif
             p->x = ri->b.x; p->y = ri->b.y; p->z = ri->b.z;
             p->yaw = norm_yaw_deg(ri->b.yaw); p->pitch = clamp_pitch_deg(ri->b.pitch);
+            p->buggy_body_yaw = norm_yaw_deg(ri->b.buggy_body_yaw);
+            p->buggy_yaw_rate = ri->b.buggy_yaw_rate;
+            p->buggy_steer = ri->b.buggy_steer;
+            p->buggy_slip_angle = ri->b.buggy_slip_angle;
             continue;
         }
         float t = num / den;
@@ -2466,6 +2509,10 @@ static void net_apply_remote_interpolation(unsigned int now_ms) {
         p->z = ri->a.z + (ri->b.z - ri->a.z) * t;
         p->yaw = angle_lerp_deg(ri->a.yaw, ri->b.yaw, t);
         p->pitch = clamp_pitch_deg(ri->a.pitch + (ri->b.pitch - ri->a.pitch) * t);
+        p->buggy_body_yaw = angle_lerp_deg(ri->a.buggy_body_yaw, ri->b.buggy_body_yaw, t);
+        p->buggy_yaw_rate = ri->a.buggy_yaw_rate + (ri->b.buggy_yaw_rate - ri->a.buggy_yaw_rate) * t;
+        p->buggy_steer = ri->a.buggy_steer + (ri->b.buggy_steer - ri->a.buggy_steer) * t;
+        p->buggy_slip_angle = ri->a.buggy_slip_angle + (ri->b.buggy_slip_angle - ri->a.buggy_slip_angle) * t;
     }
 
 #if NET_JITTER_DIAG
@@ -2534,6 +2581,10 @@ void net_process_snapshot(char *buffer, int len) {
     unsigned int local_ack_seq = 0;
     float local_auth_x = 0.0f, local_auth_y = 0.0f, local_auth_z = 0.0f;
     float local_auth_yaw = 0.0f, local_auth_pitch = 0.0f;
+    float local_auth_buggy_body_yaw = 0.0f;
+    float local_auth_buggy_yaw_rate = 0.0f;
+    float local_auth_buggy_steer = 0.0f;
+    float local_auth_buggy_slip_angle = 0.0f;
 
     for(int i=0; i<count; i++) {
         if (cursor + (int)sizeof(NetPlayer) > len) break;
@@ -2553,6 +2604,10 @@ void net_process_snapshot(char *buffer, int len) {
             p->x = np->x; p->y = np->y; p->z = np->z;
             p->yaw   = norm_yaw_deg(np->yaw);
             p->pitch = clamp_pitch_deg(np->pitch);
+            p->buggy_body_yaw = norm_yaw_deg(np->buggy_body_yaw);
+            p->buggy_yaw_rate = np->buggy_yaw_rate;
+            p->buggy_steer = np->buggy_steer;
+            p->buggy_slip_angle = np->buggy_slip_angle;
         }
 
         p->state = np->state;
@@ -2588,6 +2643,10 @@ void net_process_snapshot(char *buffer, int len) {
             local_auth_z = np->z;
             local_auth_yaw = np->yaw;
             local_auth_pitch = np->pitch;
+            local_auth_buggy_body_yaw = np->buggy_body_yaw;
+            local_auth_buggy_yaw_rate = np->buggy_yaw_rate;
+            local_auth_buggy_steer = np->buggy_steer;
+            local_auth_buggy_slip_angle = np->buggy_slip_angle;
 
             int first_local_snapshot_sync = !net_have_initial_local_snapshot_sync;
 
@@ -2628,7 +2687,8 @@ void net_process_snapshot(char *buffer, int len) {
     }
 
     if (local_seen) {
-        client_reconcile_local_player(local_ack_seq, local_auth_x, local_auth_y, local_auth_z, local_auth_yaw, local_auth_pitch);
+        client_reconcile_local_player(local_ack_seq, local_auth_x, local_auth_y, local_auth_z, local_auth_yaw, local_auth_pitch,
+                                      local_auth_buggy_body_yaw, local_auth_buggy_yaw_rate, local_auth_buggy_steer, local_auth_buggy_slip_angle);
     }
 
     for (int id = 1; id < MAX_CLIENTS; id++) {

--- a/apps/server/src/main.c
+++ b/apps/server/src/main.c
@@ -475,6 +475,10 @@ void server_broadcast() {
             np.last_seq = client_last_seq[pi];
             np.x = p->x; np.y = p->y; np.z = p->z;
             np.yaw = norm_yaw_deg(p->yaw); np.pitch = clamp_pitch_deg(p->pitch);
+            np.buggy_body_yaw = norm_yaw_deg(p->buggy_body_yaw);
+            np.buggy_yaw_rate = p->buggy_yaw_rate;
+            np.buggy_steer = p->buggy_steer;
+            np.buggy_slip_angle = p->buggy_slip_angle;
             np.current_weapon = (unsigned char)p->current_weapon;
             np.state = (unsigned char)p->state;
             np.health = (unsigned char)p->health;

--- a/packages/common/net_sim.h
+++ b/packages/common/net_sim.h
@@ -33,6 +33,82 @@ static const HelicopterTuning g_heli_tuning = {
     14.0f, 16.0f, 7.0f, 4.5f, 3.4f, 2.6f
 };
 
+static inline float shankpit_buggy_clampf(float v, float lo, float hi) {
+    if (v < lo) return lo;
+    if (v > hi) return hi;
+    return v;
+}
+
+static inline void shankpit_buggy_sync_state(PlayerState *p) {
+    if (!p) return;
+    p->yaw = norm_yaw_deg(p->buggy_body_yaw);
+}
+
+static inline void shankpit_buggy_simulate(PlayerState *p) {
+    if (!p) return;
+
+    float planar_speed = sqrtf(p->vx * p->vx + p->vz * p->vz);
+    float speed_ratio = shankpit_buggy_clampf(planar_speed / BUGGY_MAX_SPEED, 0.0f, 1.0f);
+    float steer_input = shankpit_buggy_clampf(p->in_strafe, -1.0f, 1.0f);
+
+    if (fabsf(steer_input) < 0.01f) steer_input = 0.0f;
+    if (planar_speed < BUGGY_MIN_STEER_SPEED) steer_input *= (planar_speed / BUGGY_MIN_STEER_SPEED);
+
+    p->buggy_steer += (steer_input - p->buggy_steer) * 0.22f;
+
+    float target_yaw_rate = p->buggy_steer * BUGGY_STEER_STRENGTH;
+    float yaw_rate_cap = BUGGY_MAX_YAW_RATE_LOW + (BUGGY_MAX_YAW_RATE_HIGH - BUGGY_MAX_YAW_RATE_LOW) * speed_ratio;
+    if (target_yaw_rate > yaw_rate_cap) target_yaw_rate = yaw_rate_cap;
+    if (target_yaw_rate < -yaw_rate_cap) target_yaw_rate = -yaw_rate_cap;
+
+    p->buggy_yaw_rate += (target_yaw_rate - p->buggy_yaw_rate) * BUGGY_YAW_RATE_RESPONSE;
+    p->buggy_yaw_rate *= (1.0f - BUGGY_YAW_DAMPING);
+    p->buggy_body_yaw = norm_yaw_deg(p->buggy_body_yaw + p->buggy_yaw_rate);
+
+    float yaw_rad = -p->buggy_body_yaw * 0.0174533f;
+    float fx = sinf(yaw_rad), fz = -cosf(yaw_rad);
+    float rx = cosf(yaw_rad), rz = sinf(yaw_rad);
+    float forward_speed = p->vx * fx + p->vz * fz;
+    float lateral_speed = p->vx * rx + p->vz * rz;
+
+    float motor_axis = shankpit_buggy_clampf(p->in_fwd, -1.0f, 1.0f);
+    float accel = BUGGY_ACCEL * BUGGY_MAX_SPEED;
+    forward_speed += motor_axis * accel;
+
+    float lateral_grip = BUGGY_GRIP_LOW_SPEED + (BUGGY_GRIP_HIGH_SPEED - BUGGY_GRIP_LOW_SPEED) * speed_ratio;
+    float drift_commit = shankpit_buggy_clampf(fabsf(p->buggy_steer) * speed_ratio, 0.0f, 1.0f);
+    float grip_scale = 1.0f - drift_commit * BUGGY_DRIFT_MULTIPLIER;
+    if (grip_scale < 0.12f) grip_scale = 0.12f;
+    lateral_speed *= (1.0f - lateral_grip * grip_scale);
+
+    float induced_slip = p->buggy_steer * planar_speed * (0.08f + 0.16f * speed_ratio);
+    lateral_speed += induced_slip;
+
+    forward_speed *= (1.0f - BUGGY_LONGITUDINAL_DRAG);
+    lateral_speed *= (1.0f - BUGGY_LATERAL_DRAG);
+
+    if (forward_speed > BUGGY_MAX_SPEED) forward_speed = BUGGY_MAX_SPEED;
+    if (forward_speed < -BUGGY_MAX_SPEED * 0.68f) forward_speed = -BUGGY_MAX_SPEED * 0.68f;
+
+    p->vx = fx * forward_speed + rx * lateral_speed;
+    p->vz = fz * forward_speed + rz * lateral_speed;
+
+    float travel_yaw = p->buggy_body_yaw;
+    if (planar_speed > 0.01f) {
+        travel_yaw = norm_yaw_deg(atan2f(p->vx, -p->vz) * 57.29578f);
+    }
+    float realign_scale = (1.0f - fabsf(p->buggy_steer)) * shankpit_buggy_clampf(planar_speed / (BUGGY_MAX_SPEED * 0.75f), 0.0f, 1.0f);
+    float yaw_err = angle_diff(travel_yaw, p->buggy_body_yaw);
+    p->buggy_body_yaw = norm_yaw_deg(p->buggy_body_yaw + yaw_err * BUGGY_AUTO_REALIGN * realign_scale);
+
+    p->buggy_forward_speed = forward_speed;
+    p->buggy_lateral_speed = lateral_speed;
+    p->buggy_slip_angle = atan2f(lateral_speed, fabsf(forward_speed) + 0.02f) * 57.29578f;
+    p->buggy_visual_roll = shankpit_buggy_clampf(-(p->buggy_steer * 0.7f + p->buggy_slip_angle * 0.018f), -1.0f, 1.0f) * BUGGY_BODY_ROLL_MAX;
+    p->buggy_visual_pitch = shankpit_buggy_clampf(-(motor_axis * 0.55f + (forward_speed - planar_speed) * 0.35f), -1.0f, 1.0f) * BUGGY_BODY_PITCH_MAX;
+    shankpit_buggy_sync_state(p);
+}
+
 static inline int heli_point_collides(float x, float y, float z) {
     for (int i = 1; i < map_count; i++) {
         Box b = map_geo[i];
@@ -153,9 +229,15 @@ static inline void shankpit_apply_usercmd_inputs(PlayerState *p, const UserCmd *
 
 static inline void shankpit_simulate_movement_tick(PlayerState *p, unsigned int now_ms) {
     if (!p) return;
+    if (p->in_vehicle && p->vehicle_type != VEH_HELICOPTER) {
+        p->vehicle_type = VEH_BUGGY;
+    }
     if (p->in_vehicle && p->vehicle_type == VEH_HELICOPTER) {
         p->vx = p->vy = p->vz = 0.0f;
         return;
+    }
+    if (!p->in_vehicle || p->vehicle_type != VEH_BUGGY) {
+        phys_init_buggy_state(p);
     }
 
     // Net movement contract:
@@ -164,19 +246,22 @@ static inline void shankpit_simulate_movement_tick(PlayerState *p, unsigned int 
     //   server authority and client prediction/replay.
     // - Reconciliation should only correct transport drift, not hide sim mismatches.
 
-    MoveIntent move_intent = {
-        .forward = p->in_fwd,
-        .strafe = p->in_vehicle ? 0.0f : p->in_strafe,
-        .control_yaw_deg = p->yaw,
-        .wants_jump = p->in_jump,
-        .wants_sprint = 0
-    };
-    MoveWish move_wish = shankpit_move_wish_from_intent(move_intent);
-
-    float max_spd = p->in_vehicle ? BUGGY_MAX_SPEED : MAX_SPEED;
-    float acc = p->in_vehicle ? BUGGY_ACCEL : ACCEL;
-    float wish_speed = move_wish.magnitude * max_spd;
-    accelerate(p, move_wish.dir_x, move_wish.dir_z, wish_speed, acc);
+    if (p->in_vehicle && p->vehicle_type == VEH_BUGGY) {
+        shankpit_buggy_simulate(p);
+    } else {
+        MoveIntent move_intent = {
+            .forward = p->in_fwd,
+            .strafe = p->in_vehicle ? 0.0f : p->in_strafe,
+            .control_yaw_deg = p->yaw,
+            .wants_jump = p->in_jump,
+            .wants_sprint = 0
+        };
+        MoveWish move_wish = shankpit_move_wish_from_intent(move_intent);
+        float max_spd = p->in_vehicle ? BUGGY_MAX_SPEED : MAX_SPEED;
+        float acc = p->in_vehicle ? BUGGY_ACCEL : ACCEL;
+        float wish_speed = move_wish.magnitude * max_spd;
+        accelerate(p, move_wish.dir_x, move_wish.dir_z, wish_speed, acc);
+    }
 
     float g = p->in_vehicle ? BUGGY_GRAVITY : (p->in_jump ? GRAVITY_FLOAT : GRAVITY_DROP);
     p->vy -= g;

--- a/packages/common/physics.h
+++ b/packages/common/physics.h
@@ -22,6 +22,21 @@
 #define BUGGY_ACCEL 0.08f       
 #define BUGGY_FRICTION 0.03f    
 #define BUGGY_GRAVITY 0.15f     
+#define BUGGY_MIN_STEER_SPEED 0.12f
+#define BUGGY_STEER_STRENGTH 175.0f
+#define BUGGY_MAX_YAW_RATE_LOW 3.8f
+#define BUGGY_MAX_YAW_RATE_HIGH 7.4f
+#define BUGGY_YAW_RATE_RESPONSE 0.18f
+#define BUGGY_YAW_DAMPING 0.08f
+#define BUGGY_AUTO_REALIGN 0.055f
+#define BUGGY_GRIP_LOW_SPEED 0.42f
+#define BUGGY_GRIP_HIGH_SPEED 0.11f
+#define BUGGY_DRIFT_MULTIPLIER 0.72f
+#define BUGGY_LONGITUDINAL_DRAG 0.018f
+#define BUGGY_LATERAL_DRAG 0.055f
+#define BUGGY_BODY_ROLL_MAX 9.5f
+#define BUGGY_BODY_PITCH_MAX 5.5f
+#define BUGGY_WHEEL_STEER_MAX 30.0f
 
 #define EYE_HEIGHT 2.59f    
 #define PLAYER_WIDTH 0.97f  
@@ -47,6 +62,21 @@
 void evolve_bot(PlayerState *loser, PlayerState *winner);
 PlayerState* get_best_bot();
 void phys_respawn(PlayerState *p, unsigned int now);
+
+static inline void phys_init_buggy_state(PlayerState *p) {
+    if (!p) return;
+    float yaw = p->yaw;
+    while (yaw >= 360.0f) yaw -= 360.0f;
+    while (yaw < 0.0f) yaw += 360.0f;
+    p->buggy_body_yaw = yaw;
+    p->buggy_yaw_rate = 0.0f;
+    p->buggy_steer = 0.0f;
+    p->buggy_forward_speed = 0.0f;
+    p->buggy_lateral_speed = 0.0f;
+    p->buggy_slip_angle = 0.0f;
+    p->buggy_visual_roll = 0.0f;
+    p->buggy_visual_pitch = 0.0f;
+}
 
 typedef struct { float x, y, z, w, h, d; } Box;
 typedef struct { float x, y; } Vec2;
@@ -1403,7 +1433,27 @@ void apply_friction(PlayerState *p) {
     if (speed < 0.001f) { p->vx = 0; p->vz = 0; return; }
     
     float drop = 0;
-    if (p->in_vehicle) {
+    if (p->in_vehicle && p->vehicle_type == VEH_BUGGY) {
+        float yaw_rad = -p->buggy_body_yaw * 0.0174533f;
+        float fx = sinf(yaw_rad), fz = -cosf(yaw_rad);
+        float rx = cosf(yaw_rad), rz = sinf(yaw_rad);
+        float forward_speed = p->vx * fx + p->vz * fz;
+        float lateral_speed = p->vx * rx + p->vz * rz;
+        float speed_ratio = speed / BUGGY_MAX_SPEED;
+        if (speed_ratio < 0.0f) speed_ratio = 0.0f;
+        if (speed_ratio > 1.0f) speed_ratio = 1.0f;
+        float side_grip = BUGGY_GRIP_LOW_SPEED + (BUGGY_GRIP_HIGH_SPEED - BUGGY_GRIP_LOW_SPEED) * speed_ratio;
+        float drift_relief = 1.0f - fabsf(p->buggy_steer) * speed_ratio * BUGGY_DRIFT_MULTIPLIER;
+        if (drift_relief < 0.1f) drift_relief = 0.1f;
+        lateral_speed *= (1.0f - side_grip * drift_relief);
+        forward_speed *= (1.0f - BUGGY_FRICTION);
+        p->vx = fx * forward_speed + rx * lateral_speed;
+        p->vz = fz * forward_speed + rz * lateral_speed;
+        p->buggy_forward_speed = forward_speed;
+        p->buggy_lateral_speed = lateral_speed;
+        p->buggy_slip_angle = atan2f(lateral_speed, fabsf(forward_speed) + 0.01f) * 57.29578f;
+        return;
+    } else if (p->in_vehicle) {
         drop = speed * BUGGY_FRICTION;
     } 
     else if (p->on_ground) {
@@ -1488,6 +1538,7 @@ void resolve_collision(PlayerState *p) {
 void phys_respawn(PlayerState *p, unsigned int now) {
     p->active = 1; p->state = STATE_ALIVE;
     p->health = 100; p->shield = 100; p->respawn_time = 0; p->in_vehicle = 0;
+    phys_init_buggy_state(p);
     p->katana_slash_timer = 0;
     p->dash_timer = 0;
     p->dash_vx = p->dash_vy = p->dash_vz = 0.0f;

--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -98,6 +98,10 @@ typedef struct {
     unsigned char scene_id;
     unsigned int last_seq;
     float x, y, z; float yaw, pitch;
+    float buggy_body_yaw;
+    float buggy_yaw_rate;
+    float buggy_steer;
+    float buggy_slip_angle;
     unsigned char current_weapon;
     unsigned char state;
     unsigned char health;
@@ -161,6 +165,14 @@ typedef struct {
     int vehicle_cooldown;
     unsigned int portal_cooldown_until_ms;
     float accumulated_reward; 
+    float buggy_body_yaw;
+    float buggy_yaw_rate;
+    float buggy_steer;
+    float buggy_forward_speed;
+    float buggy_lateral_speed;
+    float buggy_slip_angle;
+    float buggy_visual_roll;
+    float buggy_visual_pitch;
     BotGenome brain;
     unsigned int last_hit_time;
     unsigned int respawn_time;


### PR DESCRIPTION
### Motivation
- Replace the old “model snaps to `p->yaw`” behavior with a lightweight arcade steering/drift model so the buggy feels heavy, drifty and visually readable while keeping server authority and client prediction parity.
- Separate visual body orientation from movement direction and steering intent to allow yaw-rate integration, lateral momentum and progressive realign without hard snaps.
- Provide easy tuning knobs and minimal debug output to iterate on feel without a larger refactor.

### Description
- Added explicit buggy state to `PlayerState` and `NetPlayer` (fields like `buggy_body_yaw`, `buggy_yaw_rate`, `buggy_steer`, `buggy_forward_speed`, `buggy_lateral_speed`, `buggy_slip_angle`, `buggy_visual_roll`, `buggy_visual_pitch`) and an initializer `phys_init_buggy_state` in `packages/common/physics.h` to keep visual and sim state separate.
- Introduced a shared arcade buggy simulation pipeline in `packages/common/net_sim.h` (`shankpit_buggy_simulate`): convert steer input -> target yaw rate, smooth/damp yaw rate, integrate `buggy_body_yaw`, compute forward/right axes, decompose velocity, apply forward accel, speed-dependent lateral grip, induced slip, drag, and progressive realignment to travel direction; and call it from `shankpit_simulate_movement_tick` when `VEH_BUGGY` is active.
- Extended tuning constants in `packages/common/physics.h` (steer strength, min steer speed, yaw rate caps, yaw response/damping, auto-realign, grip low/high, drift multiplier, longitudinal/lateral drag, visual roll/pitch limits, wheel steer max) and used them in the simulation and rendering.
- Adjusted friction logic so buggy lateral momentum decays via grip model instead of instant annihilation (`apply_friction` now handles `VEH_BUGGY` differently).
- Network parity: server snapshot packing added buggy fields and client snapshot handling (spawn sync, interpolation, local reconciliation) consumes them so server remains authoritative and remote vehicles render smoothly and consistently.
- Rendering/UI: `draw_player_3rd()` now uses `buggy_body_yaw` and applies `buggy_visual_roll`/`buggy_visual_pitch`; `draw_buggy_model()` shows front wheel steer visually; HUD debug line added showing `FWD/LAT/SLIP/YAWR/STR` to iterate quickly.
- Files touched include `packages/common/net_sim.h`, `packages/common/physics.h`, `packages/common/protocol.h`, `apps/server/src/main.c`, and `apps/lobby/src/main.c`.

### Testing
- Built server-only binary: `gcc -O2 -Wall -D_REENTRANT -Ipackages/common -Ipackages/simulation -Ipackages/render -Ipackages/world apps/server/src/main.c packages/world/terrain.c -o /tmp/shank_server_test -lm` — succeeded (server compile passed).
- Full `make -j2` run failed for the lobby/client target because this environment lacks SDL2 headers (`SDL2/SDL.h`, `SDL2/SDL_opengl.h`), so client build could not be validated here.
- No runtime integration tests were executed in this environment; server compile success indicates the shared sim and server snapshot changes are syntactically integrated, but visual tuning and playfeel should be validated in-game (requires SDL2 client build and playtesting).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2fc1b6f88327a7ee6db5217e091b)