### PR TITLE
Add Genie and Wanderer player skins

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -100,6 +100,8 @@ typedef enum {
     SKIN_PIMP,
     SKIN_VIKING,
     SKIN_BILL,
+    SKIN_GENIE,
+    SKIN_WANDERER,
     SKIN_COUNT
 } PlayerSkin;
 
@@ -112,7 +114,9 @@ static const char *SKIN_LABELS[SKIN_COUNT] = {
     "NINJA",
     "PIMP",
     "VIKING",
-    "BILL"
+    "BILL",
+    "GENIE",
+    "WANDERER"
 };
 static const char *SKIN_CONFIG_PATH = "shankpit_skin.cfg";
 static void ensure_skin_selection_visible(void);
@@ -1711,6 +1715,68 @@ static void draw_player_skin_bill(PlayerState *p, float draw_pitch, float draw_r
     glScalef(0.8f, 0.8f, 0.8f); draw_gun_model(p->current_weapon); glPopMatrix();
 }
 
+static void draw_player_skin_genie(PlayerState *p, float draw_pitch, float draw_recoil) {
+    glColor3f(0.26f, 0.64f, 0.92f);
+    glPushMatrix(); glTranslatef(0.0f, 0.95f, 0.0f); draw_box(1.18f, 1.20f, 0.66f); draw_box_outline(1.18f, 1.20f, 0.66f); glPopMatrix();
+    glColor3f(0.88f, 0.72f, 0.12f);
+    glPushMatrix(); glTranslatef(0.0f, 0.35f, 0.36f); draw_box(0.16f, 0.52f, 0.06f); draw_box_outline(0.16f, 0.52f, 0.06f); glPopMatrix();
+    glPushMatrix(); glTranslatef(-0.70f, 0.86f, 0.0f); draw_box(0.30f, 1.18f, 0.34f); draw_box_outline(0.30f, 1.18f, 0.34f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.70f, 0.86f, 0.0f); draw_box(0.30f, 1.18f, 0.34f); draw_box_outline(0.30f, 1.18f, 0.34f); glPopMatrix();
+    glColor3f(0.10f, 0.48f, 0.84f);
+    glPushMatrix(); glTranslatef(0.0f, -0.30f, 0.0f); draw_box(0.78f, 0.92f, 0.64f); draw_box_outline(0.78f, 0.92f, 0.64f); glPopMatrix();
+    glColor3f(0.20f, 0.62f, 0.95f);
+    glPushMatrix(); glTranslatef(0.0f, -0.82f, 0.0f); draw_box(0.58f, 0.46f, 0.54f); draw_box_outline(0.58f, 0.46f, 0.54f); glPopMatrix();
+
+    glPushMatrix();
+    glTranslatef(0.0f, 1.94f, 0.0f);
+    glRotatef(draw_pitch, 1, 0, 0);
+    glColor3f(0.64f, 0.80f, 0.92f); draw_box(0.68f, 0.84f, 0.68f); draw_box_outline(0.68f, 0.84f, 0.68f);
+    glColor3f(0.06f, 0.08f, 0.12f);
+    glPushMatrix(); glTranslatef(0.0f, 0.38f, 0.0f); draw_box(0.62f, 0.16f, 0.58f); draw_box_outline(0.62f, 0.16f, 0.58f); glPopMatrix();
+    glColor3f(0.94f, 0.80f, 0.18f);
+    glPushMatrix(); glTranslatef(0.0f, 0.62f, 0.0f); draw_box(0.34f, 0.26f, 0.32f); draw_box_outline(0.34f, 0.26f, 0.32f); glPopMatrix();
+    glColor3f(0.06f, 0.12f, 0.18f);
+    glPushMatrix(); glTranslatef(0.0f, 0.08f, 0.37f); draw_box(0.54f, 0.22f, 0.10f); draw_box_outline(0.54f, 0.22f, 0.10f); glPopMatrix();
+    glPopMatrix();
+
+    glPushMatrix(); glTranslatef(0.64f, 1.03f, 0.57f);
+    glRotatef(draw_pitch, 1, 0, 0);
+    glRotatef(-draw_recoil * 10.0f, 1, 0, 0);
+    glTranslatef(0.0f, 0.0f, -draw_recoil * 0.08f);
+    glScalef(0.8f, 0.8f, 0.8f); draw_gun_model(p->current_weapon); glPopMatrix();
+}
+
+static void draw_player_skin_wanderer(PlayerState *p, float draw_pitch, float draw_recoil) {
+    glColor3f(0.42f, 0.30f, 0.22f);
+    glPushMatrix(); glTranslatef(0.0f, 0.78f, 0.0f); draw_box(1.30f, 1.58f, 0.76f); draw_box_outline(1.30f, 1.58f, 0.76f); glPopMatrix();
+    glColor3f(0.30f, 0.44f, 0.28f);
+    glPushMatrix(); glTranslatef(0.0f, 0.72f, 0.39f); draw_box(0.80f, 0.52f, 0.06f); draw_box_outline(0.80f, 0.52f, 0.06f); glPopMatrix();
+    glColor3f(0.34f, 0.24f, 0.18f);
+    glPushMatrix(); glTranslatef(-0.74f, 0.82f, 0.0f); draw_box(0.30f, 1.20f, 0.34f); draw_box_outline(0.30f, 1.20f, 0.34f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.74f, 0.82f, 0.0f); draw_box(0.30f, 1.20f, 0.34f); draw_box_outline(0.30f, 1.20f, 0.34f); glPopMatrix();
+    glColor3f(0.10f, 0.10f, 0.12f);
+    glPushMatrix(); glTranslatef(-0.34f, -0.10f, 0.0f); draw_box(0.42f, 1.42f, 0.42f); draw_box_outline(0.42f, 1.42f, 0.42f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.34f, -0.10f, 0.0f); draw_box(0.42f, 1.42f, 0.42f); draw_box_outline(0.42f, 1.42f, 0.42f); glPopMatrix();
+
+    glPushMatrix();
+    glTranslatef(0.0f, 1.94f, 0.0f);
+    glRotatef(draw_pitch, 1, 0, 0);
+    glColor3f(0.70f, 0.55f, 0.44f); draw_box(0.68f, 0.84f, 0.68f); draw_box_outline(0.68f, 0.84f, 0.68f);
+    glColor3f(0.24f, 0.14f, 0.08f);
+    glPushMatrix(); glTranslatef(0.0f, 0.14f, 0.37f); draw_box(0.56f, 0.22f, 0.10f); draw_box_outline(0.56f, 0.22f, 0.10f); glPopMatrix();
+    glColor3f(0.16f, 0.10f, 0.06f);
+    glPushMatrix(); glTranslatef(0.0f, 0.34f, 0.40f); draw_box(0.44f, 0.20f, 0.06f); draw_box_outline(0.44f, 0.20f, 0.06f); glPopMatrix();
+    glColor3f(0.18f, 0.11f, 0.06f);
+    glPushMatrix(); glTranslatef(0.0f, 0.58f, 0.0f); draw_box(0.86f, 0.24f, 0.82f); draw_box_outline(0.86f, 0.24f, 0.82f); glPopMatrix();
+    glPopMatrix();
+
+    glPushMatrix(); glTranslatef(0.64f, 1.03f, 0.57f);
+    glRotatef(draw_pitch, 1, 0, 0);
+    glRotatef(-draw_recoil * 10.0f, 1, 0, 0);
+    glTranslatef(0.0f, 0.0f, -draw_recoil * 0.08f);
+    glScalef(0.8f, 0.8f, 0.8f); draw_gun_model(p->current_weapon); glPopMatrix();
+}
+
 void draw_weapon_p(PlayerState *p) {
     if (p->in_vehicle) return; 
     glPushMatrix();
@@ -1765,6 +1831,12 @@ void draw_player_3rd(PlayerState *p) {
     } else {
         // TODO(net): replicate skin on player state (e.g. p->skin) so remote players can use per-player skins.
         switch (clamp_skin_id(g_selected_skin)) {
+            case SKIN_WANDERER:
+                draw_player_skin_wanderer(p, draw_pitch, draw_recoil);
+                break;
+            case SKIN_GENIE:
+                draw_player_skin_genie(p, draw_pitch, draw_recoil);
+                break;
             case SKIN_BILL:
                 draw_player_skin_bill(p, draw_pitch, draw_recoil);
                 break;


### PR DESCRIPTION
### Motivation
- Expose two new player appearances so users can select `GENIE` and `WANDERER` from the skin chooser and see distinct third-person models.

### Description
- Extend `PlayerSkin` enum with `SKIN_GENIE` and `SKIN_WANDERER` and add their labels to `SKIN_LABELS` so they appear in the UI (`apps/lobby/src/main.c`).
- Implement `draw_player_skin_genie` and `draw_player_skin_wanderer` voxel-style rendering functions with unique color/palette and silhouette details (`apps/lobby/src/main.c`).
- Wire both new skins into the third-person rendering dispatch in `draw_player_3rd` so selecting them renders the new models (`apps/lobby/src/main.c`).
- Updated `shankpit_skin.cfg` handling implicitly by increasing `SKIN_COUNT` to include the two new entries.

### Testing
- Ran `make lobby` to build the lobby client, which produced a compilation error due to missing SDL2 development headers in this environment (`SDL2/SDL.h` and `SDL2/SDL_opengl.h`), so a full build/run test could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de84f5ee808327b0c4fd440687fe7b)