### PR TITLE
Add sticky grenades, world pickups, and Poo Poo Island scene

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -525,6 +525,8 @@ static void lobby_apply_scene_id(const char *scene_id) {
         scene_load(SCENE_VOXWORLD);
     } else if (strcmp(scene_id, "OIL_TANKER") == 0) {
         scene_load(SCENE_OIL_TANKER);
+    } else if (strcmp(scene_id, "POO_POO_ISLAND") == 0) {
+        scene_load(SCENE_POO_POO_ISLAND);
     }
 }
 
@@ -965,6 +967,21 @@ void draw_terrain() {
         const VoxRouteAnchor *routes = dust_get_route_anchors(&route_count);
         glColor3f(0.4f, 0.85f, 1.0f);
         for (int i = 0; i < route_count; i++) glVertex3f(routes[i].x, terrain_sample_height(t, routes[i].x, routes[i].z) + 2.0f, routes[i].z);
+        glEnd();
+    }
+    if (voxworld_points_debug && local_state.scene_id == SCENE_POO_POO_ISLAND) {
+        int count = 0;
+        const VoxRouteAnchor *anchors = poo_poo_island_get_landmark_anchors(&count);
+        glPointSize(10.0f);
+        glBegin(GL_POINTS);
+        glColor3f(0.2f, 1.0f, 0.9f);
+        for (int i = 0; i < count; i++) glVertex3f(anchors[i].x, terrain_sample_height(t, anchors[i].x, anchors[i].z) + 2.0f, anchors[i].z);
+        glColor3f(1.0f, 0.6f, 0.25f);
+        for (int i = 0; i < MAX_WORLD_PICKUPS; i++) {
+            WorldPickup *wp = &local_state.world_pickups[i];
+            if (!wp->active || wp->scene_id != SCENE_POO_POO_ISLAND) continue;
+            glVertex3f(wp->x, wp->y + 1.5f, wp->z);
+        }
         glEnd();
     }
 }
@@ -1761,6 +1778,20 @@ void draw_hud(PlayerState *p) {
     glRectf(x0, y_health0, x0 + (p->health * (x1 - x0) / 100.0f), y_health1);
     glColor3f(0.10f, 0.12f, 0.20f); glRectf(x0, y_shield0, x1, y_shield1); glColor3f(0.34f, 0.52f, 0.86f);
     glRectf(x0, y_shield0, x0 + (p->shield * (x1 - x0) / 100.0f), y_shield1);
+    int sticky_count = p->sticky_grenades;
+    if (sticky_count < 0) sticky_count = 0;
+    if (sticky_count > 8) sticky_count = 8;
+    glColor3f(0.20f, 0.98f, 1.0f);
+    for (int i = 0; i < sticky_count; i++) {
+        float px = 52.0f + i * 14.0f;
+        float py = 112.0f;
+        glBegin(GL_QUADS);
+        glVertex2f(px, py); glVertex2f(px + 9.0f, py);
+        glVertex2f(px + 9.0f, py + 9.0f); glVertex2f(px, py + 9.0f);
+        glEnd();
+    }
+    glColor3f(0.70f, 0.45f, 0.95f);
+    draw_string("STICKY", 52, 124, 4);
     
     if (p->in_vehicle) {
         glColor3f(0.0f, 1.0f, 0.0f);
@@ -1822,6 +1853,7 @@ static const char *scene_name_ui(int scene_id) {
         case SCENE_VOXWORLD: return "VOXWORLD";
         case SCENE_DUST_COMPOUND: return "DUST_COMPOUND";
         case SCENE_OIL_TANKER: return "OIL_TANKER";
+        case SCENE_POO_POO_ISLAND: return "POO_POO_ISLAND";
         default: return "UNKNOWN";
     }
 }
@@ -1966,6 +1998,18 @@ static void draw_garage_portal_frame() {
         glVertex3f(-GARAGE_DUST_PORTAL_RADIUS, 6.0f, 0.0f);
         glEnd();
         glPopMatrix();
+
+        glPushMatrix();
+        glTranslatef(GARAGE_POO_PORTAL_X, GARAGE_POO_PORTAL_Y, GARAGE_POO_PORTAL_Z);
+        glColor3f(0.22f, 1.0f, 0.92f);
+        glLineWidth(3.0f);
+        glBegin(GL_LINE_LOOP);
+        glVertex3f(-GARAGE_POO_PORTAL_RADIUS, -2.0f, 0.0f);
+        glVertex3f(GARAGE_POO_PORTAL_RADIUS, -2.0f, 0.0f);
+        glVertex3f(GARAGE_POO_PORTAL_RADIUS, 6.0f, 0.0f);
+        glVertex3f(-GARAGE_POO_PORTAL_RADIUS, 6.0f, 0.0f);
+        glEnd();
+        glPopMatrix();
     }
 }
 
@@ -2001,6 +2045,7 @@ static void draw_garage_overlay(PlayerState *p) {
     draw_string("PORTAL -> STADIUM", 40, 640, 6);
     draw_string("PORTAL -> VOXWORLD TERRAIN", 40, 620, 6);
     draw_string("PORTAL -> OIL TANKER", 40, 600, 6);
+    draw_string("PORTAL -> POO POO ISLAND", 40, 580, 6);
 
     int pad_count = 0;
     const VehiclePad *pads = scene_vehicle_pads(local_state.scene_id, &pad_count);
@@ -2030,6 +2075,7 @@ static void draw_garage_overlay(PlayerState *p) {
     int vox_portal_target = target_in_view(p, GARAGE_VOX_PORTAL_X, GARAGE_VOX_PORTAL_Y, GARAGE_VOX_PORTAL_Z, 30.0f, 0.75f);
     int tanker_portal_target = target_in_view(p, GARAGE_TANKER_PORTAL_X, GARAGE_TANKER_PORTAL_Y, GARAGE_TANKER_PORTAL_Z, 30.0f, 0.75f);
     int dust_portal_target = target_in_view(p, GARAGE_DUST_PORTAL_X, GARAGE_DUST_PORTAL_Y, GARAGE_DUST_PORTAL_Z, 30.0f, 0.75f);
+    int poo_portal_target = target_in_view(p, GARAGE_POO_PORTAL_X, GARAGE_POO_PORTAL_Y, GARAGE_POO_PORTAL_Z, 30.0f, 0.75f);
     int pad_target = 0;
     int heli_target = 0;
     if (scene_near_vehicle_pad(local_state.scene_id, p->x, p->z, 12.0f, NULL)) {
@@ -2051,7 +2097,7 @@ static void draw_garage_overlay(PlayerState *p) {
     }
 
     glColor3f(1.0f, 1.0f, 0.0f);
-    if (portal_target || vox_portal_target || tanker_portal_target || dust_portal_target) {
+    if (portal_target || vox_portal_target || tanker_portal_target || dust_portal_target || poo_portal_target) {
         draw_string("TRAVEL", 600, 350, 8);
     } else if (heli_target || (p->in_vehicle && p->vehicle_type == VEH_HELICOPTER)) {
         draw_string(p->in_vehicle ? "PRESS F TO EXIT HELICOPTER" : "PRESS F TO ENTER HELICOPTER", 460, 350, 8);
@@ -2077,6 +2123,28 @@ void draw_projectiles() {
         glVertex3f(p->x, p->y, p->z);
     }
     glEnd();
+
+    glPointSize(8.0f);
+    glBegin(GL_POINTS);
+    for (int i = 0; i < MAX_STICKY_GRENADES; i++) {
+        StickyGrenadeState *g = &local_state.sticky_grenades[i];
+        if (!g->active || g->scene_id != local_state.scene_id) continue;
+        float pulse = 0.55f + 0.45f * sinf((float)g->fuse_ticks * 0.2f);
+        glColor3f(0.18f + 0.4f * pulse, 0.95f, 1.0f);
+        glVertex3f(g->x, g->y, g->z);
+    }
+    glEnd();
+
+    glPointSize(10.0f);
+    glBegin(GL_POINTS);
+    for (int i = 0; i < MAX_WORLD_PICKUPS; i++) {
+        WorldPickup *wp = &local_state.world_pickups[i];
+        if (!wp->active || !wp->available || wp->scene_id != local_state.scene_id) continue;
+        if (wp->type == PICKUP_STICKY_GRENADE) glColor3f(0.25f, 0.98f, 1.0f);
+        else glColor3f(0.2f, 1.0f, 0.25f);
+        glVertex3f(wp->x, wp->y + 1.0f + 0.35f * sinf((float)SDL_GetTicks() * 0.006f + i), wp->z);
+    }
+    glEnd();
 }
 
 static void client_apply_scene_id(int scene_id, unsigned int now_ms) {
@@ -2092,6 +2160,8 @@ static void client_apply_scene_id(int scene_id, unsigned int now_ms) {
             local_state.helicopters[i].active = 0;
             local_state.helicopters[i].occupant_player_id = -1;
         }
+        for (int i = 0; i < MAX_STICKY_GRENADES; i++) local_state.sticky_grenades[i].active = 0;
+        for (int i = 0; i < MAX_WORLD_PICKUPS; i++) local_state.world_pickups[i].active = 0;
     }
 }
 
@@ -2365,7 +2435,7 @@ void net_connect() {
     }
 }
 
-UserCmd client_create_cmd(float fwd, float str, float yaw, float pitch, int shoot, int jump, int crouch, int reload, int use, int ability, int wpn_idx) {
+UserCmd client_create_cmd(float fwd, float str, float yaw, float pitch, int shoot, int jump, int crouch, int reload, int use, int ability, int grenade, int wpn_idx) {
     UserCmd cmd;
     memset(&cmd, 0, sizeof(UserCmd));
     cmd.sequence = ++net_cmd_seq; cmd.timestamp = SDL_GetTicks();
@@ -2376,6 +2446,7 @@ UserCmd client_create_cmd(float fwd, float str, float yaw, float pitch, int shoo
     if(reload) cmd.buttons |= BTN_RELOAD;
     if(use) cmd.buttons |= BTN_USE;
     if(ability) cmd.buttons |= BTN_ABILITY_1;
+    if(grenade) cmd.buttons |= BTN_GRENADE;
     client_cmd_hist[cmd.sequence % CLIENT_RECON_HISTORY] = cmd;
     net_latest_seq_sent = cmd.sequence;
     cmd.weapon_idx = wpn_idx; return cmd;
@@ -2697,6 +2768,7 @@ void net_process_snapshot(char *buffer, int len) {
         p->is_shooting = now_shooting;
         p->in_vehicle = np->in_vehicle;
         p->storm_charges = np->storm_charges;
+        p->sticky_grenades = (int)np->sticky_grenades;
         p->hit_feedback = np->hit_feedback;
         p->kills = (int)np->kills;
         p->deaths = (int)np->deaths;
@@ -2770,6 +2842,8 @@ void net_process_snapshot(char *buffer, int len) {
         local_state.helicopters[hi].active = 0;
         local_state.helicopters[hi].occupant_player_id = -1;
     }
+    for (int gi = 0; gi < MAX_STICKY_GRENADES; gi++) local_state.sticky_grenades[gi].active = 0;
+    for (int wi = 0; wi < MAX_WORLD_PICKUPS; wi++) local_state.world_pickups[wi].active = 0;
     unsigned char heli_count = 0;
     if (cursor < len) {
         heli_count = *(unsigned char *)(buffer + cursor);
@@ -2809,6 +2883,49 @@ void net_process_snapshot(char *buffer, int len) {
         if (!p->active) continue;
         if (!p->in_vehicle) p->vehicle_type = VEH_NONE;
         else if (p->vehicle_type != VEH_HELICOPTER) p->vehicle_type = VEH_BUGGY;
+    }
+    unsigned char sticky_count = 0;
+    if (cursor < len) {
+        sticky_count = *(unsigned char *)(buffer + cursor);
+        cursor++;
+        for (int gi = 0; gi < sticky_count; gi++) {
+            if (cursor + (int)sizeof(NetStickyGrenade) > len) break;
+            NetStickyGrenade *ng = (NetStickyGrenade *)(buffer + cursor);
+            cursor += (int)sizeof(NetStickyGrenade);
+            if (ng->id >= MAX_STICKY_GRENADES) continue;
+            StickyGrenadeState *g = &local_state.sticky_grenades[ng->id];
+            g->active = ng->active;
+            g->id = ng->id;
+            g->scene_id = ng->scene_id;
+            g->attached = ng->attached;
+            g->attach_type = ng->attach_type;
+            g->attach_target_id = ng->attach_target_id;
+            g->exploded = ng->exploded;
+            g->owner_player_id = ng->owner_player_id;
+            g->x = ng->x; g->y = ng->y; g->z = ng->z;
+            g->normal_x = ng->nx; g->normal_y = ng->ny; g->normal_z = ng->nz;
+            g->fuse_ticks = ng->fuse_ticks;
+        }
+    }
+    unsigned char pickup_count = 0;
+    if (cursor < len) {
+        pickup_count = *(unsigned char *)(buffer + cursor);
+        cursor++;
+        for (int wi = 0; wi < pickup_count; wi++) {
+            if (cursor + (int)sizeof(NetWorldPickup) > len) break;
+            NetWorldPickup *nw = (NetWorldPickup *)(buffer + cursor);
+            cursor += (int)sizeof(NetWorldPickup);
+            if (nw->id >= MAX_WORLD_PICKUPS) continue;
+            WorldPickup *wp = &local_state.world_pickups[nw->id];
+            wp->active = nw->active;
+            wp->id = nw->id;
+            wp->scene_id = nw->scene_id;
+            wp->available = nw->available;
+            wp->type = nw->type;
+            wp->dropped_by_player_id = nw->dropped_by_player_id;
+            wp->x = nw->x; wp->y = nw->y; wp->z = nw->z;
+            wp->radius = nw->radius;
+        }
     }
 
     int render_id = (my_client_id > 0 && my_client_id < MAX_CLIENTS && local_state.players[my_client_id].active)
@@ -3156,6 +3273,7 @@ int main(int argc, char* argv[]) {
             int reload = in_heli ? k[SDL_SCANCODE_Q] : k[SDL_SCANCODE_R];
             int use = k[SDL_SCANCODE_F];
             int ability = in_heli ? k[SDL_SCANCODE_E] : k[SDL_SCANCODE_E];
+            int grenade = k[SDL_SCANCODE_G];
             if(k[SDL_SCANCODE_1]) wpn_req=0; if(k[SDL_SCANCODE_2]) wpn_req=1;
             if(k[SDL_SCANCODE_3]) wpn_req=2; if(k[SDL_SCANCODE_4]) wpn_req=3; if(k[SDL_SCANCODE_5]) wpn_req=4; if(k[SDL_SCANCODE_6]) wpn_req=5;
 
@@ -3172,7 +3290,7 @@ int main(int argc, char* argv[]) {
                 if (net_local_pid > 0 && net_have_initial_local_snapshot_sync) {
                     unsigned int now_ms = SDL_GetTicks();
                     if (now_ms - net_last_cmd_send_ms >= CLIENT_USERCMD_INTERVAL_MS) {
-                        UserCmd cmd = client_create_cmd(fwd, str, cam_yaw, cam_pitch, shoot, jump, crouch, reload, use, ability, wpn_req);
+                        UserCmd cmd = client_create_cmd(fwd, str, cam_yaw, cam_pitch, shoot, jump, crouch, reload, use, ability, grenade, wpn_req);
                         client_apply_cmd_movement(&local_state.players[net_local_pid], &cmd, now_ms);
                         net_send_cmd(cmd);
                         net_last_cmd_send_ms = now_ms;
@@ -3183,6 +3301,7 @@ int main(int argc, char* argv[]) {
                 net_apply_remote_interpolation(SDL_GetTicks());
             } else {
                 local_state.players[0].in_use = use;
+                local_state.players[0].in_grenade = grenade;
                 if (use && local_state.players[0].vehicle_cooldown == 0 && local_state.transition_timer == 0) {
                     PlayerState *p0 = &local_state.players[0];
                     HelicopterState *near_h = NULL;

--- a/apps/server/src/main.c
+++ b/apps/server/src/main.c
@@ -486,6 +486,7 @@ void server_broadcast() {
             np.in_vehicle = (unsigned char)p->in_vehicle;
             np.hit_feedback = (unsigned char)p->hit_feedback;
             np.storm_charges = (unsigned char)p->storm_charges;
+            np.sticky_grenades = (unsigned char)(p->sticky_grenades < 0 ? 0 : p->sticky_grenades);
             np.kills = (unsigned short)(p->kills < 0 ? 0 : p->kills);
             np.deaths = (unsigned short)(p->deaths < 0 ? 0 : p->deaths);
             p->accumulated_reward = 0;
@@ -521,6 +522,57 @@ void server_broadcast() {
             nh.health = (unsigned char)(h->health < 0 ? 0 : (h->health > 255 ? 255 : h->health));
             nh.occupant_player_id = (signed char)h->occupant_player_id;
             memcpy(buffer + cursor, &nh, sizeof(NetHelicopter)); cursor += (int)sizeof(NetHelicopter);
+        }
+        unsigned char sticky_count = 0;
+        for (int gi = 0; gi < MAX_STICKY_GRENADES; gi++) {
+            StickyGrenadeState *g = &local_state.sticky_grenades[gi];
+            if (!g->active || g->scene_id != recipient_scene) continue;
+            sticky_count++;
+        }
+        if (cursor + 1 > (int)sizeof(buffer)) continue;
+        memcpy(buffer + cursor, &sticky_count, 1); cursor += 1;
+        for (int gi = 0; gi < MAX_STICKY_GRENADES; gi++) {
+            StickyGrenadeState *g = &local_state.sticky_grenades[gi];
+            if (!g->active || g->scene_id != recipient_scene) continue;
+            if (cursor + (int)sizeof(NetStickyGrenade) > (int)sizeof(buffer)) break;
+            NetStickyGrenade ng;
+            memset(&ng, 0, sizeof(ng));
+            ng.id = (unsigned char)g->id;
+            ng.scene_id = (unsigned char)g->scene_id;
+            ng.active = (unsigned char)g->active;
+            ng.attached = (unsigned char)g->attached;
+            ng.attach_type = g->attach_type;
+            ng.attach_target_id = (signed char)g->attach_target_id;
+            ng.exploded = (unsigned char)g->exploded;
+            ng.owner_player_id = (signed char)g->owner_player_id;
+            ng.x = g->x; ng.y = g->y; ng.z = g->z;
+            ng.nx = g->normal_x; ng.ny = g->normal_y; ng.nz = g->normal_z;
+            ng.fuse_ticks = (unsigned short)(g->fuse_ticks < 0 ? 0 : g->fuse_ticks);
+            memcpy(buffer + cursor, &ng, sizeof(NetStickyGrenade)); cursor += (int)sizeof(NetStickyGrenade);
+        }
+        unsigned char pickup_count = 0;
+        for (int wi = 0; wi < MAX_WORLD_PICKUPS; wi++) {
+            WorldPickup *wp = &local_state.world_pickups[wi];
+            if (!wp->active || wp->scene_id != recipient_scene) continue;
+            pickup_count++;
+        }
+        if (cursor + 1 > (int)sizeof(buffer)) continue;
+        memcpy(buffer + cursor, &pickup_count, 1); cursor += 1;
+        for (int wi = 0; wi < MAX_WORLD_PICKUPS; wi++) {
+            WorldPickup *wp = &local_state.world_pickups[wi];
+            if (!wp->active || wp->scene_id != recipient_scene) continue;
+            if (cursor + (int)sizeof(NetWorldPickup) > (int)sizeof(buffer)) break;
+            NetWorldPickup nw;
+            memset(&nw, 0, sizeof(nw));
+            nw.id = (unsigned char)wp->id;
+            nw.scene_id = (unsigned char)wp->scene_id;
+            nw.active = (unsigned char)wp->active;
+            nw.available = (unsigned char)wp->available;
+            nw.type = wp->type;
+            nw.dropped_by_player_id = (signed char)wp->dropped_by_player_id;
+            nw.x = wp->x; nw.y = wp->y; nw.z = wp->z;
+            nw.radius = wp->radius;
+            memcpy(buffer + cursor, &nw, sizeof(NetWorldPickup)); cursor += (int)sizeof(NetWorldPickup);
         }
 #if HELI_NET_DEBUG
         printf("[HELI SNAPSHOT][TX] client=%d scene=%d heli_count=%u players=%u\n", i, recipient_scene, heli_count, count);

--- a/packages/common/net_sim.h
+++ b/packages/common/net_sim.h
@@ -145,6 +145,7 @@ static inline void shankpit_apply_usercmd_inputs(PlayerState *p, const UserCmd *
     p->in_use = (cmd->buttons & BTN_USE) != 0;
     p->in_ability = (cmd->buttons & BTN_ABILITY_1) != 0;
     p->in_bike = (cmd->buttons & BTN_VEHICLE_2) != 0;
+    p->in_grenade = (cmd->buttons & BTN_GRENADE) != 0;
 
     if (cmd->weapon_idx >= 0 && cmd->weapon_idx < MAX_WEAPONS) {
         p->current_weapon = cmd->weapon_idx;

--- a/packages/common/physics.h
+++ b/packages/common/physics.h
@@ -121,6 +121,9 @@ static int map_geo_dust_init = 0;
 static Box map_geo_tanker[CITY_MAX_BOXES];
 static int map_geo_tanker_count = 0;
 static int map_geo_tanker_init = 0;
+static Box map_geo_poo_island[CITY_MAX_BOXES];
+static int map_geo_poo_island_count = 0;
+static int map_geo_poo_island_init = 0;
 
 static const Box *map_geo = map_geo_stadium;
 static int map_count = 0;
@@ -179,6 +182,9 @@ static int map_count = 0;
 #define TANKER_KILL_Y -70.0f
 #define TANKER_BOUNDS_X 360.0f
 #define TANKER_BOUNDS_Z 240.0f
+#define POO_POO_KILL_Y -140.0f
+#define POO_POO_BOUNDS_X 860.0f
+#define POO_POO_BOUNDS_Z 860.0f
 
 #define GARAGE_PORTAL_X 0.0f
 #define GARAGE_PORTAL_Y 6.0f
@@ -196,6 +202,10 @@ static int map_count = 0;
 #define GARAGE_TANKER_PORTAL_Y 6.0f
 #define GARAGE_TANKER_PORTAL_Z 0.0f
 #define GARAGE_TANKER_PORTAL_RADIUS 6.0f
+#define GARAGE_POO_PORTAL_X 48.0f
+#define GARAGE_POO_PORTAL_Y 6.0f
+#define GARAGE_POO_PORTAL_Z -32.0f
+#define GARAGE_POO_PORTAL_RADIUS 6.5f
 #define STADIUM_PORTAL_X 0.0f
 #define STADIUM_PORTAL_Y 2.0f
 #define STADIUM_PORTAL_Z 0.0f
@@ -219,6 +229,10 @@ static int map_count = 0;
 #define TANKER_PORTAL_Y 6.0f
 #define TANKER_PORTAL_Z 0.0f
 #define TANKER_PORTAL_RADIUS 13.0f
+#define POO_PORTAL_X -740.0f
+#define POO_PORTAL_Y 10.0f
+#define POO_PORTAL_Z -620.0f
+#define POO_PORTAL_RADIUS 15.0f
 #define PORTAL_ID_GARAGE_EXIT 0
 #define PORTAL_ID_STADIUM_TO_VOXWORLD 1
 #define PORTAL_ID_VOXWORLD_TO_STADIUM 2
@@ -227,6 +241,8 @@ static int map_count = 0;
 #define PORTAL_ID_DUST_TO_GARAGE 5
 #define PORTAL_ID_GARAGE_TO_TANKER 6
 #define PORTAL_ID_TANKER_TO_GARAGE 7
+#define PORTAL_ID_GARAGE_TO_POO_POO_ISLAND 8
+#define PORTAL_ID_POO_POO_ISLAND_TO_GARAGE 9
 
 typedef struct {
     float x;
@@ -307,6 +323,10 @@ static const Vec2 tanker_spawn_points_dm[] = {
     {-110.0f, 140.0f}, {-30.0f, -72.0f}, {-20.0f, 82.0f}, {80.0f, -155.0f},
     {90.0f, 155.0f}, {150.0f, -30.0f}, {155.0f, 35.0f}, {220.0f, 0.0f}
 };
+static const Vec2 poo_poo_spawn_points_dm[] = {
+    {-640.0f, -520.0f}, {-500.0f, -600.0f}, {-350.0f, -640.0f}, {-140.0f, -580.0f},
+    {140.0f, -440.0f}, {260.0f, -150.0f}, {220.0f, 160.0f}, {-80.0f, 220.0f}
+};
 static const VoxRouteAnchor dust_route_anchors[] = {
     {DUST_MID_X, DUST_MID_Z, "MID"},
     {DUST_UNDERPASS_X, DUST_UNDERPASS_Z, "UNDERPASS"},
@@ -317,6 +337,15 @@ static const VoxRouteAnchor dust_route_anchors[] = {
 static const VoxRouteAnchor dust_objective_anchors[] = {
     {DUST_A_SITE_X, DUST_A_SITE_Z, "ALPHA"},
     {DUST_B_SITE_X, DUST_B_SITE_Z, "BRAVO"}
+};
+static const VoxRouteAnchor poo_poo_landmark_anchors[] = {
+    {-620.0f, -560.0f, "POO POO TOWN"},
+    {-520.0f, -650.0f, "BEACH"},
+    {-300.0f, -470.0f, "MARINA"},
+    {420.0f, -120.0f, "LIGHTHOUSE"},
+    {-40.0f, -80.0f, "HILLS"},
+    {320.0f, 280.0f, "VOLCANO"},
+    {80.0f, -320.0f, "LOOP BRIDGE"}
 };
 
 #define MAX_VOXWORLD_BUSHES 256
@@ -647,6 +676,44 @@ static inline void init_oil_tanker_geo(void) {
     printf("[OIL_TANKER] authored geo boxes=%d\n", map_geo_tanker_count);
 }
 
+static inline void poo_add_box(float x, float y, float z, float w, float h, float d) {
+    if (map_geo_poo_island_count >= CITY_MAX_BOXES) return;
+    map_geo_poo_island[map_geo_poo_island_count++] = (Box){x, y, z, w, h, d};
+}
+
+static inline float poo_height_at(float x, float z) {
+    if (g_scene_terrain.active && g_scene_terrain.heights) {
+        return terrain_sample_height(&g_scene_terrain, x, z);
+    }
+    return 0.0f;
+}
+
+static inline void init_poo_poo_island_geo(void) {
+    if (map_geo_poo_island_init) return;
+    map_geo_poo_island_init = 1;
+    map_geo_poo_island_count = 0;
+    poo_add_box(0.0f, -15.0f, 0.0f, 1900.0f, 20.0f, 1900.0f);
+    poo_add_box(0.0f, 180.0f, 870.0f, 1900.0f, 350.0f, 10.0f);
+    poo_add_box(0.0f, 180.0f, -870.0f, 1900.0f, 350.0f, 10.0f);
+    poo_add_box(870.0f, 180.0f, 0.0f, 10.0f, 350.0f, 1900.0f);
+    poo_add_box(-870.0f, 180.0f, 0.0f, 10.0f, 350.0f, 1900.0f);
+    // Town blocks
+    poo_add_box(-610.0f, poo_height_at(-610.0f, -560.0f) + 8.0f, -560.0f, 180.0f, 16.0f, 160.0f);
+    poo_add_box(-540.0f, poo_height_at(-540.0f, -500.0f) + 9.0f, -500.0f, 130.0f, 18.0f, 100.0f);
+    poo_add_box(-450.0f, poo_height_at(-450.0f, -560.0f) + 9.0f, -560.0f, 100.0f, 18.0f, 110.0f);
+    // Marina / docks
+    poo_add_box(-330.0f, poo_height_at(-330.0f, -430.0f) + 4.0f, -430.0f, 190.0f, 8.0f, 42.0f);
+    poo_add_box(-250.0f, poo_height_at(-250.0f, -395.0f) + 4.0f, -395.0f, 170.0f, 8.0f, 32.0f);
+    // Lighthouse
+    poo_add_box(430.0f, poo_height_at(430.0f, -120.0f) + 20.0f, -120.0f, 36.0f, 40.0f, 36.0f);
+    // Volcano crown
+    poo_add_box(320.0f, poo_height_at(320.0f, 290.0f) + 20.0f, 290.0f, 130.0f, 20.0f, 120.0f);
+    // Bridges / loop route hints
+    poo_add_box(80.0f, poo_height_at(80.0f, -320.0f) + 6.0f, -320.0f, 180.0f, 8.0f, 30.0f);
+    poo_add_box(240.0f, poo_height_at(240.0f, -240.0f) + 6.0f, -240.0f, 120.0f, 8.0f, 30.0f);
+    printf("[POO_POO_ISLAND] authored geo boxes=%d\n", map_geo_poo_island_count);
+}
+
 static int phys_scene_id = SCENE_STADIUM;
 static TerrainHeightfield g_scene_terrain = {0};
 static int g_last_ground_source_terrain = 0;
@@ -655,6 +722,8 @@ static inline void init_voxworld_bloodgulch_terrain(void);
 static inline void init_dust_compound_terrain(void);
 static inline void init_dust_compound_geo(void);
 static inline void init_oil_tanker_geo(void);
+static inline void init_poo_poo_island_terrain(void);
+static inline void init_poo_poo_island_geo(void);
 static inline void voxworld_build_bushes(void);
 
 static inline float voxworld_bush_hash01(int x, int z, int salt) {
@@ -796,6 +865,12 @@ static inline void phys_set_scene(int scene_id) {
         map_geo = map_geo_tanker;
         map_count = map_geo_tanker_count;
         g_scene_terrain.active = 0;
+    } else if (scene_id == SCENE_POO_POO_ISLAND) {
+        init_poo_poo_island_terrain();
+        init_poo_poo_island_geo();
+        map_geo = map_geo_poo_island;
+        map_count = map_geo_poo_island_count;
+        g_scene_terrain.active = (g_scene_terrain.heights != NULL);
     } else if (scene_id == SCENE_VOXWORLD) {
         init_voxworld_bloodgulch_terrain();
         init_voxworld_bloodgulch_geo();
@@ -938,6 +1013,38 @@ static inline void init_dust_compound_terrain(void) {
     g_scene_terrain_scene_id = SCENE_DUST_COMPOUND;
 }
 
+static inline void init_poo_poo_island_terrain(void) {
+    if (g_scene_terrain_scene_id == SCENE_POO_POO_ISLAND && g_scene_terrain.heights) {
+        g_scene_terrain.active = 1;
+        return;
+    }
+    if (g_scene_terrain.heights) terrain_free(&g_scene_terrain);
+    if (!terrain_init(&g_scene_terrain, 160, 160, 11.0f, -880.0f, -880.0f)) return;
+    terrain_clear(&g_scene_terrain, -2.0f);
+    for (int gz = 0; gz < g_scene_terrain.height; gz++) {
+        for (int gx = 0; gx < g_scene_terrain.width; gx++) {
+            float wx = g_scene_terrain.origin_x + gx * g_scene_terrain.cell_size;
+            float wz = g_scene_terrain.origin_z + gz * g_scene_terrain.cell_size;
+            float dist = sqrtf(wx * wx + wz * wz);
+            float island = 65.0f - (dist * 0.08f);
+            float h = island + 6.0f * sinf(wx * 0.006f) + 5.0f * cosf(wz * 0.0065f);
+            h += 2.0f * sinf((wx + wz) * 0.015f);
+            h += 38.0f * expf(-((wx - 320.0f)*(wx - 320.0f) + (wz - 280.0f)*(wz - 280.0f)) / (2.0f * 150.0f * 150.0f)); // volcano
+            h += 20.0f * expf(-((wx + 620.0f)*(wx + 620.0f) + (wz + 560.0f)*(wz + 560.0f)) / (2.0f * 170.0f * 170.0f)); // town shelf
+            h -= 18.0f * expf(-((wx + 500.0f)*(wx + 500.0f) + (wz + 680.0f)*(wz + 680.0f)) / (2.0f * 180.0f * 140.0f)); // beach
+            if (dist > 760.0f) h -= (dist - 760.0f) * 0.42f;
+            terrain_set_height(&g_scene_terrain, gx, gz, h);
+        }
+    }
+    vox_terrain_stamp(&g_scene_terrain, -620.0f, -560.0f, 220.0f, 22.0f, 1.0f);
+    vox_terrain_stamp(&g_scene_terrain, -520.0f, -650.0f, 240.0f, 5.0f, 0.75f);
+    vox_terrain_stamp(&g_scene_terrain, -280.0f, -440.0f, 150.0f, 8.0f, 0.9f);
+    vox_terrain_stamp(&g_scene_terrain, 420.0f, -120.0f, 110.0f, 44.0f, 1.0f);
+    vox_terrain_stamp(&g_scene_terrain, 320.0f, 280.0f, 200.0f, 78.0f, 0.9f);
+    vox_terrain_smooth(&g_scene_terrain, 2, 0.48f);
+    g_scene_terrain_scene_id = SCENE_POO_POO_ISLAND;
+}
+
 static inline void scene_spawn_point(int scene_id, int slot, float *out_x, float *out_y, float *out_z) {
     if (scene_id == SCENE_GARAGE_OSAKA) {
         float offsets[] = {-20.0f, 0.0f, 20.0f, -10.0f, 10.0f};
@@ -972,6 +1079,14 @@ static inline void scene_spawn_point(int scene_id, int slot, float *out_x, float
         *out_y = 6.0f;
         return;
     }
+    if (scene_id == SCENE_POO_POO_ISLAND) {
+        int count = (int)(sizeof(poo_poo_spawn_points_dm) / sizeof(Vec2));
+        int idx = slot % count;
+        *out_x = poo_poo_spawn_points_dm[idx].x;
+        *out_z = poo_poo_spawn_points_dm[idx].y;
+        *out_y = poo_height_at(*out_x, *out_z) + 6.0f;
+        return;
+    }
     if (slot % 2 == 0) {
         *out_x = 0.0f; *out_z = 0.0f; *out_y = 80.0f;
     } else {
@@ -983,16 +1098,22 @@ static inline void scene_spawn_point(int scene_id, int slot, float *out_x, float
 }
 
 static inline void scene_spawn_for_player(PlayerState *p, float *out_x, float *out_y, float *out_z) {
-    if (p->scene_id != SCENE_VOXWORLD && p->scene_id != SCENE_DUST_COMPOUND && p->scene_id != SCENE_OIL_TANKER) {
+    if (p->scene_id != SCENE_VOXWORLD && p->scene_id != SCENE_DUST_COMPOUND && p->scene_id != SCENE_OIL_TANKER && p->scene_id != SCENE_POO_POO_ISLAND) {
         scene_spawn_point(p->scene_id, p->id, out_x, out_y, out_z);
         return;
     }
-    const Vec2 *pts = (p->scene_id == SCENE_DUST_COMPOUND) ? dust_spawn_points_dm
-                    : (p->scene_id == SCENE_OIL_TANKER ? tanker_spawn_points_dm : voxworld_spawn_points_ffa);
-    int count = (p->scene_id == SCENE_DUST_COMPOUND)
-        ? (int)(sizeof(dust_spawn_points_dm) / sizeof(Vec2))
-        : (p->scene_id == SCENE_OIL_TANKER ? (int)(sizeof(tanker_spawn_points_dm) / sizeof(Vec2))
-                                           : (int)(sizeof(voxworld_spawn_points_ffa) / sizeof(Vec2)));
+    const Vec2 *pts = voxworld_spawn_points_ffa;
+    int count = (int)(sizeof(voxworld_spawn_points_ffa) / sizeof(Vec2));
+    if (p->scene_id == SCENE_DUST_COMPOUND) {
+        pts = dust_spawn_points_dm;
+        count = (int)(sizeof(dust_spawn_points_dm) / sizeof(Vec2));
+    } else if (p->scene_id == SCENE_OIL_TANKER) {
+        pts = tanker_spawn_points_dm;
+        count = (int)(sizeof(tanker_spawn_points_dm) / sizeof(Vec2));
+    } else if (p->scene_id == SCENE_POO_POO_ISLAND) {
+        pts = poo_poo_spawn_points_dm;
+        count = (int)(sizeof(poo_poo_spawn_points_dm) / sizeof(Vec2));
+    }
     int team_mode = (g_phys_game_mode == MODE_TDM || g_phys_game_mode == MODE_CTF);
     int team = p->team_id;
     if (team_mode && (team != 0 && team != 1)) team = (p->id % 2);
@@ -1018,7 +1139,7 @@ static inline void scene_spawn_for_player(PlayerState *p, float *out_x, float *o
     *out_z = pts[idx].y;
     *out_y = (p->scene_id == SCENE_DUST_COMPOUND)
         ? (dust_height_at(*out_x, *out_z) + 5.5f)
-        : (p->scene_id == SCENE_OIL_TANKER ? 6.0f : (voxworld_height_at(*out_x, *out_z) + 6.0f));
+        : (p->scene_id == SCENE_OIL_TANKER ? 6.0f : (p->scene_id == SCENE_POO_POO_ISLAND ? (poo_height_at(*out_x, *out_z) + 6.0f) : (voxworld_height_at(*out_x, *out_z) + 6.0f)));
 }
 
 static inline void scene_force_spawn(PlayerState *p) {
@@ -1072,12 +1193,20 @@ static inline void scene_safety_check(PlayerState *p) {
             p->z < -TANKER_BOUNDS_Z || p->z > TANKER_BOUNDS_Z) {
             scene_force_spawn(p);
         }
+        return;
+    }
+    if (p->scene_id == SCENE_POO_POO_ISLAND) {
+        if (p->y < POO_POO_KILL_Y ||
+            p->x < -POO_POO_BOUNDS_X || p->x > POO_POO_BOUNDS_X ||
+            p->z < -POO_POO_BOUNDS_Z || p->z > POO_POO_BOUNDS_Z) {
+            scene_force_spawn(p);
+        }
     }
 }
 
 static inline int scene_portal_active(int scene_id) {
     return scene_id == SCENE_GARAGE_OSAKA || scene_id == SCENE_STADIUM ||
-           scene_id == SCENE_VOXWORLD || scene_id == SCENE_DUST_COMPOUND || scene_id == SCENE_OIL_TANKER;
+           scene_id == SCENE_VOXWORLD || scene_id == SCENE_DUST_COMPOUND || scene_id == SCENE_OIL_TANKER || scene_id == SCENE_POO_POO_ISLAND;
 }
 
 static inline int portal_resolve_destination(int current_scene, int portal_id, int slot,
@@ -1114,6 +1243,13 @@ static inline int portal_resolve_destination(int current_scene, int portal_id, i
         *out_z = 0.0f;
         return 1;
     }
+    if (current_scene == SCENE_GARAGE_OSAKA && portal_id == PORTAL_ID_GARAGE_TO_POO_POO_ISLAND) {
+        *out_scene = SCENE_POO_POO_ISLAND;
+        *out_x = -620.0f;
+        *out_y = 30.0f;
+        *out_z = -580.0f;
+        return 1;
+    }
     if (current_scene == SCENE_STADIUM && portal_id == PORTAL_ID_STADIUM_TO_VOXWORLD) {
         *out_scene = SCENE_VOXWORLD;
         *out_x = STADIUM_EDGE_TELEPORT_X;
@@ -1140,6 +1276,13 @@ static inline int portal_resolve_destination(int current_scene, int portal_id, i
         *out_x = GARAGE_TANKER_PORTAL_X + 10.0f;
         *out_y = GARAGE_TANKER_PORTAL_Y;
         *out_z = GARAGE_TANKER_PORTAL_Z;
+        return 1;
+    }
+    if (current_scene == SCENE_POO_POO_ISLAND && portal_id == PORTAL_ID_POO_POO_ISLAND_TO_GARAGE) {
+        *out_scene = SCENE_GARAGE_OSAKA;
+        *out_x = GARAGE_POO_PORTAL_X - 8.0f;
+        *out_y = GARAGE_POO_PORTAL_Y;
+        *out_z = GARAGE_POO_PORTAL_Z;
         return 1;
     }
     return 0;
@@ -1171,6 +1314,11 @@ static inline void scene_portal_info(int scene_id, float *out_x, float *out_y, f
         *out_y = TANKER_PORTAL_Y;
         *out_z = TANKER_PORTAL_Z;
         *out_radius = TANKER_PORTAL_RADIUS;
+    } else if (scene_id == SCENE_POO_POO_ISLAND) {
+        *out_x = POO_PORTAL_X;
+        *out_y = POO_PORTAL_Y;
+        *out_z = POO_PORTAL_Z;
+        *out_radius = POO_PORTAL_RADIUS;
     } else {
         *out_x = 0.0f; *out_y = 0.0f; *out_z = 0.0f; *out_radius = 0.0f;
     }
@@ -1225,6 +1373,11 @@ static inline const Vec2 *dust_get_spawn_points_dm(int *out_count) {
     return dust_spawn_points_dm;
 }
 
+static inline const VoxRouteAnchor *poo_poo_island_get_landmark_anchors(int *out_count) {
+    if (out_count) *out_count = (int)(sizeof(poo_poo_landmark_anchors) / sizeof(VoxRouteAnchor));
+    return poo_poo_landmark_anchors;
+}
+
 static inline int scene_portal_triggered(PlayerState *p, int *out_portal_id) {
     if (!scene_portal_active(p->scene_id)) return 0;
 
@@ -1248,6 +1401,13 @@ static inline int scene_portal_triggered(PlayerState *p, int *out_portal_id) {
         float dist_sq_dust = dx_dust * dx_dust + dz_dust * dz_dust;
         if (dist_sq_dust <= (GARAGE_DUST_PORTAL_RADIUS * GARAGE_DUST_PORTAL_RADIUS)) {
             if (out_portal_id) *out_portal_id = PORTAL_ID_GARAGE_TO_DUST;
+            return 1;
+        }
+        float dx_poo = p->x - GARAGE_POO_PORTAL_X;
+        float dz_poo = p->z - GARAGE_POO_PORTAL_Z;
+        float dist_sq_poo = dx_poo * dx_poo + dz_poo * dz_poo;
+        if (dist_sq_poo <= (GARAGE_POO_PORTAL_RADIUS * GARAGE_POO_PORTAL_RADIUS)) {
+            if (out_portal_id) *out_portal_id = PORTAL_ID_GARAGE_TO_POO_POO_ISLAND;
             return 1;
         }
     }
@@ -1281,7 +1441,7 @@ static inline int scene_portal_triggered(PlayerState *p, int *out_portal_id) {
         if (out_portal_id) {
             *out_portal_id = (p->scene_id == SCENE_VOXWORLD)
                 ? PORTAL_ID_VOXWORLD_TO_STADIUM
-                : (p->scene_id == SCENE_DUST_COMPOUND ? PORTAL_ID_DUST_TO_GARAGE : (p->scene_id == SCENE_OIL_TANKER ? PORTAL_ID_TANKER_TO_GARAGE : PORTAL_ID_GARAGE_EXIT));
+                : (p->scene_id == SCENE_DUST_COMPOUND ? PORTAL_ID_DUST_TO_GARAGE : (p->scene_id == SCENE_OIL_TANKER ? PORTAL_ID_TANKER_TO_GARAGE : (p->scene_id == SCENE_POO_POO_ISLAND ? PORTAL_ID_POO_POO_ISLAND_TO_GARAGE : PORTAL_ID_GARAGE_EXIT)));
         }
         return 1;
     }
@@ -1639,13 +1799,16 @@ void phys_respawn(PlayerState *p, unsigned int now) {
     p->dash_hit_count = 0;
     p->use_was_down = 0;
     if (p->scene_id != SCENE_GARAGE_OSAKA && p->scene_id != SCENE_STADIUM &&
-        p->scene_id != SCENE_VOXWORLD && p->scene_id != SCENE_DUST_COMPOUND) {
+        p->scene_id != SCENE_VOXWORLD && p->scene_id != SCENE_DUST_COMPOUND &&
+        p->scene_id != SCENE_OIL_TANKER && p->scene_id != SCENE_POO_POO_ISLAND) {
         p->scene_id = SCENE_GARAGE_OSAKA;
     }
     scene_spawn_for_player(p, &p->x, &p->y, &p->z);
     p->current_weapon = WPN_MAGNUM;
     for(int i=0; i<MAX_WEAPONS; i++) p->ammo[i] = WPN_STATS[i].ammo_max;
     p->storm_charges = 0;
+    p->sticky_grenades = 1;
+    p->sticky_throw_cooldown = 0;
     p->ability_cooldown = 0;
     p->portal_cooldown_until_ms = 0;
     p->stunned_until_ms = 0;

--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -5,6 +5,8 @@
 #define MAX_WEAPONS 6
 #define MAX_PROJECTILES 1024
 #define MAX_HELICOPTERS 8
+#define MAX_STICKY_GRENADES 128
+#define MAX_WORLD_PICKUPS 256
 #define LAG_HISTORY 64
 
 #define SCENE_GARAGE_OSAKA 0
@@ -13,6 +15,7 @@
 #define SCENE_DUST_COMPOUND 3
 #define SCENE_CITY 4
 #define SCENE_OIL_TANKER 5
+#define SCENE_POO_POO_ISLAND 6
 
 #define PACKET_CONNECT 0
 #define PACKET_USERCMD 1
@@ -66,6 +69,7 @@ typedef struct {
 #define BTN_USE    16
 #define BTN_ABILITY_1 32
 #define BTN_VEHICLE_2 64
+#define BTN_GRENADE 128
 
 #define VEH_NONE  0
 #define VEH_BUGGY 1
@@ -109,6 +113,7 @@ typedef struct {
     unsigned char in_vehicle;
     unsigned char hit_feedback; 
     unsigned char storm_charges;
+    unsigned char sticky_grenades;
     unsigned short kills;
     unsigned short deaths;
 } NetPlayer;
@@ -130,6 +135,31 @@ typedef struct {
 } NetHelicopter;
 
 typedef struct {
+    unsigned char id;
+    unsigned char scene_id;
+    unsigned char active;
+    unsigned char attached;
+    unsigned char attach_type;
+    signed char attach_target_id;
+    unsigned char exploded;
+    signed char owner_player_id;
+    float x, y, z;
+    float nx, ny, nz;
+    unsigned short fuse_ticks;
+} NetStickyGrenade;
+
+typedef struct {
+    unsigned char id;
+    unsigned char scene_id;
+    unsigned char active;
+    unsigned char available;
+    unsigned char type;
+    signed char dropped_by_player_id;
+    float x, y, z;
+    float radius;
+} NetWorldPickup;
+
+typedef struct {
     int version;
     float w_aggro;
     float w_strafe; float w_jump; float w_slide; float w_turret; float w_repel;      
@@ -146,6 +176,7 @@ typedef struct {
     int in_jump; int in_shoot; int in_reload; int crouching; int in_use; int in_bike;
     int use_was_down; int bike_was_down;
     int in_ability;
+    int in_grenade;
     int current_weapon; int ammo[MAX_WEAPONS];
     int reload_timer; int attack_cooldown;
     int is_shooting; int jump_timer;
@@ -177,7 +208,52 @@ typedef struct {
     unsigned int stun_immune_until_ms;
     float run_phase;
     float run_weight;
+    int sticky_grenades;
+    int sticky_throw_cooldown;
 } PlayerState;
+
+typedef enum {
+    STICKY_ATTACH_NONE = 0,
+    STICKY_ATTACH_WORLD,
+    STICKY_ATTACH_PLAYER
+} StickyAttachType;
+
+typedef struct {
+    int active;
+    int id;
+    int scene_id;
+    int owner_player_id;
+    float x, y, z;
+    float vx, vy, vz;
+    int attached;
+    unsigned char attach_type;
+    int attach_target_id;
+    float attach_local_x;
+    float attach_local_y;
+    float attach_local_z;
+    float normal_x, normal_y, normal_z;
+    int fuse_ticks;
+    int exploded;
+} StickyGrenadeState;
+
+typedef enum {
+    PICKUP_NONE = 0,
+    PICKUP_HEALTH,
+    PICKUP_STICKY_GRENADE
+} PickupType;
+
+typedef struct {
+    int active;
+    int id;
+    int scene_id;
+    unsigned char type;
+    float x, y, z;
+    float radius;
+    int respawn_ticks;
+    int respawn_delay_ticks;
+    int available;
+    int dropped_by_player_id;
+} WorldPickup;
 
 typedef struct {
     int active; unsigned int timestamp;
@@ -217,6 +293,8 @@ typedef struct {
     PlayerState players[MAX_CLIENTS];
     Projectile projectiles[MAX_PROJECTILES];
     HelicopterState helicopters[MAX_HELICOPTERS];
+    StickyGrenadeState sticky_grenades[MAX_STICKY_GRENADES];
+    WorldPickup world_pickups[MAX_WORLD_PICKUPS];
     LagRecord history[MAX_CLIENTS][LAG_HISTORY];
     int server_tick;
     int game_mode;

--- a/packages/simulation/local_game.h
+++ b/packages/simulation/local_game.h
@@ -9,6 +9,183 @@
 ServerState local_state;
 int was_holding_jump = 0;
 #define SHANKPIT_HELI_DEBUG 0
+#define STICKY_MAX_PER_PLAYER 4
+#define STICKY_FUSE_TICKS 105
+#define STICKY_THROW_COOLDOWN 24
+
+static inline void pickup_spawn(int scene_id, int type, float x, float y, float z, float radius, int respawn_delay_ticks, int dropped_by_player_id) {
+    for (int i = 0; i < MAX_WORLD_PICKUPS; i++) {
+        WorldPickup *p = &local_state.world_pickups[i];
+        if (p->active) continue;
+        memset(p, 0, sizeof(*p));
+        p->active = 1;
+        p->available = 1;
+        p->id = i;
+        p->scene_id = scene_id;
+        p->type = (unsigned char)type;
+        p->x = x; p->y = y; p->z = z;
+        p->radius = radius;
+        p->respawn_delay_ticks = respawn_delay_ticks;
+        p->dropped_by_player_id = dropped_by_player_id;
+        return;
+    }
+}
+
+static inline void poo_poo_island_init_pickups(void) {
+    pickup_spawn(SCENE_POO_POO_ISLAND, PICKUP_STICKY_GRENADE, -560.0f, 20.0f, -560.0f, 5.0f, 600, -1);
+    pickup_spawn(SCENE_POO_POO_ISLAND, PICKUP_STICKY_GRENADE, 90.0f, 18.0f, -330.0f, 5.0f, 600, -1);
+    pickup_spawn(SCENE_POO_POO_ISLAND, PICKUP_STICKY_GRENADE, 250.0f, 45.0f, 210.0f, 5.0f, 600, -1);
+    pickup_spawn(SCENE_POO_POO_ISLAND, PICKUP_HEALTH, -510.0f, 15.0f, -660.0f, 5.0f, 450, -1);
+    pickup_spawn(SCENE_POO_POO_ISLAND, PICKUP_HEALTH, -300.0f, 16.0f, -420.0f, 5.0f, 450, -1);
+    pickup_spawn(SCENE_POO_POO_ISLAND, PICKUP_HEALTH, 420.0f, 52.0f, -120.0f, 5.0f, 450, -1);
+}
+
+static inline void sticky_spawn_from_player(PlayerState *p) {
+    if (!p || p->sticky_grenades <= 0 || p->sticky_throw_cooldown > 0) return;
+    for (int i = 0; i < MAX_STICKY_GRENADES; i++) {
+        StickyGrenadeState *g = &local_state.sticky_grenades[i];
+        if (g->active) continue;
+        memset(g, 0, sizeof(*g));
+        g->active = 1;
+        g->id = i;
+        g->scene_id = p->scene_id;
+        g->owner_player_id = p->id;
+        g->x = p->x;
+        g->y = p->y + EYE_HEIGHT;
+        g->z = p->z;
+        float r = -p->yaw * 0.0174533f, rp = p->pitch * 0.0174533f;
+        float speed = 3.2f;
+        g->vx = sinf(r) * cosf(rp) * speed;
+        g->vy = sinf(rp) * speed + 0.15f;
+        g->vz = -cosf(r) * cosf(rp) * speed;
+        g->fuse_ticks = STICKY_FUSE_TICKS;
+        p->sticky_grenades--;
+        p->sticky_throw_cooldown = STICKY_THROW_COOLDOWN;
+        return;
+    }
+}
+
+static inline void drop_player_inventory_pickups(PlayerState *p) {
+    if (!p || p->sticky_grenades <= 0) return;
+    phys_set_scene(p->scene_id);
+    int src_terrain = 0;
+    float gy = phys_sample_ground_height(p->x, p->z, &src_terrain);
+    pickup_spawn(p->scene_id, PICKUP_STICKY_GRENADE, p->x, gy + 1.0f, p->z, 5.0f, 0, p->id);
+    p->sticky_grenades--;
+}
+
+static inline void sticky_explode(StickyGrenadeState *g) {
+    if (!g || !g->active) return;
+    for (int i = 0; i < MAX_CLIENTS; i++) {
+        PlayerState *t = &local_state.players[i];
+        if (!t->active || t->state == STATE_DEAD || t->scene_id != g->scene_id) continue;
+        float dx = t->x - g->x;
+        float dy = (t->y + 2.0f) - g->y;
+        float dz = t->z - g->z;
+        float d2 = dx * dx + dy * dy + dz * dz;
+        if (d2 > 100.0f) continue;
+        float d = sqrtf(d2);
+        float f = 1.0f - (d / 10.0f);
+        int dmg = (int)(120.0f * f);
+        if (dmg < 1) dmg = 1;
+        t->shield_regen_timer = SHIELD_REGEN_DELAY;
+        if (t->shield > 0) {
+            if (t->shield >= dmg) { t->shield -= dmg; dmg = 0; }
+            else { dmg -= t->shield; t->shield = 0; }
+        }
+        t->health -= dmg;
+        float inv = (d > 0.01f) ? (1.0f / d) : 0.0f;
+        float pop = (g->attach_type == STICKY_ATTACH_PLAYER && g->attach_target_id == i) ? 5.8f : 2.2f;
+        t->vx += dx * inv * pop;
+        t->vz += dz * inv * pop;
+        t->vy += (g->attach_type == STICKY_ATTACH_PLAYER && g->attach_target_id == i) ? 3.8f : 1.2f;
+        if (t->health <= 0) {
+            if (g->owner_player_id >= 0 && g->owner_player_id < MAX_CLIENTS) local_state.players[g->owner_player_id].kills++;
+            t->deaths++;
+            drop_player_inventory_pickups(t);
+            phys_respawn(t, 0);
+        }
+    }
+    g->exploded = 1;
+    g->active = 0;
+}
+
+static inline void sticky_update_all(void) {
+    for (int i = 0; i < MAX_STICKY_GRENADES; i++) {
+        StickyGrenadeState *g = &local_state.sticky_grenades[i];
+        if (!g->active) continue;
+        if (g->fuse_ticks > 0) g->fuse_ticks--;
+        if (g->attached && g->attach_type == STICKY_ATTACH_PLAYER && g->attach_target_id >= 0 && g->attach_target_id < MAX_CLIENTS) {
+            PlayerState *t = &local_state.players[g->attach_target_id];
+            if (t->active && t->state != STATE_DEAD && t->scene_id == g->scene_id) {
+                g->x = t->x + g->attach_local_x;
+                g->y = t->y + g->attach_local_y;
+                g->z = t->z + g->attach_local_z;
+            } else {
+                g->attach_type = STICKY_ATTACH_WORLD;
+            }
+        } else if (!g->attached) {
+            float nx = 0, ny = 0, nz = 0, hx = 0, hy = 0, hz = 0;
+            float nxp = g->x + g->vx, nyp = g->y + g->vy, nzp = g->z + g->vz;
+            if (trace_map(g->x, g->y, g->z, nxp, nyp, nzp, &hx, &hy, &hz, &nx, &ny, &nz)) {
+                g->attached = 1;
+                g->attach_type = STICKY_ATTACH_WORLD;
+                g->x = hx; g->y = hy; g->z = hz;
+                g->normal_x = nx; g->normal_y = ny; g->normal_z = nz;
+                g->vx = g->vy = g->vz = 0.0f;
+            } else {
+                g->x = nxp; g->y = nyp; g->z = nzp;
+                for (int t = 0; t < MAX_CLIENTS; t++) {
+                    PlayerState *pl = &local_state.players[t];
+                    if (!pl->active || pl->state == STATE_DEAD || pl->scene_id != g->scene_id) continue;
+                    if (t == g->owner_player_id) continue;
+                    float dx = pl->x - g->x, dy = (pl->y + 2.0f) - g->y, dz = pl->z - g->z;
+                    if ((dx*dx + dy*dy + dz*dz) < 8.0f) {
+                        g->attached = 1;
+                        g->attach_type = STICKY_ATTACH_PLAYER;
+                        g->attach_target_id = t;
+                        g->attach_local_x = g->x - pl->x;
+                        g->attach_local_y = g->y - pl->y;
+                        g->attach_local_z = g->z - pl->z;
+                        g->vx = g->vy = g->vz = 0.0f;
+                        break;
+                    }
+                }
+            }
+        }
+        if (g->fuse_ticks <= 0) sticky_explode(g);
+    }
+}
+
+static inline void pickup_update_and_collect(void) {
+    for (int i = 0; i < MAX_WORLD_PICKUPS; i++) {
+        WorldPickup *wp = &local_state.world_pickups[i];
+        if (!wp->active) continue;
+        if (!wp->available) {
+            if (wp->respawn_delay_ticks > 0 && ++wp->respawn_ticks >= wp->respawn_delay_ticks) {
+                wp->respawn_ticks = 0;
+                wp->available = 1;
+            }
+            continue;
+        }
+        for (int j = 0; j < MAX_CLIENTS; j++) {
+            PlayerState *p = &local_state.players[j];
+            if (!p->active || p->state == STATE_DEAD || p->scene_id != wp->scene_id) continue;
+            float dx = p->x - wp->x, dy = p->y - wp->y, dz = p->z - wp->z;
+            if ((dx*dx + dy*dy + dz*dz) > (wp->radius * wp->radius)) continue;
+            if (wp->type == PICKUP_HEALTH) {
+                if (p->health >= 100) continue;
+                p->health += 35; if (p->health > 100) p->health = 100;
+            } else if (wp->type == PICKUP_STICKY_GRENADE) {
+                if (p->sticky_grenades >= STICKY_MAX_PER_PLAYER) continue;
+                p->sticky_grenades++;
+            }
+            if (wp->respawn_delay_ticks > 0) wp->available = 0;
+            else wp->active = 0;
+            break;
+        }
+    }
+}
 
 void local_update(float fwd, float str, float yaw, float pitch, int shoot, int weapon_req, int jump, int crouch, int reload, int ability, void *server_context, unsigned int cmd_time);
 void update_entity(PlayerState *p, float dt, void *server_context, unsigned int cmd_time);
@@ -61,6 +238,17 @@ static inline void scene_load(int scene_id) {
         memset(&local_state.helicopters[hi], 0, sizeof(local_state.helicopters[hi]));
         local_state.helicopters[hi].id = hi;
         local_state.helicopters[hi].occupant_player_id = -1;
+    }
+    for (int gi = 0; gi < MAX_STICKY_GRENADES; gi++) {
+        memset(&local_state.sticky_grenades[gi], 0, sizeof(local_state.sticky_grenades[gi]));
+        local_state.sticky_grenades[gi].id = gi;
+    }
+    for (int pi = 0; pi < MAX_WORLD_PICKUPS; pi++) {
+        memset(&local_state.world_pickups[pi], 0, sizeof(local_state.world_pickups[pi]));
+        local_state.world_pickups[pi].id = pi;
+    }
+    if (scene_id == SCENE_POO_POO_ISLAND) {
+        poo_poo_island_init_pickups();
     }
 
     if (scene_id == SCENE_VOXWORLD) {
@@ -247,6 +435,7 @@ static void apply_projectile_damage(PlayerState *owner, PlayerState *target, int
     if (target->health <= 0) {
         if (owner) { owner->kills++; owner->accumulated_reward += 500.0f; }
         target->deaths++;
+        drop_player_inventory_pickups(target);
         phys_respawn(target, now_ms);
     }
 
@@ -376,6 +565,10 @@ void local_update(float fwd, float str, float yaw, float pitch, int shoot, int w
     for(int i=0; i<MAX_CLIENTS; i++) {
         PlayerState *p = &local_state.players[i];
         if (!p->active) continue;
+        if (p->sticky_throw_cooldown > 0) p->sticky_throw_cooldown--;
+        if (p->in_grenade && p->state != STATE_DEAD) {
+            sticky_spawn_from_player(p);
+        }
         if (p->in_vehicle && p->vehicle_type == VEH_HELICOPTER) {
             continue;
         }
@@ -399,6 +592,8 @@ void local_update(float fwd, float str, float yaw, float pitch, int shoot, int w
         update_entity(p, 0.016f, server_context, cmd_time);
     }
     update_projectiles(cmd_time);
+    sticky_update_all();
+    pickup_update_and_collect();
 }
 
 void local_init_match(int num_players, int mode) {


### PR DESCRIPTION
### Motivation

- Introduce Halo-style sticky grenades and world pickups as server-authoritative gameplay features and exercise them in a new authored map called `POO_POO_ISLAND`.
- Ensure pickups, death-drops, grenade attach/explode behavior, and HUD visuals are integrated into the existing scene/terrain/portal architecture without replacing prior maps or portal flows.

### Description

- Extended the protocol and server state with `SCENE_POO_POO_ISLAND`, `BTN_GRENADE`, replication types (`NetStickyGrenade`, `NetWorldPickup`), and arrays `sticky_grenades` / `world_pickups` in `ServerState` (`packages/common/protocol.h`).
- Added scene plumbing and authored content for Poo Poo Island: terrain generator, authored geo boxes, spawn points, landmark anchors, portal IDs and garage routing, and scene safety bounds (`packages/common/physics.h`).
- Implemented server-authoritative sticky grenade and pickup gameplay in the simulation layer: per-player reserve and cooldown, `sticky_spawn_from_player`, `sticky_update_all`, `sticky_explode`, `pickup_spawn`, `pickup_update_and_collect`, and `drop_player_inventory_pickups` (death-drop) in `packages/simulation/local_game.h`.
- Wired network and client UI/visuals: snapshot replication of sticky grenades and pickups in the server snapshot, client-side snapshot ingestion and rendering hooks, grenade input binding (`G` => `BTN_GRENADE`), and HUD sticky pip rendering and world pickup visuals in `apps/server/src/main.c`, `apps/lobby/src/main.c`, and `packages/common/net_sim.h`.

### Testing

- Built the server with `make server`; the server binary compiled successfully (server snapshot path and sticky/pickup state changes exercised by compilation). 
- Attempted `make lobby` in this environment but it failed due to missing SDL2/OpenGL development headers (`SDL2/SDL.h`, `SDL2/SDL_opengl.h`), which is an environment limitation rather than a code error for the lobby changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de8469f39c83279e1fce077bacecaf)