### PR TITLE
Update CHANGELOG.md with recent April gameplay and skin updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Recent changes
 
+### 2026-04-15
+- Polished TAB scoreboard readability with improved row layout and slightly increased row spacing for easier scanning during matches (`76f1945`, `33e783a`, merged in #159).
+
+### 2026-04-14
+- Expanded lobby customization with two new selectable character skins, **Genie** and **Wanderer** (`64cff5a`, merged in #158).
+- Renamed the previous POC skin option to **BILL** for clearer in-game skin naming (`c0d2098`, merged in #156).
+
+### 2026-04-13
+- Added **pirate** and **ninja** character skins to the lobby skin lineup (`06300d0`, merged in #154).
+
+### 2026-04-12
+- Added the **CYBORG** player skin and integrated it into the skin selector (`ab38202`, merged in #135).
+- Added a deterministic Voxworld bush foliage pass to improve scene dressing consistency (`127bdde`, merged in #136).
+
 ### 2026-04-12
 - Added Voxworld helicopter gameplay support, including scene-aware network replication and rooftop spawn pads with stair access for better traversal and vehicle flow (`d26454f`, `a9f5a30`, merged in #132).
 - Added a VS0 skin selector with Bat/Mayrice rendering options to expand in-game visual customization (`072e4ce`, #130).


### PR DESCRIPTION
### Motivation
- Make the project release notes complete and up to date by documenting recent scoreboard, skin, foliage, and scene changes observed in the repository history.

### Description
- Inserted new top-of-file entries for `2026-04-15`, `2026-04-14`, and `2026-04-13`, and added missing `2026-04-12` notes for the `CYBORG` skin and deterministic Voxworld foliage in `CHANGELOG.md`.
- Saved and committed the documentation change on the current branch with the commit message `Update changelog with latest April gameplay and skin updates`.

### Testing
- Confirmed the updated `CHANGELOG.md` contents with `sed -n '1,260p' CHANGELOG.md` and `nl -ba CHANGELOG.md`, which showed the new entries at the top.
- Verified the commit succeeded via `git commit` which reported one file changed and 14 insertions, and `git status --short` returned a clean state.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfaf0adf448327808c6abf0377c3ea)