### PR TITLE
Add sticky grenades, world pickups, and Poo Poo Island scene

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -525,6 +525,8 @@ static void lobby_apply_scene_id(const char *scene_id) {
         scene_load(SCENE_VOXWORLD);
     } else if (strcmp(scene_id, "OIL_TANKER") == 0) {
         scene_load(SCENE_OIL_TANKER);
+    } else if (strcmp(scene_id, "POO_POO_ISLAND") == 0) {
+        scene_load(SCENE_POO_POO_ISLAND);
     }
 }
 
@@ -1761,6 +1763,18 @@ void draw_hud(PlayerState *p) {
     glRectf(x0, y_health0, x0 + (p->health * (x1 - x0) / 100.0f), y_health1);
     glColor3f(0.10f, 0.12f, 0.20f); glRectf(x0, y_shield0, x1, y_shield1); glColor3f(0.34f, 0.52f, 0.86f);
     glRectf(x0, y_shield0, x0 + (p->shield * (x1 - x0) / 100.0f), y_shield1);
+    for (int gi = 0; gi < p->sticky_grenades; gi++) {
+        float px = x0 + gi * 14.0f;
+        float py = y_shield1 + 18.0f;
+        glColor3f(0.16f, 0.96f, 1.0f);
+        glBegin(GL_QUADS);
+        glVertex2f(px, py); glVertex2f(px + 9.0f, py); glVertex2f(px + 9.0f, py + 9.0f); glVertex2f(px, py + 9.0f);
+        glEnd();
+        glColor3f(0.72f, 0.40f, 0.95f);
+        glBegin(GL_LINE_LOOP);
+        glVertex2f(px - 1.0f, py - 1.0f); glVertex2f(px + 10.0f, py - 1.0f); glVertex2f(px + 10.0f, py + 10.0f); glVertex2f(px - 1.0f, py + 10.0f);
+        glEnd();
+    }
     
     if (p->in_vehicle) {
         glColor3f(0.0f, 1.0f, 0.0f);
@@ -1822,6 +1836,7 @@ static const char *scene_name_ui(int scene_id) {
         case SCENE_VOXWORLD: return "VOXWORLD";
         case SCENE_DUST_COMPOUND: return "DUST_COMPOUND";
         case SCENE_OIL_TANKER: return "OIL_TANKER";
+        case SCENE_POO_POO_ISLAND: return "POO_POO_ISLAND";
         default: return "UNKNOWN";
     }
 }
@@ -1966,6 +1981,18 @@ static void draw_garage_portal_frame() {
         glVertex3f(-GARAGE_DUST_PORTAL_RADIUS, 6.0f, 0.0f);
         glEnd();
         glPopMatrix();
+
+        glPushMatrix();
+        glTranslatef(GARAGE_POO_PORTAL_X, GARAGE_POO_PORTAL_Y, GARAGE_POO_PORTAL_Z);
+        glColor3f(0.35f, 1.0f, 0.9f);
+        glLineWidth(3.0f);
+        glBegin(GL_LINE_LOOP);
+        glVertex3f(-GARAGE_POO_PORTAL_RADIUS, -2.0f, 0.0f);
+        glVertex3f(GARAGE_POO_PORTAL_RADIUS, -2.0f, 0.0f);
+        glVertex3f(GARAGE_POO_PORTAL_RADIUS, 6.0f, 0.0f);
+        glVertex3f(-GARAGE_POO_PORTAL_RADIUS, 6.0f, 0.0f);
+        glEnd();
+        glPopMatrix();
     }
 }
 
@@ -2001,6 +2028,7 @@ static void draw_garage_overlay(PlayerState *p) {
     draw_string("PORTAL -> STADIUM", 40, 640, 6);
     draw_string("PORTAL -> VOXWORLD TERRAIN", 40, 620, 6);
     draw_string("PORTAL -> OIL TANKER", 40, 600, 6);
+    draw_string("PORTAL -> POO POO ISLAND", 40, 580, 6);
 
     int pad_count = 0;
     const VehiclePad *pads = scene_vehicle_pads(local_state.scene_id, &pad_count);
@@ -2030,6 +2058,7 @@ static void draw_garage_overlay(PlayerState *p) {
     int vox_portal_target = target_in_view(p, GARAGE_VOX_PORTAL_X, GARAGE_VOX_PORTAL_Y, GARAGE_VOX_PORTAL_Z, 30.0f, 0.75f);
     int tanker_portal_target = target_in_view(p, GARAGE_TANKER_PORTAL_X, GARAGE_TANKER_PORTAL_Y, GARAGE_TANKER_PORTAL_Z, 30.0f, 0.75f);
     int dust_portal_target = target_in_view(p, GARAGE_DUST_PORTAL_X, GARAGE_DUST_PORTAL_Y, GARAGE_DUST_PORTAL_Z, 30.0f, 0.75f);
+    int poo_portal_target = target_in_view(p, GARAGE_POO_PORTAL_X, GARAGE_POO_PORTAL_Y, GARAGE_POO_PORTAL_Z, 30.0f, 0.75f);
     int pad_target = 0;
     int heli_target = 0;
     if (scene_near_vehicle_pad(local_state.scene_id, p->x, p->z, 12.0f, NULL)) {
@@ -2051,7 +2080,7 @@ static void draw_garage_overlay(PlayerState *p) {
     }
 
     glColor3f(1.0f, 1.0f, 0.0f);
-    if (portal_target || vox_portal_target || tanker_portal_target || dust_portal_target) {
+    if (portal_target || vox_portal_target || tanker_portal_target || dust_portal_target || poo_portal_target) {
         draw_string("TRAVEL", 600, 350, 8);
     } else if (heli_target || (p->in_vehicle && p->vehicle_type == VEH_HELICOPTER)) {
         draw_string(p->in_vehicle ? "PRESS F TO EXIT HELICOPTER" : "PRESS F TO ENTER HELICOPTER", 460, 350, 8);
@@ -2079,6 +2108,33 @@ void draw_projectiles() {
     glEnd();
 }
 
+
+void draw_sticky_grenades() {
+    glDisable(GL_TEXTURE_2D);
+    glPointSize(9.0f);
+    glBegin(GL_POINTS);
+    for (int i = 0; i < MAX_STICKY_GRENADES; i++) {
+        StickyGrenadeState *g = &local_state.sticky_grenades[i];
+        if (!g->active || g->scene_id != local_state.scene_id) continue;
+        glColor3f(0.15f, 0.95f, 1.0f);
+        glVertex3f(g->x, g->y, g->z);
+    }
+    glEnd();
+}
+
+void draw_world_pickups() {
+    for (int i = 0; i < MAX_WORLD_PICKUPS; i++) {
+        WorldPickup *w = &local_state.pickups[i];
+        if (!w->active || !w->available || w->scene_id != local_state.scene_id) continue;
+        glPushMatrix();
+        glTranslatef(w->x, w->y, w->z);
+        if (w->type == PICKUP_STICKY_GRENADE) glColor3f(0.15f, 0.95f, 1.0f);
+        else glColor3f(0.2f, 1.0f, 0.25f);
+        draw_box(2.0f, 2.0f, 2.0f);
+        glPopMatrix();
+    }
+}
+
 static void client_apply_scene_id(int scene_id, unsigned int now_ms) {
     if (scene_id < 0) return;
     if (local_state.scene_id != scene_id) {
@@ -2092,6 +2148,8 @@ static void client_apply_scene_id(int scene_id, unsigned int now_ms) {
             local_state.helicopters[i].active = 0;
             local_state.helicopters[i].occupant_player_id = -1;
         }
+        for (int i = 0; i < MAX_STICKY_GRENADES; i++) local_state.sticky_grenades[i].active = 0;
+        for (int i = 0; i < MAX_WORLD_PICKUPS; i++) local_state.pickups[i].active = 0;
     }
 }
 
@@ -2177,6 +2235,8 @@ void draw_scene(PlayerState *render_p) {
         draw_helicopter_model(h);
     }
     draw_projectiles();
+    draw_sticky_grenades();
+    draw_world_pickups();
     if (render_p->in_vehicle) draw_player_3rd(render_p);
     for(int i=0; i<MAX_CLIENTS; i++) {
         PlayerState *p = &local_state.players[i];
@@ -2365,7 +2425,7 @@ void net_connect() {
     }
 }
 
-UserCmd client_create_cmd(float fwd, float str, float yaw, float pitch, int shoot, int jump, int crouch, int reload, int use, int ability, int wpn_idx) {
+UserCmd client_create_cmd(float fwd, float str, float yaw, float pitch, int shoot, int jump, int crouch, int reload, int use, int ability, int grenade, int wpn_idx) {
     UserCmd cmd;
     memset(&cmd, 0, sizeof(UserCmd));
     cmd.sequence = ++net_cmd_seq; cmd.timestamp = SDL_GetTicks();
@@ -2376,6 +2436,7 @@ UserCmd client_create_cmd(float fwd, float str, float yaw, float pitch, int shoo
     if(reload) cmd.buttons |= BTN_RELOAD;
     if(use) cmd.buttons |= BTN_USE;
     if(ability) cmd.buttons |= BTN_ABILITY_1;
+    if(grenade) cmd.buttons |= BTN_GRENADE;
     client_cmd_hist[cmd.sequence % CLIENT_RECON_HISTORY] = cmd;
     net_latest_seq_sent = cmd.sequence;
     cmd.weapon_idx = wpn_idx; return cmd;
@@ -2700,6 +2761,7 @@ void net_process_snapshot(char *buffer, int len) {
         p->hit_feedback = np->hit_feedback;
         p->kills = (int)np->kills;
         p->deaths = (int)np->deaths;
+        p->sticky_grenades = (int)np->sticky_grenades;
         p->ammo[p->current_weapon] = np->ammo;
 
         if (now_shooting && !was_shooting) p->recoil_anim = 1.0f;
@@ -2804,6 +2866,45 @@ void net_process_snapshot(char *buffer, int len) {
     printf("[HELI SNAPSHOT][RX] scene=%d heli_count=%u cursor=%d len=%d\n",
            (int)head->scene_id, heli_count, cursor, len);
 #endif
+    for (int si = 0; si < MAX_STICKY_GRENADES; si++) local_state.sticky_grenades[si].active = 0;
+    if (cursor + 2 <= len) {
+        unsigned short sticky_count = *(unsigned short *)(buffer + cursor);
+        cursor += 2;
+        for (unsigned short si = 0; si < sticky_count; si++) {
+            if (cursor + (int)sizeof(NetStickyGrenade) > len) break;
+            NetStickyGrenade *ng = (NetStickyGrenade *)(buffer + cursor);
+            cursor += (int)sizeof(NetStickyGrenade);
+            if (ng->id >= MAX_STICKY_GRENADES) continue;
+            StickyGrenadeState *g = &local_state.sticky_grenades[ng->id];
+            g->active = 1;
+            g->id = ng->id;
+            g->scene_id = ng->scene_id;
+            g->attached = ng->attached;
+            g->attach_type = ng->attach_type;
+            g->attach_target_id = ng->attach_target_id;
+            g->fuse_ticks = ng->fuse_ticks;
+            g->x = ng->x; g->y = ng->y; g->z = ng->z;
+        }
+    }
+    for (int wi = 0; wi < MAX_WORLD_PICKUPS; wi++) local_state.pickups[wi].active = 0;
+    if (cursor + 2 <= len) {
+        unsigned short pickup_count = *(unsigned short *)(buffer + cursor);
+        cursor += 2;
+        for (unsigned short wi = 0; wi < pickup_count; wi++) {
+            if (cursor + (int)sizeof(NetWorldPickup) > len) break;
+            NetWorldPickup *nw = (NetWorldPickup *)(buffer + cursor);
+            cursor += (int)sizeof(NetWorldPickup);
+            if (nw->id >= MAX_WORLD_PICKUPS) continue;
+            WorldPickup *w = &local_state.pickups[nw->id];
+            w->active = 1;
+            w->id = nw->id;
+            w->scene_id = nw->scene_id;
+            w->type = nw->type;
+            w->available = nw->available;
+            w->x = nw->x; w->y = nw->y; w->z = nw->z;
+            w->radius = nw->radius;
+        }
+    }
     for (int i = 1; i < MAX_CLIENTS; i++) {
         PlayerState *p = &local_state.players[i];
         if (!p->active) continue;
@@ -3172,7 +3273,7 @@ int main(int argc, char* argv[]) {
                 if (net_local_pid > 0 && net_have_initial_local_snapshot_sync) {
                     unsigned int now_ms = SDL_GetTicks();
                     if (now_ms - net_last_cmd_send_ms >= CLIENT_USERCMD_INTERVAL_MS) {
-                        UserCmd cmd = client_create_cmd(fwd, str, cam_yaw, cam_pitch, shoot, jump, crouch, reload, use, ability, wpn_req);
+                        UserCmd cmd = client_create_cmd(fwd, str, cam_yaw, cam_pitch, shoot, jump, crouch, reload, use, ability, k[SDL_SCANCODE_G], wpn_req);
                         client_apply_cmd_movement(&local_state.players[net_local_pid], &cmd, now_ms);
                         net_send_cmd(cmd);
                         net_last_cmd_send_ms = now_ms;
@@ -3183,6 +3284,7 @@ int main(int argc, char* argv[]) {
                 net_apply_remote_interpolation(SDL_GetTicks());
             } else {
                 local_state.players[0].in_use = use;
+                local_state.players[0].in_bike = k[SDL_SCANCODE_G];
                 if (use && local_state.players[0].vehicle_cooldown == 0 && local_state.transition_timer == 0) {
                     PlayerState *p0 = &local_state.players[0];
                     HelicopterState *near_h = NULL;

--- a/apps/server/src/main.c
+++ b/apps/server/src/main.c
@@ -488,6 +488,7 @@ void server_broadcast() {
             np.storm_charges = (unsigned char)p->storm_charges;
             np.kills = (unsigned short)(p->kills < 0 ? 0 : p->kills);
             np.deaths = (unsigned short)(p->deaths < 0 ? 0 : p->deaths);
+            np.sticky_grenades = (unsigned char)(p->sticky_grenades < 0 ? 0 : (p->sticky_grenades > 255 ? 255 : p->sticky_grenades));
             p->accumulated_reward = 0;
             memcpy(buffer + cursor, &np, sizeof(NetPlayer)); cursor += (int)sizeof(NetPlayer);
         }
@@ -521,6 +522,53 @@ void server_broadcast() {
             nh.health = (unsigned char)(h->health < 0 ? 0 : (h->health > 255 ? 255 : h->health));
             nh.occupant_player_id = (signed char)h->occupant_player_id;
             memcpy(buffer + cursor, &nh, sizeof(NetHelicopter)); cursor += (int)sizeof(NetHelicopter);
+        }
+
+        unsigned short sticky_count = 0;
+        for (int si = 0; si < MAX_STICKY_GRENADES; si++) {
+            StickyGrenadeState *sg = &local_state.sticky_grenades[si];
+            if (!sg->active || sg->scene_id != recipient_scene) continue;
+            sticky_count++;
+        }
+        if (cursor + 2 > (int)sizeof(buffer)) continue;
+        memcpy(buffer + cursor, &sticky_count, 2); cursor += 2;
+        for (int si = 0; si < MAX_STICKY_GRENADES; si++) {
+            StickyGrenadeState *sg = &local_state.sticky_grenades[si];
+            if (!sg->active || sg->scene_id != recipient_scene) continue;
+            if (cursor + (int)sizeof(NetStickyGrenade) > (int)sizeof(buffer)) break;
+            NetStickyGrenade ng;
+            memset(&ng, 0, sizeof(ng));
+            ng.id = (unsigned short)sg->id;
+            ng.scene_id = (unsigned char)sg->scene_id;
+            ng.attached = (unsigned char)sg->attached;
+            ng.attach_type = (unsigned char)sg->attach_type;
+            ng.attach_target_id = (signed char)sg->attach_target_id;
+            ng.fuse_ticks = (unsigned char)(sg->fuse_ticks < 0 ? 0 : (sg->fuse_ticks > 255 ? 255 : sg->fuse_ticks));
+            ng.x = sg->x; ng.y = sg->y; ng.z = sg->z;
+            memcpy(buffer + cursor, &ng, sizeof(ng)); cursor += (int)sizeof(ng);
+        }
+
+        unsigned short pickup_count = 0;
+        for (int wi = 0; wi < MAX_WORLD_PICKUPS; wi++) {
+            WorldPickup *wp = &local_state.pickups[wi];
+            if (!wp->active || !wp->available || wp->scene_id != recipient_scene) continue;
+            pickup_count++;
+        }
+        if (cursor + 2 > (int)sizeof(buffer)) continue;
+        memcpy(buffer + cursor, &pickup_count, 2); cursor += 2;
+        for (int wi = 0; wi < MAX_WORLD_PICKUPS; wi++) {
+            WorldPickup *wp = &local_state.pickups[wi];
+            if (!wp->active || !wp->available || wp->scene_id != recipient_scene) continue;
+            if (cursor + (int)sizeof(NetWorldPickup) > (int)sizeof(buffer)) break;
+            NetWorldPickup nw;
+            memset(&nw, 0, sizeof(nw));
+            nw.id = (unsigned short)wp->id;
+            nw.scene_id = (unsigned char)wp->scene_id;
+            nw.type = (unsigned char)wp->type;
+            nw.available = (unsigned char)wp->available;
+            nw.x = wp->x; nw.y = wp->y; nw.z = wp->z;
+            nw.radius = wp->radius;
+            memcpy(buffer + cursor, &nw, sizeof(nw)); cursor += (int)sizeof(nw);
         }
 #if HELI_NET_DEBUG
         printf("[HELI SNAPSHOT][TX] client=%d scene=%d heli_count=%u players=%u\n", i, recipient_scene, heli_count, count);
@@ -699,6 +747,8 @@ int main(int argc, char *argv[]) {
         }
 
         update_projectiles(now);
+        sticky_update_all(now);
+        pickup_update_and_collect();
         recorder_write_frame(tick, now);
         if ((tick % SERVER_SNAPSHOT_INTERVAL_TICKS) == 0) {
             server_broadcast();

--- a/packages/common/net_sim.h
+++ b/packages/common/net_sim.h
@@ -144,7 +144,7 @@ static inline void shankpit_apply_usercmd_inputs(PlayerState *p, const UserCmd *
     p->in_reload = (cmd->buttons & BTN_RELOAD) != 0;
     p->in_use = (cmd->buttons & BTN_USE) != 0;
     p->in_ability = (cmd->buttons & BTN_ABILITY_1) != 0;
-    p->in_bike = (cmd->buttons & BTN_VEHICLE_2) != 0;
+    p->in_bike = (cmd->buttons & (BTN_VEHICLE_2 | BTN_GRENADE)) != 0;
 
     if (cmd->weapon_idx >= 0 && cmd->weapon_idx < MAX_WEAPONS) {
         p->current_weapon = cmd->weapon_idx;

--- a/packages/common/physics.h
+++ b/packages/common/physics.h
@@ -121,6 +121,9 @@ static int map_geo_dust_init = 0;
 static Box map_geo_tanker[CITY_MAX_BOXES];
 static int map_geo_tanker_count = 0;
 static int map_geo_tanker_init = 0;
+static Box map_geo_poo_poo[CITY_MAX_BOXES];
+static int map_geo_poo_poo_count = 0;
+static int map_geo_poo_poo_init = 0;
 
 static const Box *map_geo = map_geo_stadium;
 static int map_count = 0;
@@ -180,6 +183,15 @@ static int map_count = 0;
 #define TANKER_BOUNDS_X 360.0f
 #define TANKER_BOUNDS_Z 240.0f
 
+#define POO_POO_KILL_Y -120.0f
+#define POO_POO_TERRAIN_W 164
+#define POO_POO_TERRAIN_H 164
+#define POO_POO_CELL 16.0f
+#define POO_POO_ORIGIN_X (-(POO_POO_TERRAIN_W * POO_POO_CELL * 0.5f))
+#define POO_POO_ORIGIN_Z (-(POO_POO_TERRAIN_H * POO_POO_CELL * 0.5f))
+#define POO_POO_BOUNDS_X 1250.0f
+#define POO_POO_BOUNDS_Z 1250.0f
+
 #define GARAGE_PORTAL_X 0.0f
 #define GARAGE_PORTAL_Y 6.0f
 #define GARAGE_PORTAL_Z 56.0f
@@ -219,6 +231,14 @@ static int map_count = 0;
 #define TANKER_PORTAL_Y 6.0f
 #define TANKER_PORTAL_Z 0.0f
 #define TANKER_PORTAL_RADIUS 13.0f
+#define POO_POO_PORTAL_X -870.0f
+#define POO_POO_PORTAL_Y 8.0f
+#define POO_POO_PORTAL_Z 720.0f
+#define POO_POO_PORTAL_RADIUS 18.0f
+#define GARAGE_POO_PORTAL_X 48.0f
+#define GARAGE_POO_PORTAL_Y 6.0f
+#define GARAGE_POO_PORTAL_Z -26.0f
+#define GARAGE_POO_PORTAL_RADIUS 6.0f
 #define PORTAL_ID_GARAGE_EXIT 0
 #define PORTAL_ID_STADIUM_TO_VOXWORLD 1
 #define PORTAL_ID_VOXWORLD_TO_STADIUM 2
@@ -227,6 +247,8 @@ static int map_count = 0;
 #define PORTAL_ID_DUST_TO_GARAGE 5
 #define PORTAL_ID_GARAGE_TO_TANKER 6
 #define PORTAL_ID_TANKER_TO_GARAGE 7
+#define PORTAL_ID_GARAGE_TO_POO_POO_ISLAND 8
+#define PORTAL_ID_POO_POO_ISLAND_TO_GARAGE 9
 
 typedef struct {
     float x;
@@ -306,6 +328,19 @@ static const Vec2 tanker_spawn_points_dm[] = {
     {-260.0f, 0.0f}, {-210.0f, -90.0f}, {-205.0f, 92.0f}, {-120.0f, -140.0f},
     {-110.0f, 140.0f}, {-30.0f, -72.0f}, {-20.0f, 82.0f}, {80.0f, -155.0f},
     {90.0f, 155.0f}, {150.0f, -30.0f}, {155.0f, 35.0f}, {220.0f, 0.0f}
+};
+static const Vec2 poo_poo_spawn_points_dm[] = {
+    {-760.0f, 620.0f}, {-620.0f, 760.0f}, {-910.0f, 510.0f}, {-560.0f, 520.0f},
+    {-240.0f, 220.0f}, {-40.0f, -40.0f}, {220.0f, -220.0f}, {480.0f, -620.0f},
+    {620.0f, -780.0f}, {800.0f, -520.0f}, {-320.0f, -540.0f}, {140.0f, 620.0f}
+};
+static const VoxRouteAnchor poo_poo_route_anchors[] = {
+    {-720.0f, 640.0f, "POO POO TOWN"},
+    {-960.0f, 760.0f, "BEACH STRIP"},
+    {-500.0f, 410.0f, "MARINA"},
+    {80.0f, 520.0f, "LIGHTHOUSE"},
+    {40.0f, 60.0f, "GREEN BELT"},
+    {660.0f, -650.0f, "VOLCANO"}
 };
 static const VoxRouteAnchor dust_route_anchors[] = {
     {DUST_MID_X, DUST_MID_Z, "MID"},
@@ -647,6 +682,70 @@ static inline void init_oil_tanker_geo(void) {
     printf("[OIL_TANKER] authored geo boxes=%d\n", map_geo_tanker_count);
 }
 
+
+static TerrainHeightfield g_scene_terrain;
+static int g_scene_terrain_scene_id;
+
+static inline float poo_poo_height_at(float x, float z) {
+    if (g_scene_terrain.active && g_scene_terrain.heights) return terrain_sample_height(&g_scene_terrain, x, z);
+    return 2.0f;
+}
+
+static inline void poo_poo_add_box(float x, float y, float z, float w, float h, float d) {
+    if (map_geo_poo_poo_count >= CITY_MAX_BOXES) return;
+    map_geo_poo_poo[map_geo_poo_poo_count++] = (Box){x, y, z, w, h, d};
+}
+
+static inline void init_poo_poo_island_geo(void) {
+    if (map_geo_poo_poo_init) return;
+    map_geo_poo_poo_init = 1;
+    map_geo_poo_poo_count = 0;
+    poo_poo_add_box(0.0f, -9.0f, 0.0f, 2600.0f, 12.0f, 2600.0f);
+    poo_poo_add_box(0.0f, 130.0f, POO_POO_BOUNDS_Z, 2600.0f, 260.0f, 18.0f);
+    poo_poo_add_box(0.0f, 130.0f, -POO_POO_BOUNDS_Z, 2600.0f, 260.0f, 18.0f);
+    poo_poo_add_box(POO_POO_BOUNDS_X, 130.0f, 0.0f, 18.0f, 260.0f, 2600.0f);
+    poo_poo_add_box(-POO_POO_BOUNDS_X, 130.0f, 0.0f, 18.0f, 260.0f, 2600.0f);
+    float town_y = poo_poo_height_at(-720.0f, 640.0f);
+    poo_poo_add_box(-720.0f, town_y + 7.0f, 640.0f, 220.0f, 14.0f, 200.0f);
+    poo_poo_add_box(-640.0f, town_y + 13.0f, 620.0f, 60.0f, 26.0f, 60.0f);
+    poo_poo_add_box(-770.0f, town_y + 13.0f, 690.0f, 52.0f, 26.0f, 52.0f);
+    poo_poo_add_box(-560.0f, poo_poo_height_at(-560.0f, 430.0f) + 6.0f, 430.0f, 180.0f, 12.0f, 70.0f);
+    poo_poo_add_box(60.0f, poo_poo_height_at(60.0f, 520.0f) + 26.0f, 520.0f, 26.0f, 52.0f, 26.0f);
+    poo_poo_add_box(680.0f, poo_poo_height_at(680.0f, -640.0f) + 22.0f, -640.0f, 120.0f, 44.0f, 110.0f);
+    poo_poo_add_box(-180.0f, poo_poo_height_at(-180.0f, 120.0f) + 5.0f, 120.0f, 420.0f, 10.0f, 24.0f);
+    poo_poo_add_box(120.0f, poo_poo_height_at(120.0f, -140.0f) + 5.0f, -140.0f, 360.0f, 10.0f, 24.0f);
+    printf("[POO_POO_ISLAND] authored geo boxes=%d\n", map_geo_poo_poo_count);
+}
+
+static inline void init_poo_poo_island_terrain(void) {
+    if (g_scene_terrain_scene_id == SCENE_POO_POO_ISLAND && g_scene_terrain.heights) { g_scene_terrain.active = 1; return; }
+    if (g_scene_terrain.heights) terrain_free(&g_scene_terrain);
+    if (!terrain_init(&g_scene_terrain, POO_POO_TERRAIN_W, POO_POO_TERRAIN_H, POO_POO_CELL, POO_POO_ORIGIN_X, POO_POO_ORIGIN_Z)) return;
+    terrain_clear(&g_scene_terrain, 2.0f);
+    for (int gz = 0; gz < g_scene_terrain.height; gz++) {
+        for (int gx = 0; gx < g_scene_terrain.width; gx++) {
+            float wx = g_scene_terrain.origin_x + gx * g_scene_terrain.cell_size;
+            float wz = g_scene_terrain.origin_z + gz * g_scene_terrain.cell_size;
+            float r = sqrtf(wx * wx + wz * wz);
+            float coast = 18.0f - r * 0.02f;
+            float waves = sinf(wx * 0.006f) * 2.0f + cosf(wz * 0.008f) * 1.5f;
+            float town = expf(-((wx + 720.0f)*(wx + 720.0f) + (wz - 640.0f)*(wz - 640.0f)) / (2.0f * 240.0f * 240.0f)) * 8.0f;
+            float hill = expf(-((wx - 40.0f)*(wx - 40.0f) + (wz - 40.0f)*(wz - 40.0f)) / (2.0f * 310.0f * 310.0f)) * 12.0f;
+            float volcano = expf(-((wx - 680.0f)*(wx - 680.0f) + (wz + 650.0f)*(wz + 650.0f)) / (2.0f * 260.0f * 260.0f)) * 58.0f;
+            float h = coast + waves + town + hill + volcano;
+            if (r > 1200.0f) h -= (r - 1200.0f) * 0.06f;
+            terrain_set_height(&g_scene_terrain, gx, gz, h);
+        }
+    }
+    vox_terrain_stamp(&g_scene_terrain, -720.0f, 640.0f, 220.0f, 16.0f, 1.0f);
+    vox_terrain_stamp(&g_scene_terrain, -560.0f, 430.0f, 180.0f, 10.0f, 1.0f);
+    vox_terrain_stamp(&g_scene_terrain, 60.0f, 520.0f, 120.0f, 20.0f, 1.0f);
+    vox_terrain_stamp(&g_scene_terrain, 680.0f, -650.0f, 180.0f, 66.0f, 0.85f);
+    vox_terrain_smooth(&g_scene_terrain, 2, 0.46f);
+    printf("[POO_POO_ISLAND] terrain initialized %dx%d cell=%.1f origin=(%.1f, %.1f)\n", g_scene_terrain.width, g_scene_terrain.height, g_scene_terrain.cell_size, g_scene_terrain.origin_x, g_scene_terrain.origin_z);
+    g_scene_terrain_scene_id = SCENE_POO_POO_ISLAND;
+}
+
 static int phys_scene_id = SCENE_STADIUM;
 static TerrainHeightfield g_scene_terrain = {0};
 static int g_last_ground_source_terrain = 0;
@@ -655,6 +754,8 @@ static inline void init_voxworld_bloodgulch_terrain(void);
 static inline void init_dust_compound_terrain(void);
 static inline void init_dust_compound_geo(void);
 static inline void init_oil_tanker_geo(void);
+static inline void init_poo_poo_island_terrain(void);
+static inline void init_poo_poo_island_geo(void);
 static inline void voxworld_build_bushes(void);
 
 static inline float voxworld_bush_hash01(int x, int z, int salt) {
@@ -796,6 +897,12 @@ static inline void phys_set_scene(int scene_id) {
         map_geo = map_geo_tanker;
         map_count = map_geo_tanker_count;
         g_scene_terrain.active = 0;
+    } else if (scene_id == SCENE_POO_POO_ISLAND) {
+        init_poo_poo_island_terrain();
+        init_poo_poo_island_geo();
+        map_geo = map_geo_poo_poo;
+        map_count = map_geo_poo_poo_count;
+        g_scene_terrain.active = (g_scene_terrain.heights != NULL);
     } else if (scene_id == SCENE_VOXWORLD) {
         init_voxworld_bloodgulch_terrain();
         init_voxworld_bloodgulch_geo();
@@ -972,6 +1079,14 @@ static inline void scene_spawn_point(int scene_id, int slot, float *out_x, float
         *out_y = 6.0f;
         return;
     }
+    if (scene_id == SCENE_POO_POO_ISLAND) {
+        int count = (int)(sizeof(poo_poo_spawn_points_dm) / sizeof(Vec2));
+        int idx = slot % count;
+        *out_x = poo_poo_spawn_points_dm[idx].x;
+        *out_z = poo_poo_spawn_points_dm[idx].y;
+        *out_y = poo_poo_height_at(*out_x, *out_z) + 5.5f;
+        return;
+    }
     if (slot % 2 == 0) {
         *out_x = 0.0f; *out_z = 0.0f; *out_y = 80.0f;
     } else {
@@ -983,16 +1098,18 @@ static inline void scene_spawn_point(int scene_id, int slot, float *out_x, float
 }
 
 static inline void scene_spawn_for_player(PlayerState *p, float *out_x, float *out_y, float *out_z) {
-    if (p->scene_id != SCENE_VOXWORLD && p->scene_id != SCENE_DUST_COMPOUND && p->scene_id != SCENE_OIL_TANKER) {
+    if (p->scene_id != SCENE_VOXWORLD && p->scene_id != SCENE_DUST_COMPOUND && p->scene_id != SCENE_OIL_TANKER && p->scene_id != SCENE_POO_POO_ISLAND) {
         scene_spawn_point(p->scene_id, p->id, out_x, out_y, out_z);
         return;
     }
     const Vec2 *pts = (p->scene_id == SCENE_DUST_COMPOUND) ? dust_spawn_points_dm
-                    : (p->scene_id == SCENE_OIL_TANKER ? tanker_spawn_points_dm : voxworld_spawn_points_ffa);
+                    : (p->scene_id == SCENE_OIL_TANKER ? tanker_spawn_points_dm
+                       : (p->scene_id == SCENE_POO_POO_ISLAND ? poo_poo_spawn_points_dm : voxworld_spawn_points_ffa));
     int count = (p->scene_id == SCENE_DUST_COMPOUND)
         ? (int)(sizeof(dust_spawn_points_dm) / sizeof(Vec2))
         : (p->scene_id == SCENE_OIL_TANKER ? (int)(sizeof(tanker_spawn_points_dm) / sizeof(Vec2))
-                                           : (int)(sizeof(voxworld_spawn_points_ffa) / sizeof(Vec2)));
+           : (p->scene_id == SCENE_POO_POO_ISLAND ? (int)(sizeof(poo_poo_spawn_points_dm) / sizeof(Vec2))
+                                                  : (int)(sizeof(voxworld_spawn_points_ffa) / sizeof(Vec2))));
     int team_mode = (g_phys_game_mode == MODE_TDM || g_phys_game_mode == MODE_CTF);
     int team = p->team_id;
     if (team_mode && (team != 0 && team != 1)) team = (p->id % 2);
@@ -1018,7 +1135,9 @@ static inline void scene_spawn_for_player(PlayerState *p, float *out_x, float *o
     *out_z = pts[idx].y;
     *out_y = (p->scene_id == SCENE_DUST_COMPOUND)
         ? (dust_height_at(*out_x, *out_z) + 5.5f)
-        : (p->scene_id == SCENE_OIL_TANKER ? 6.0f : (voxworld_height_at(*out_x, *out_z) + 6.0f));
+        : (p->scene_id == SCENE_OIL_TANKER ? 6.0f
+           : (p->scene_id == SCENE_POO_POO_ISLAND ? (poo_poo_height_at(*out_x, *out_z) + 5.5f)
+                                                  : (voxworld_height_at(*out_x, *out_z) + 6.0f)));
 }
 
 static inline void scene_force_spawn(PlayerState *p) {
@@ -1072,12 +1191,20 @@ static inline void scene_safety_check(PlayerState *p) {
             p->z < -TANKER_BOUNDS_Z || p->z > TANKER_BOUNDS_Z) {
             scene_force_spawn(p);
         }
+        return;
+    }
+    if (p->scene_id == SCENE_POO_POO_ISLAND) {
+        if (p->y < POO_POO_KILL_Y ||
+            p->x < -POO_POO_BOUNDS_X || p->x > POO_POO_BOUNDS_X ||
+            p->z < -POO_POO_BOUNDS_Z || p->z > POO_POO_BOUNDS_Z) {
+            scene_force_spawn(p);
+        }
     }
 }
 
 static inline int scene_portal_active(int scene_id) {
     return scene_id == SCENE_GARAGE_OSAKA || scene_id == SCENE_STADIUM ||
-           scene_id == SCENE_VOXWORLD || scene_id == SCENE_DUST_COMPOUND || scene_id == SCENE_OIL_TANKER;
+           scene_id == SCENE_VOXWORLD || scene_id == SCENE_DUST_COMPOUND || scene_id == SCENE_OIL_TANKER || scene_id == SCENE_POO_POO_ISLAND;
 }
 
 static inline int portal_resolve_destination(int current_scene, int portal_id, int slot,
@@ -1114,6 +1241,13 @@ static inline int portal_resolve_destination(int current_scene, int portal_id, i
         *out_z = 0.0f;
         return 1;
     }
+    if (current_scene == SCENE_GARAGE_OSAKA && portal_id == PORTAL_ID_GARAGE_TO_POO_POO_ISLAND) {
+        *out_scene = SCENE_POO_POO_ISLAND;
+        *out_x = -760.0f;
+        *out_y = poo_poo_height_at(-760.0f, 620.0f) + 6.0f;
+        *out_z = 620.0f;
+        return 1;
+    }
     if (current_scene == SCENE_STADIUM && portal_id == PORTAL_ID_STADIUM_TO_VOXWORLD) {
         *out_scene = SCENE_VOXWORLD;
         *out_x = STADIUM_EDGE_TELEPORT_X;
@@ -1140,6 +1274,13 @@ static inline int portal_resolve_destination(int current_scene, int portal_id, i
         *out_x = GARAGE_TANKER_PORTAL_X + 10.0f;
         *out_y = GARAGE_TANKER_PORTAL_Y;
         *out_z = GARAGE_TANKER_PORTAL_Z;
+        return 1;
+    }
+    if (current_scene == SCENE_POO_POO_ISLAND && portal_id == PORTAL_ID_POO_POO_ISLAND_TO_GARAGE) {
+        *out_scene = SCENE_GARAGE_OSAKA;
+        *out_x = GARAGE_POO_PORTAL_X - 10.0f;
+        *out_y = GARAGE_POO_PORTAL_Y;
+        *out_z = GARAGE_POO_PORTAL_Z;
         return 1;
     }
     return 0;
@@ -1171,6 +1312,11 @@ static inline void scene_portal_info(int scene_id, float *out_x, float *out_y, f
         *out_y = TANKER_PORTAL_Y;
         *out_z = TANKER_PORTAL_Z;
         *out_radius = TANKER_PORTAL_RADIUS;
+    } else if (scene_id == SCENE_POO_POO_ISLAND) {
+        *out_x = POO_POO_PORTAL_X;
+        *out_y = POO_POO_PORTAL_Y;
+        *out_z = POO_POO_PORTAL_Z;
+        *out_radius = POO_POO_PORTAL_RADIUS;
     } else {
         *out_x = 0.0f; *out_y = 0.0f; *out_z = 0.0f; *out_radius = 0.0f;
     }
@@ -1250,6 +1396,13 @@ static inline int scene_portal_triggered(PlayerState *p, int *out_portal_id) {
             if (out_portal_id) *out_portal_id = PORTAL_ID_GARAGE_TO_DUST;
             return 1;
         }
+        float dx_poo = p->x - GARAGE_POO_PORTAL_X;
+        float dz_poo = p->z - GARAGE_POO_PORTAL_Z;
+        float dist_sq_poo = dx_poo * dx_poo + dz_poo * dz_poo;
+        if (dist_sq_poo <= (GARAGE_POO_PORTAL_RADIUS * GARAGE_POO_PORTAL_RADIUS)) {
+            if (out_portal_id) *out_portal_id = PORTAL_ID_GARAGE_TO_POO_POO_ISLAND;
+            return 1;
+        }
     }
 
     if (p->scene_id == SCENE_STADIUM) {
@@ -1281,7 +1434,7 @@ static inline int scene_portal_triggered(PlayerState *p, int *out_portal_id) {
         if (out_portal_id) {
             *out_portal_id = (p->scene_id == SCENE_VOXWORLD)
                 ? PORTAL_ID_VOXWORLD_TO_STADIUM
-                : (p->scene_id == SCENE_DUST_COMPOUND ? PORTAL_ID_DUST_TO_GARAGE : (p->scene_id == SCENE_OIL_TANKER ? PORTAL_ID_TANKER_TO_GARAGE : PORTAL_ID_GARAGE_EXIT));
+                : (p->scene_id == SCENE_DUST_COMPOUND ? PORTAL_ID_DUST_TO_GARAGE : (p->scene_id == SCENE_OIL_TANKER ? PORTAL_ID_TANKER_TO_GARAGE : (p->scene_id == SCENE_POO_POO_ISLAND ? PORTAL_ID_POO_POO_ISLAND_TO_GARAGE : PORTAL_ID_GARAGE_EXIT)));
         }
         return 1;
     }
@@ -1639,13 +1792,16 @@ void phys_respawn(PlayerState *p, unsigned int now) {
     p->dash_hit_count = 0;
     p->use_was_down = 0;
     if (p->scene_id != SCENE_GARAGE_OSAKA && p->scene_id != SCENE_STADIUM &&
-        p->scene_id != SCENE_VOXWORLD && p->scene_id != SCENE_DUST_COMPOUND) {
+        p->scene_id != SCENE_VOXWORLD && p->scene_id != SCENE_DUST_COMPOUND && p->scene_id != SCENE_OIL_TANKER && p->scene_id != SCENE_POO_POO_ISLAND) {
         p->scene_id = SCENE_GARAGE_OSAKA;
     }
     scene_spawn_for_player(p, &p->x, &p->y, &p->z);
     p->current_weapon = WPN_MAGNUM;
     for(int i=0; i<MAX_WEAPONS; i++) p->ammo[i] = WPN_STATS[i].ammo_max;
     p->storm_charges = 0;
+    p->sticky_grenades = 1;
+    p->sticky_throw_cooldown = 0;
+    p->grenade_was_down = 0;
     p->ability_cooldown = 0;
     p->portal_cooldown_until_ms = 0;
     p->stunned_until_ms = 0;

--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -5,6 +5,8 @@
 #define MAX_WEAPONS 6
 #define MAX_PROJECTILES 1024
 #define MAX_HELICOPTERS 8
+#define MAX_STICKY_GRENADES 256
+#define MAX_WORLD_PICKUPS 256
 #define LAG_HISTORY 64
 
 #define SCENE_GARAGE_OSAKA 0
@@ -13,6 +15,7 @@
 #define SCENE_DUST_COMPOUND 3
 #define SCENE_CITY 4
 #define SCENE_OIL_TANKER 5
+#define SCENE_POO_POO_ISLAND 6
 
 #define PACKET_CONNECT 0
 #define PACKET_USERCMD 1
@@ -66,6 +69,7 @@ typedef struct {
 #define BTN_USE    16
 #define BTN_ABILITY_1 32
 #define BTN_VEHICLE_2 64
+#define BTN_GRENADE 128
 
 #define VEH_NONE  0
 #define VEH_BUGGY 1
@@ -93,6 +97,49 @@ typedef struct {
     unsigned char scene_id;
 } Projectile;
 
+typedef enum {
+    STICKY_ATTACH_NONE = 0,
+    STICKY_ATTACH_WORLD = 1,
+    STICKY_ATTACH_PLAYER = 2
+} StickyAttachType;
+
+typedef struct {
+    int active;
+    int id;
+    int scene_id;
+    int owner_player_id;
+    float x, y, z;
+    float vx, vy, vz;
+    int attached;
+    unsigned char attach_type;
+    int attach_target_id;
+    float attach_local_x;
+    float attach_local_y;
+    float attach_local_z;
+    float normal_x, normal_y, normal_z;
+    int fuse_ticks;
+    int exploded;
+} StickyGrenadeState;
+
+typedef enum {
+    PICKUP_NONE = 0,
+    PICKUP_HEALTH = 1,
+    PICKUP_STICKY_GRENADE = 2
+} PickupType;
+
+typedef struct {
+    int active;
+    int id;
+    int scene_id;
+    unsigned char type;
+    float x, y, z;
+    float radius;
+    int respawn_ticks;
+    int respawn_delay_ticks;
+    int available;
+    int dropped_by_player_id;
+} WorldPickup;
+
 typedef struct {
     unsigned char id; 
     unsigned char scene_id;
@@ -111,6 +158,7 @@ typedef struct {
     unsigned char storm_charges;
     unsigned short kills;
     unsigned short deaths;
+    unsigned char sticky_grenades;
 } NetPlayer;
 
 typedef struct {
@@ -128,6 +176,25 @@ typedef struct {
     unsigned char health;
     signed char occupant_player_id;
 } NetHelicopter;
+
+typedef struct {
+    unsigned short id;
+    unsigned char scene_id;
+    unsigned char attached;
+    unsigned char attach_type;
+    signed char attach_target_id;
+    unsigned char fuse_ticks;
+    float x, y, z;
+} NetStickyGrenade;
+
+typedef struct {
+    unsigned short id;
+    unsigned char scene_id;
+    unsigned char type;
+    unsigned char available;
+    float x, y, z;
+    float radius;
+} NetWorldPickup;
 
 typedef struct {
     int version;
@@ -177,6 +244,9 @@ typedef struct {
     unsigned int stun_immune_until_ms;
     float run_phase;
     float run_weight;
+    int sticky_grenades;
+    int sticky_throw_cooldown;
+    int grenade_was_down;
 } PlayerState;
 
 typedef struct {
@@ -217,6 +287,8 @@ typedef struct {
     PlayerState players[MAX_CLIENTS];
     Projectile projectiles[MAX_PROJECTILES];
     HelicopterState helicopters[MAX_HELICOPTERS];
+    StickyGrenadeState sticky_grenades[MAX_STICKY_GRENADES];
+    WorldPickup pickups[MAX_WORLD_PICKUPS];
     LagRecord history[MAX_CLIENTS][LAG_HISTORY];
     int server_tick;
     int game_mode;

--- a/packages/simulation/local_game.h
+++ b/packages/simulation/local_game.h
@@ -10,10 +10,21 @@ ServerState local_state;
 int was_holding_jump = 0;
 #define SHANKPIT_HELI_DEBUG 0
 
+#define STICKY_GRENADE_MAX_RESERVE 4
+#define STICKY_GRENADE_FUSE_TICKS 105
+#define STICKY_GRENADE_THROW_COOLDOWN 24
+#define STICKY_GRENADE_THROW_SPEED 2.6f
+#define STICKY_GRENADE_DAMAGE 120
+#define STICKY_GRENADE_RADIUS 10.0f
+#define PICKUP_DEFAULT_RESPAWN_TICKS 900
+
 void local_update(float fwd, float str, float yaw, float pitch, int shoot, int weapon_req, int jump, int crouch, int reload, int ability, void *server_context, unsigned int cmd_time);
 void update_entity(PlayerState *p, float dt, void *server_context, unsigned int cmd_time);
 static inline void heli_spawn_defaults(HelicopterState *h, int id, int scene_id, float x, float y, float z);
 void local_init_match(int num_players, int mode);
+static void apply_projectile_damage(PlayerState *owner, PlayerState *target, int damage, unsigned int now_ms);
+static inline void poo_poo_island_init_pickups(void);
+static inline void sticky_try_throw(PlayerState *p);
 
 float rand_weight() { return ((float)(rand()%2000)/1000.0f) - 1.0f; } 
 float rand_pos() { return ((float)(rand()%1000)/1000.0f); } 
@@ -62,6 +73,9 @@ static inline void scene_load(int scene_id) {
         local_state.helicopters[hi].id = hi;
         local_state.helicopters[hi].occupant_player_id = -1;
     }
+
+    for (int si = 0; si < MAX_STICKY_GRENADES; si++) local_state.sticky_grenades[si].active = 0;
+    if (scene_id == SCENE_POO_POO_ISLAND) poo_poo_island_init_pickups();
 
     if (scene_id == SCENE_VOXWORLD) {
         float red_y = voxworld_heli_spawn_y(VOXWORLD_BASE_RED_X);
@@ -232,8 +246,200 @@ void update_entity(PlayerState *p, float dt, void *server_context, unsigned int 
     if (p->recoil_anim < 0) p->recoil_anim = 0;
     if (p->hit_feedback > 0) p->hit_feedback--;
 
+    sticky_try_throw(p);
     update_weapons(p, local_state.players, local_state.projectiles, p->in_shoot > 0, p->in_reload > 0, p->in_ability > 0);
     scene_safety_check(p);
+}
+
+
+static inline WorldPickup *pickup_spawn(int scene_id, unsigned char type, float x, float y, float z, int respawn_delay_ticks, int dropped_by_player_id) {
+    for (int i = 0; i < MAX_WORLD_PICKUPS; i++) {
+        WorldPickup *w = &local_state.pickups[i];
+        if (w->active) continue;
+        memset(w, 0, sizeof(*w));
+        w->active = 1;
+        w->id = i;
+        w->scene_id = scene_id;
+        w->type = type;
+        w->x = x; w->y = y; w->z = z;
+        w->radius = 3.5f;
+        w->respawn_delay_ticks = respawn_delay_ticks;
+        w->respawn_ticks = 0;
+        w->available = 1;
+        w->dropped_by_player_id = dropped_by_player_id;
+        return w;
+    }
+    return NULL;
+}
+
+static inline void poo_poo_island_init_pickups(void) {
+    for (int i = 0; i < MAX_WORLD_PICKUPS; i++) {
+        WorldPickup *w = &local_state.pickups[i];
+        if (!w->active || w->scene_id != SCENE_POO_POO_ISLAND) continue;
+        w->active = 0;
+    }
+    pickup_spawn(SCENE_POO_POO_ISLAND, PICKUP_STICKY_GRENADE, -675.0f, poo_poo_height_at(-675.0f, 590.0f) + 2.0f, 590.0f, PICKUP_DEFAULT_RESPAWN_TICKS, -1);
+    pickup_spawn(SCENE_POO_POO_ISLAND, PICKUP_STICKY_GRENADE, -220.0f, poo_poo_height_at(-220.0f, 190.0f) + 2.0f, 190.0f, PICKUP_DEFAULT_RESPAWN_TICKS, -1);
+    pickup_spawn(SCENE_POO_POO_ISLAND, PICKUP_STICKY_GRENADE, 540.0f, poo_poo_height_at(540.0f, -420.0f) + 2.0f, -420.0f, PICKUP_DEFAULT_RESPAWN_TICKS, -1);
+    pickup_spawn(SCENE_POO_POO_ISLAND, PICKUP_HEALTH, -920.0f, poo_poo_height_at(-920.0f, 760.0f) + 2.0f, 760.0f, 720, -1);
+    pickup_spawn(SCENE_POO_POO_ISLAND, PICKUP_HEALTH, -430.0f, poo_poo_height_at(-430.0f, 400.0f) + 2.0f, 400.0f, 720, -1);
+    pickup_spawn(SCENE_POO_POO_ISLAND, PICKUP_HEALTH, 130.0f, poo_poo_height_at(130.0f, 420.0f) + 2.0f, 420.0f, 720, -1);
+    pickup_spawn(SCENE_POO_POO_ISLAND, PICKUP_HEALTH, 310.0f, poo_poo_height_at(310.0f, -260.0f) + 2.0f, -260.0f, 720, -1);
+}
+
+static inline void drop_player_inventory_pickups(PlayerState *p) {
+    if (!p || p->sticky_grenades <= 0) return;
+    float gy = phys_sample_ground_height(p->x, p->z, NULL) + 2.0f;
+    pickup_spawn(p->scene_id, PICKUP_STICKY_GRENADE, p->x, gy, p->z, 0, p->id);
+}
+
+static inline int sticky_spawn_from_player(PlayerState *p) {
+    for (int i = 0; i < MAX_STICKY_GRENADES; i++) {
+        StickyGrenadeState *g = &local_state.sticky_grenades[i];
+        if (g->active) continue;
+        memset(g, 0, sizeof(*g));
+        g->active = 1;
+        g->id = i;
+        g->scene_id = p->scene_id;
+        g->owner_player_id = p->id;
+        g->x = p->x;
+        g->y = p->y + EYE_HEIGHT;
+        g->z = p->z;
+        float r = -p->yaw * 0.0174533f; float rp = p->pitch * 0.0174533f;
+        g->vx = sinf(r) * cosf(rp) * STICKY_GRENADE_THROW_SPEED;
+        g->vy = sinf(rp) * STICKY_GRENADE_THROW_SPEED;
+        g->vz = -cosf(r) * cosf(rp) * STICKY_GRENADE_THROW_SPEED;
+        g->normal_y = 1.0f;
+        g->fuse_ticks = STICKY_GRENADE_FUSE_TICKS;
+        return 1;
+    }
+    return 0;
+}
+
+static inline void sticky_try_throw(PlayerState *p) {
+    if (!p || p->state == STATE_DEAD) return;
+    int grenade_pressed = p->in_bike;
+    int grenade_edge = grenade_pressed && !p->grenade_was_down;
+    p->grenade_was_down = grenade_pressed;
+    if (p->sticky_throw_cooldown > 0) p->sticky_throw_cooldown--;
+    if (!grenade_edge) return;
+    if (p->sticky_throw_cooldown > 0 || p->sticky_grenades <= 0) return;
+    if (sticky_spawn_from_player(p)) {
+        p->sticky_grenades--;
+        if (p->sticky_grenades < 0) p->sticky_grenades = 0;
+        p->sticky_throw_cooldown = STICKY_GRENADE_THROW_COOLDOWN;
+    }
+}
+
+static inline void sticky_explode(StickyGrenadeState *g, unsigned int now_ms) {
+    if (!g || !g->active || g->exploded) return;
+    g->exploded = 1;
+    for (int i = 0; i < MAX_CLIENTS; i++) {
+        PlayerState *t = &local_state.players[i];
+        if (!t->active || t->state == STATE_DEAD || t->scene_id != g->scene_id) continue;
+        float dx = t->x - g->x;
+        float dy = (t->y + EYE_HEIGHT * 0.5f) - g->y;
+        float dz = t->z - g->z;
+        float dist = sqrtf(dx*dx + dy*dy + dz*dz);
+        if (dist > STICKY_GRENADE_RADIUS) continue;
+        float falloff = 1.0f - (dist / STICKY_GRENADE_RADIUS);
+        if (falloff < 0.0f) falloff = 0.0f;
+        int damage = (int)(STICKY_GRENADE_DAMAGE * falloff);
+        if (damage < 8) damage = 8;
+        PlayerState *owner = (g->owner_player_id >= 0 && g->owner_player_id < MAX_CLIENTS) ? &local_state.players[g->owner_player_id] : NULL;
+        apply_projectile_damage(owner, t, damage, now_ms);
+        float inv = (dist > 0.001f) ? (1.0f / dist) : 0.0f;
+        float boost = (g->attach_type == STICKY_ATTACH_PLAYER && g->attach_target_id == i) ? 6.8f : 3.6f;
+        t->vx += dx * inv * boost;
+        t->vz += dz * inv * boost;
+        t->vy += 2.4f + falloff * 1.8f;
+    }
+    g->active = 0;
+}
+
+static inline void sticky_update_all(unsigned int now_ms) {
+    for (int i = 0; i < MAX_STICKY_GRENADES; i++) {
+        StickyGrenadeState *g = &local_state.sticky_grenades[i];
+        if (!g->active) continue;
+        if (g->fuse_ticks > 0) g->fuse_ticks--;
+        if (g->attached && g->attach_type == STICKY_ATTACH_PLAYER) {
+            if (g->attach_target_id >= 0 && g->attach_target_id < MAX_CLIENTS) {
+                PlayerState *t = &local_state.players[g->attach_target_id];
+                if (t->active && t->state != STATE_DEAD && t->scene_id == g->scene_id) {
+                    g->x = t->x + g->attach_local_x;
+                    g->y = t->y + g->attach_local_y;
+                    g->z = t->z + g->attach_local_z;
+                } else {
+                    g->attached = 1;
+                    g->attach_type = STICKY_ATTACH_WORLD;
+                }
+            }
+        } else if (!g->attached) {
+            phys_set_scene(g->scene_id);
+            float nx, ny, nz, hx, hy, hz;
+            float nxp = g->x + g->vx;
+            float nyp = g->y + g->vy;
+            float nzp = g->z + g->vz;
+            if (trace_map(g->x, g->y, g->z, nxp, nyp, nzp, &hx, &hy, &hz, &nx, &ny, &nz)) {
+                g->x = hx; g->y = hy; g->z = hz;
+                g->attached = 1;
+                g->attach_type = STICKY_ATTACH_WORLD;
+                g->vx = g->vy = g->vz = 0.0f;
+                g->normal_x = nx; g->normal_y = ny; g->normal_z = nz;
+            } else {
+                g->x = nxp; g->y = nyp; g->z = nzp;
+            }
+            for (int t = 0; t < MAX_CLIENTS && !g->attached; t++) {
+                PlayerState *pl = &local_state.players[t];
+                if (!pl->active || pl->state == STATE_DEAD || pl->scene_id != g->scene_id || t == g->owner_player_id) continue;
+                float dx = pl->x - g->x; float dy = (pl->y + 2.2f) - g->y; float dz = pl->z - g->z;
+                if ((dx*dx + dy*dy + dz*dz) < 6.0f) {
+                    g->attached = 1; g->attach_type = STICKY_ATTACH_PLAYER; g->attach_target_id = t;
+                    g->attach_local_x = g->x - pl->x; g->attach_local_y = g->y - pl->y; g->attach_local_z = g->z - pl->z;
+                    g->vx = g->vy = g->vz = 0.0f;
+                }
+            }
+        }
+        if (g->fuse_ticks <= 0) sticky_explode(g, now_ms);
+    }
+}
+
+static inline void pickup_update_and_collect(void) {
+    for (int i = 0; i < MAX_WORLD_PICKUPS; i++) {
+        WorldPickup *w = &local_state.pickups[i];
+        if (!w->active) continue;
+        if (!w->available) {
+            if (w->respawn_delay_ticks > 0) {
+                w->respawn_ticks++;
+                if (w->respawn_ticks >= w->respawn_delay_ticks) {
+                    w->respawn_ticks = 0;
+                    w->available = 1;
+                }
+            }
+            continue;
+        }
+        for (int pi = 0; pi < MAX_CLIENTS; pi++) {
+            PlayerState *p = &local_state.players[pi];
+            if (!p->active || p->state == STATE_DEAD || p->scene_id != w->scene_id) continue;
+            float dx = p->x - w->x, dz = p->z - w->z;
+            if ((dx * dx + dz * dz) > (w->radius * w->radius)) continue;
+            if (w->type == PICKUP_HEALTH) {
+                if (p->health >= 100) continue;
+                p->health += 35;
+                if (p->health > 100) p->health = 100;
+            } else if (w->type == PICKUP_STICKY_GRENADE) {
+                if (p->sticky_grenades >= STICKY_GRENADE_MAX_RESERVE) continue;
+                p->sticky_grenades++;
+            }
+            if (w->respawn_delay_ticks > 0) {
+                w->available = 0;
+                w->respawn_ticks = 0;
+            } else {
+                w->active = 0;
+            }
+            break;
+        }
+    }
 }
 
 static void apply_projectile_damage(PlayerState *owner, PlayerState *target, int damage, unsigned int now_ms) {
@@ -247,6 +453,7 @@ static void apply_projectile_damage(PlayerState *owner, PlayerState *target, int
     if (target->health <= 0) {
         if (owner) { owner->kills++; owner->accumulated_reward += 500.0f; }
         target->deaths++;
+        drop_player_inventory_pickups(target);
         phys_respawn(target, now_ms);
     }
 
@@ -399,6 +606,8 @@ void local_update(float fwd, float str, float yaw, float pitch, int shoot, int w
         update_entity(p, 0.016f, server_context, cmd_time);
     }
     update_projectiles(cmd_time);
+    sticky_update_all(cmd_time);
+    pickup_update_and_collect();
 }
 
 void local_init_match(int num_players, int mode) {


### PR DESCRIPTION
### Motivation
- Implement Halo-style sticky grenades (inventory, throw, attach, fuse, explosion impulse) and make them a world-playable resource rather than a toy prototype. 
- Add a server-authoritative world pickup system (health + sticky grenades) with authored spawn anchors and death-drop behavior so items persist in the world. 
- Add a new explorable destination scene `SCENE_POO_POO_ISLAND` and wire portals/terrain/spawn logic so the new gameplay systems are actually exercised in-world.

### Description
- Protocol and shared state: added `MAX_STICKY_GRENADES`, `MAX_WORLD_PICKUPS`, `SCENE_POO_POO_ISLAND`, `BTN_GRENADE`, sticky/pickup structs, net mirror structs (`NetStickyGrenade`, `NetWorldPickup`), and per-player sticky reserve fields in `packages/common/protocol.h` so state can be replicated. 
- Scene/physics: added Poo Poo Island terrain and authored geo helpers, spawn anchors, safety bounds, portal constants and portal routing (garage <-> Poo Poo) and scene dispatch wiring in `packages/common/physics.h`. 
- Gameplay simulation: implemented server-side sticky grenade lifecycle and world pickups in `packages/simulation/local_game.h` (spawn from player, movement without bouncing, attach-to-world/player, fuse countdown, `sticky_explode()` radial damage + impulse, pickup spawn/collect/respawn, death drop). Integrated sticky + pickup updates into server tick and local sim loops. 
- Netcode/server: extended snapshot composition in `apps/server/src/main.c` to include player sticky reserve and to stream sticky grenade + pickup entity lists (`sticky_count`/`pickup_count`) per-scene; server runs authoritative `sticky_update_all()` and `pickup_update_and_collect()`. 
- Client/UI: added grenade input mapping (`G`) to `client_create_cmd`, mapped it through `packages/common/net_sim.h`, parsed sticky/pickup streams in `apps/lobby/src/main.c`, added HUD pips for sticky reserve, and simple rendering for sticky projectiles and world pickups plus garage portal UI for the new island. 

### Testing
- Built the server successfully with `make server` (server binary compiles and server-side simulation code including sticky/pickups was built). 
- Attempted full client+server build with `make -j4` but the lobby/client build failed in this environment due to missing SDL2/OpenGL development headers (`SDL2/SDL.h`, `SDL2/SDL_opengl.h`), so visual/runtime client verification could not be performed here. 
- No automated unit tests were added; integration validated by compiling the server and inspecting snapshot serialization and server tick wiring (`sticky_update_all` / `pickup_update_and_collect`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de8469f39c83279e1fce077bacecaf)