### PR TITLE
Add TDMO online team-deathmatch mode with server bot-fill and snapshot support

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -144,6 +144,7 @@ static void draw_box(float w, float h, float d);
 
 int sock = -1;
 struct sockaddr_in server_addr;
+static int net_requested_mode = MODE_DEATHMATCH;
 
 #define NET_CMD_HISTORY 3
 #define CLIENT_USERCMD_HZ 60
@@ -418,6 +419,7 @@ void draw_string(const char* str, float x, float y, float size) {
 
 typedef enum {
     LOBBY_JOIN = 0,
+    LOBBY_TDMO,
     LOBBY_SOLO,
     LOBBY_BATTLE,
     LOBBY_TDMB,
@@ -429,6 +431,7 @@ char lobby_labels_mutable[LOBBY_COUNT][64];
 
 static const char *LOBBY_LABELS[LOBBY_COUNT] = {
     "JOIN",
+    "TDMO",
     "SOLO",
     "BATTLE (BOTS)",
     "TDMB",
@@ -545,6 +548,14 @@ static void lobby_apply_ui_state() {
     if (strcmp(ui_state.active_mode_id, "mode.join") == 0) {
         app_state = STATE_GAME_NET;
         reset_client_render_state_for_net();
+        net_requested_mode = MODE_DEATHMATCH;
+        net_connect();
+        return;
+    }
+    if (strcmp(ui_state.active_mode_id, "mode.tdmo") == 0) {
+        app_state = STATE_GAME_NET;
+        reset_client_render_state_for_net();
+        net_requested_mode = MODE_TDMO;
         net_connect();
         return;
     }
@@ -609,6 +620,12 @@ static void lobby_start_action(int action) {
     if (action == LOBBY_JOIN) {
         app_state = STATE_GAME_NET;
         reset_client_render_state_for_net();
+        net_requested_mode = MODE_DEATHMATCH;
+        net_connect();
+    } else if (action == LOBBY_TDMO) {
+        app_state = STATE_GAME_NET;
+        reset_client_render_state_for_net();
+        net_requested_mode = MODE_TDMO;
         net_connect();
     } else {
         app_state = STATE_GAME_LOCAL;
@@ -1827,7 +1844,7 @@ void draw_player_3rd(PlayerState *p) {
         draw_buggy_model(p);
     } else {
         int forced_skin = -1;
-        if (local_state.game_mode == MODE_TDMB) {
+        if (local_state.game_mode == MODE_TDMB || local_state.game_mode == MODE_TDMO) {
             forced_skin = (p->team_id == 1) ? SKIN_NINJA : SKIN_PIRATE;
         }
         int draw_skin = (forced_skin >= 0) ? forced_skin : clamp_skin_id(g_selected_skin);
@@ -1978,7 +1995,7 @@ void draw_hud(PlayerState *p) {
     }
 
 
-    if (local_state.game_mode == MODE_TDMB) {
+    if (local_state.game_mode == MODE_TDMB || local_state.game_mode == MODE_TDMO) {
         char score_buf[96];
         snprintf(score_buf, sizeof(score_buf), "BLUE %d  -  %d RED", local_state.team_scores[1], local_state.team_scores[0]);
         glColor3f(0.40f, 0.75f, 1.0f);
@@ -2075,7 +2092,7 @@ static int score_row_cmp_desc(const void *a, const void *b) {
 }
 
 static int mode_uses_team_scoreboard(int mode) {
-    return mode == MODE_TDM || mode == MODE_TDMB || mode == MODE_CTF;
+    return mode == MODE_TDM || mode == MODE_TDMB || mode == MODE_TDMO || mode == MODE_CTF;
 }
 
 static int is_valid_scoreboard_team_id(int team_id) {
@@ -2085,7 +2102,7 @@ static int is_valid_scoreboard_team_id(int team_id) {
 static void scoreboard_team_totals(int mode, int *out_blue, int *out_red) {
     int blue = 0;
     int red = 0;
-    if (mode == MODE_TDMB) {
+    if (mode == MODE_TDMB || mode == MODE_TDMO) {
         blue = local_state.team_scores[TDMB_BLUE_TEAM];
         red = local_state.team_scores[TDMB_RED_TEAM];
     } else {
@@ -2521,7 +2538,7 @@ static void draw_travel_overlay() {
 
 
 static void draw_tdmb_match_over_overlay(void) {
-    if (local_state.game_mode != MODE_TDMB || !local_state.match_over) return;
+    if ((local_state.game_mode != MODE_TDMB && local_state.game_mode != MODE_TDMO) || !local_state.match_over) return;
     glDisable(GL_DEPTH_TEST);
     glMatrixMode(GL_PROJECTION); glPushMatrix(); glLoadIdentity(); gluOrtho2D(0, 1280, 0, 720);
     glMatrixMode(GL_MODELVIEW); glPushMatrix(); glLoadIdentity();
@@ -2598,7 +2615,7 @@ void draw_scene(PlayerState *render_p) {
     draw_terrain();
     draw_voxworld_bushes();
     draw_map();
-    if (local_state.game_mode == MODE_TDMB && local_state.scene_id == SCENE_VOXWORLD) {
+    if ((local_state.game_mode == MODE_TDMB || local_state.game_mode == MODE_TDMO) && local_state.scene_id == SCENE_VOXWORLD) {
         float ry = voxworld_height_at(VOXWORLD_BASE_RED_X, VOXWORLD_BASE_Z) + 9.0f;
         float by = voxworld_height_at(VOXWORLD_BASE_BLUE_X, VOXWORLD_BASE_Z) + 9.0f;
         glColor3f(1.0f, 0.25f, 0.25f);
@@ -2916,6 +2933,7 @@ void net_shutdown() {
 
 void net_connect() {
     if (sock < 0) net_init();
+    local_state.game_mode = net_requested_mode;
     struct hostent *he = gethostbyname(SERVER_HOST);
     if (he) {
         server_addr.sin_family = AF_INET; 
@@ -2923,9 +2941,11 @@ void net_connect() {
         memcpy(&server_addr.sin_addr, he->h_addr_list[0], he->h_length);
         char buffer[128];
         NetHeader *h = (NetHeader*)buffer;
+        memset(buffer, 0, sizeof(buffer));
         h->type = PACKET_CONNECT;
         h->scene_id = 0;
-        sendto(sock, buffer, sizeof(NetHeader), 0, (struct sockaddr*)&server_addr, sizeof(server_addr));
+        buffer[sizeof(NetHeader)] = (unsigned char)(net_requested_mode & 0xFF);
+        sendto(sock, buffer, sizeof(NetHeader) + 1, 0, (struct sockaddr*)&server_addr, sizeof(server_addr));
         printf("Connected to %s...\n", SERVER_HOST);
     } else {
         printf("Failed to resolve %s\n", SERVER_HOST);
@@ -3247,6 +3267,8 @@ void net_process_snapshot(char *buffer, int len) {
         }
 
         p->state = np->state;
+        p->is_bot = np->is_bot ? 1 : 0;
+        p->team_id = np->team_id;
         p->health = np->health;
         p->shield = np->shield;
         p->crouching = np->crouching;
@@ -3446,6 +3468,9 @@ void net_tick() {
             }
 
             printf("[NET] WELCOME my_client_id=%d net_local_pid=%d\n", my_client_id, net_local_pid);
+            if (len >= (int)sizeof(NetHeader) + 1) {
+                local_state.game_mode = (unsigned char)buffer[sizeof(NetHeader)];
+            }
             printf("✅ JOINED SERVER AS CLIENT ID: %d\n", my_client_id);
         }
     }
@@ -3626,8 +3651,8 @@ int main(int argc, char* argv[]) {
                 }
             } else {
                 if (e.type == SDL_KEYDOWN) {
-                    if (local_state.game_mode == MODE_TDMB && local_state.match_over && e.key.keysym.sym == SDLK_r) {
-                        local_init_match(12, MODE_TDMB);
+                    if ((local_state.game_mode == MODE_TDMB || local_state.game_mode == MODE_TDMO) && local_state.match_over && e.key.keysym.sym == SDLK_r) {
+                        local_init_match(12, local_state.game_mode);
                     } else if (e.key.keysym.sym == SDLK_ESCAPE) {
                         if (app_state == STATE_GAME_NET) net_shutdown();
                         app_state = STATE_LOBBY;

--- a/apps/server/src/main.c
+++ b/apps/server/src/main.c
@@ -58,11 +58,14 @@ static RecorderState recorder = {0};
 #define SERVER_SNAPSHOT_INTERVAL_TICKS 3
 #define SERVER_DM_FRAG_LIMIT 25
 #define SERVER_DM_ROUND_MS (6 * 60 * 1000)
+#define TDMO_TEAM_SIZE 6
+#define TDMO_SCORE_LIMIT 25
 
 static const int g_dm_rotation[] = { SCENE_STADIUM, SCENE_VOXWORLD, SCENE_OIL_TANKER };
 static int g_dm_rotation_idx = 0;
 static int g_server_match_scene = SCENE_GARAGE_OSAKA;
 static unsigned int g_round_start_ms = 0;
+static int g_tdmo_tie_breaker = 0;
 
 #define RECORDER_SHAKE_POS 0.08f
 #define RECORDER_SHAKE_ANGLE 0.35f
@@ -118,6 +121,115 @@ static int addr_equal(const struct sockaddr_in *a, const struct sockaddr_in *b) 
     return a->sin_addr.s_addr == b->sin_addr.s_addr && a->sin_port == b->sin_port;
 }
 
+static int server_team_mode_enabled(int mode) {
+    return mode == MODE_TDM || mode == MODE_TDMB || mode == MODE_TDMO || mode == MODE_CTF;
+}
+
+static int tdmo_bot_slot_available(int slot) {
+    return slot > 0 && slot < MAX_CLIENTS && !slots[slot].active && !local_state.players[slot].active;
+}
+
+static int tdmo_find_free_bot_slot(void) {
+    for (int i = MAX_CLIENTS - 1; i >= 1; i--) {
+        if (tdmo_bot_slot_available(i)) return i;
+    }
+    return -1;
+}
+
+static int tdmo_human_count_on_team(int team_id) {
+    int count = 0;
+    for (int i = 1; i < MAX_CLIENTS; i++) {
+        if (!slots[i].active || !slots[i].welcomed) continue;
+        PlayerState *p = &local_state.players[i];
+        if (!p->active || p->is_bot) continue;
+        if (p->team_id == team_id) count++;
+    }
+    return count;
+}
+
+static int tdmo_total_count_on_team(int team_id) {
+    int count = 0;
+    for (int i = 1; i < MAX_CLIENTS; i++) {
+        PlayerState *p = &local_state.players[i];
+        if (!p->active) continue;
+        if (p->team_id == team_id) count++;
+    }
+    return count;
+}
+
+static int tdmo_choose_join_team(void) {
+    int blue_humans = tdmo_human_count_on_team(TDMB_BLUE_TEAM);
+    int red_humans = tdmo_human_count_on_team(TDMB_RED_TEAM);
+    if (blue_humans != red_humans) {
+        return (blue_humans < red_humans) ? TDMB_BLUE_TEAM : TDMB_RED_TEAM;
+    }
+    int blue_total = tdmo_total_count_on_team(TDMB_BLUE_TEAM);
+    int red_total = tdmo_total_count_on_team(TDMB_RED_TEAM);
+    if (blue_total != red_total) {
+        return (blue_total < red_total) ? TDMB_BLUE_TEAM : TDMB_RED_TEAM;
+    }
+    int team = (g_tdmo_tie_breaker++ & 1) ? TDMB_RED_TEAM : TDMB_BLUE_TEAM;
+    return team;
+}
+
+static int tdmo_remove_one_bot_from_team(int team_id) {
+    for (int i = MAX_CLIENTS - 1; i >= 1; i--) {
+        PlayerState *p = &local_state.players[i];
+        if (!p->active || !p->is_bot || p->team_id != team_id) continue;
+        memset(p, 0, sizeof(*p));
+        p->id = i;
+        p->team_id = -1;
+        return 1;
+    }
+    return 0;
+}
+
+static int tdmo_spawn_bot_on_team(int team_id, unsigned int now_ms) {
+    int slot = tdmo_find_free_bot_slot();
+    if (slot == -1) return 0;
+    PlayerState *p = &local_state.players[slot];
+    memset(p, 0, sizeof(*p));
+    p->id = slot;
+    p->active = 1;
+    p->is_bot = 1;
+    p->team_id = team_id;
+    p->scene_id = g_server_match_scene;
+    p->state = STATE_ALIVE;
+    p->health = 100;
+    p->shield = 100;
+    p->current_weapon = WPN_AR;
+    p->ammo[WPN_AR] = WPN_STATS[WPN_AR].ammo_max;
+    init_genome(&p->brain);
+    phys_respawn(p, now_ms);
+    return 1;
+}
+
+static void tdmo_fill_team_to_target(int team_id, unsigned int now_ms) {
+    while (tdmo_total_count_on_team(team_id) < TDMO_TEAM_SIZE) {
+        if (!tdmo_spawn_bot_on_team(team_id, now_ms)) break;
+    }
+}
+
+static void tdmo_ensure_population(unsigned int now_ms) {
+    tdmo_fill_team_to_target(TDMB_BLUE_TEAM, now_ms);
+    tdmo_fill_team_to_target(TDMB_RED_TEAM, now_ms);
+}
+
+static void tdmo_activate_match(unsigned int now_ms) {
+    local_init_match(1, MODE_TDMO);
+    g_server_match_scene = SCENE_VOXWORLD;
+    scene_load(g_server_match_scene);
+    local_state.game_mode = MODE_TDMO;
+    local_state.score_limit = TDMO_SCORE_LIMIT;
+    local_state.team_scores[TDMB_BLUE_TEAM] = 0;
+    local_state.team_scores[TDMB_RED_TEAM] = 0;
+    local_state.match_over = 0;
+    local_state.winning_team = -1;
+    local_state.players[0].active = 0;
+    g_tdmo_tie_breaker = 0;
+    tdmo_ensure_population(now_ms);
+}
+
 static int find_slot_by_addr(const struct sockaddr_in *addr) {
     for (int i = 1; i < MAX_CLIENTS; i++) {
         if (slots[i].active && addr_equal(&slots[i].addr, addr)) {
@@ -158,6 +270,8 @@ static int alloc_slot(const struct sockaddr_in *addr) {
 
 static void free_slot(int slot) {
     if (slot <= 0 || slot >= MAX_CLIENTS) return;
+    int was_human = local_state.players[slot].active && !local_state.players[slot].is_bot;
+    int prev_team = local_state.players[slot].team_id;
     for (int i = 0; i < MAX_HELICOPTERS; i++) {
         if (local_state.helicopters[i].active && local_state.helicopters[i].occupant_player_id == slot) {
             local_state.helicopters[i].occupant_player_id = -1;
@@ -170,6 +284,10 @@ static void free_slot(int slot) {
     slots[slot].last_heard = 0.0;
     slots[slot].player_id = -1;
     server_disconnect(slot, client_last_seq);
+    if (local_state.game_mode == MODE_TDMO && was_human && team_id_is_valid(prev_team)) {
+        tdmo_spawn_bot_on_team(prev_team, get_server_time());
+        tdmo_ensure_population(get_server_time());
+    }
 }
 
 static HelicopterState *server_find_nearby_heli(int scene_id, float x, float y, float z, float radius) {
@@ -204,14 +322,16 @@ static int server_try_exit_heli(PlayerState *p, HelicopterState *h) {
 
 static void send_welcome(const struct sockaddr_in *addr, int client_id) {
     unsigned int now = get_server_time();
-    NetHeader h;
-    h.type = PACKET_WELCOME;
-    h.client_id = (unsigned char)client_id;
-    h.sequence = 0;
-    h.timestamp = now;
-    h.entity_count = 0;
-    h.scene_id = (unsigned char)local_state.players[client_id].scene_id;
-    sendto(sock, (char*)&h, sizeof(NetHeader), 0,
+    char packet[sizeof(NetHeader) + 1];
+    NetHeader *h = (NetHeader*)packet;
+    h->type = PACKET_WELCOME;
+    h->client_id = (unsigned char)client_id;
+    h->sequence = 0;
+    h->timestamp = now;
+    h->entity_count = 0;
+    h->scene_id = (unsigned char)local_state.players[client_id].scene_id;
+    packet[sizeof(NetHeader)] = (unsigned char)(local_state.game_mode & 0xFF);
+    sendto(sock, packet, sizeof(packet), 0,
            (const struct sockaddr*)addr, sizeof(struct sockaddr_in));
     if (client_id > 0 && client_id < MAX_CLIENTS) {
         slots[client_id].welcomed = 1;
@@ -346,6 +466,8 @@ int parse_server_mode(int argc, char **argv) {
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--tdm") == 0) {
             mode = MODE_TDM;
+        } else if (strcmp(argv[i], "--tdmo") == 0) {
+            mode = MODE_TDMO;
         } else if (strcmp(argv[i], "--deathmatch") == 0) {
             mode = MODE_DEATHMATCH;
         }
@@ -393,8 +515,33 @@ void server_handle_packet(struct sockaddr_in *sender, char *buffer, int size) {
     if (client_id == -1) return;
 
     if (head->type == PACKET_CONNECT) {
+        int requested_mode = MODE_DEATHMATCH;
+        if (size >= (int)sizeof(NetHeader) + 1) {
+            requested_mode = (unsigned char)buffer[sizeof(NetHeader)];
+        }
+        if (requested_mode == MODE_TDMO && local_state.game_mode != MODE_TDMO) {
+            tdmo_activate_match(get_server_time());
+        }
         PlayerState *p = &local_state.players[client_id];
         client_last_seq[client_id] = 0;
+        if (local_state.game_mode == MODE_TDMO) {
+            int team = tdmo_choose_join_team();
+            tdmo_remove_one_bot_from_team(team);
+            memset(p, 0, sizeof(*p));
+            p->id = client_id;
+            p->active = 1;
+            p->is_bot = 0;
+            p->team_id = team;
+            p->scene_id = g_server_match_scene;
+            p->state = STATE_ALIVE;
+            p->health = 100;
+            p->shield = 100;
+            p->current_weapon = WPN_MAGNUM;
+            p->ammo[WPN_MAGNUM] = WPN_STATS[WPN_MAGNUM].ammo_max;
+            phys_respawn(p, get_server_time());
+            local_state.client_meta[client_id].active = 1;
+            tdmo_ensure_population(get_server_time());
+        }
         p->in_fwd = 0.0f;
         p->in_strafe = 0.0f;
         p->in_jump = 0;
@@ -431,8 +578,10 @@ void server_handle_packet(struct sockaddr_in *sender, char *buffer, int size) {
             slots[client_id].last_heard = now_seconds();
             local_state.client_meta[client_id].last_heard_ms = get_server_time();
             slots[client_id].cmd_seen = 1;
-            local_state.players[client_id].active = slots[client_id].welcomed && slots[client_id].cmd_seen;
-            local_state.client_meta[client_id].active = local_state.players[client_id].active;
+            if (local_state.game_mode != MODE_TDMO) {
+                local_state.players[client_id].active = slots[client_id].welcomed && slots[client_id].cmd_seen;
+                local_state.client_meta[client_id].active = local_state.players[client_id].active;
+            }
         }
     }
 }
@@ -446,9 +595,13 @@ void server_broadcast() {
         unsigned char count = 0;
 
         for (int pi = 1; pi < MAX_CLIENTS; pi++) {
-            if (!(slots[pi].active && slots[pi].welcomed && slots[pi].cmd_seen)) continue;
-            if (!local_state.players[pi].active) continue;
-            if (local_state.players[pi].scene_id != recipient_scene) continue;
+            PlayerState *p = &local_state.players[pi];
+            if (!p->active || p->scene_id != recipient_scene) continue;
+            if (p->is_bot) {
+                count++;
+                continue;
+            }
+            if (!(slots[pi].active && slots[pi].welcomed)) continue;
             count++;
         }
 
@@ -465,13 +618,15 @@ void server_broadcast() {
 
         for (int pi = 1; pi < MAX_CLIENTS; pi++) {
             PlayerState *p = &local_state.players[pi];
-            if (!(slots[pi].active && slots[pi].welcomed && slots[pi].cmd_seen && p->active)) continue;
-            if (p->scene_id != recipient_scene) continue;
+            if (!p->active || p->scene_id != recipient_scene) continue;
+            if (!p->is_bot && !(slots[pi].active && slots[pi].welcomed)) continue;
 
             if (cursor + (int)sizeof(NetPlayer) + 1 > (int)sizeof(buffer)) break;
             NetPlayer np;
             np.id = (unsigned char)pi;
             np.scene_id = (unsigned char)p->scene_id;
+            np.is_bot = (unsigned char)(p->is_bot ? 1 : 0);
+            np.team_id = (signed char)p->team_id;
             np.last_seq = client_last_seq[pi];
             np.x = p->x; np.y = p->y; np.z = p->z;
             np.yaw = norm_yaw_deg(p->yaw); np.pitch = clamp_pitch_deg(p->pitch);
@@ -554,7 +709,9 @@ int main(int argc, char *argv[]) {
     server_net_init();
     int mode = parse_server_mode(argc, argv);
     local_init_match(1, mode);
-    if (mode == MODE_DEATHMATCH || mode == MODE_TDM) {
+    if (mode == MODE_TDMO) {
+        tdmo_activate_match(get_server_time());
+    } else if (mode == MODE_DEATHMATCH || mode == MODE_TDM) {
         g_server_match_scene = g_dm_rotation[g_dm_rotation_idx];
         scene_load(g_server_match_scene);
         g_round_start_ms = get_server_time();
@@ -567,7 +724,13 @@ int main(int argc, char *argv[]) {
     local_state.players[0].active = 0;
     local_state.players[0].health = 0;
     local_state.players[0].state = STATE_DEAD;
-    printf("SERVER MODE: %s\n", mode == MODE_TDM ? "TEAM DEATHMATCH" : "DEATHMATCH");
+    if (mode == MODE_TDM) {
+        printf("SERVER MODE: TEAM DEATHMATCH\n");
+    } else if (mode == MODE_TDMO) {
+        printf("SERVER MODE: ONLINE TEAM DEATHMATCH (TDMO)\n");
+    } else {
+        printf("SERVER MODE: DEATHMATCH\n");
+    }
 
     int running = 1;
     unsigned int tick = 0;
@@ -584,6 +747,9 @@ int main(int argc, char *argv[]) {
         }
 
         unsigned int now = get_server_time();
+        if (local_state.game_mode == MODE_TDMO) {
+            tdmo_ensure_population(now);
+        }
         // TIMEOUT_SWEEP
         for (int i = 1; i < MAX_CLIENTS; i++) {
             if (slots[i].active && now_seconds() - slots[i].last_heard > 5.0) {
@@ -595,6 +761,27 @@ int main(int argc, char *argv[]) {
 
         for(int i=0; i<MAX_CLIENTS; i++) {
             PlayerState *p = &local_state.players[i];
+
+            if (local_state.game_mode == MODE_TDMO && p->active && p->is_bot && p->state != STATE_DEAD) {
+                float b_fwd = 0.0f;
+                float b_yaw = p->yaw;
+                int b_btns = 0;
+                bot_think(i, local_state.players, &b_fwd, &b_yaw, &b_btns);
+                p->yaw = b_yaw;
+                float brad = b_yaw * 3.14159f / 180.0f;
+                float bx = sinf(brad) * b_fwd;
+                float bz = cosf(brad) * b_fwd;
+                accelerate(p, bx, bz, MAX_SPEED, ACCEL);
+                p->in_shoot = (b_btns & BTN_ATTACK) ? 1 : 0;
+                p->in_jump = (b_btns & BTN_JUMP) ? 1 : 0;
+                p->in_reload = (b_btns & BTN_RELOAD) ? 1 : 0;
+                p->crouching = (b_btns & BTN_CROUCH) ? 1 : 0;
+                p->in_ability = 0;
+                if (p->in_jump && p->on_ground) {
+                    p->y += 0.1f;
+                    p->vy += JUMP_FORCE;
+                }
+            }
 
             if (i > 0 && p->active && p->state == STATE_DEAD) {
                 if (local_state.game_mode != MODE_SURVIVAL && now > p->respawn_time) {
@@ -686,7 +873,7 @@ int main(int argc, char *argv[]) {
             }
         }
 
-        if ((mode == MODE_DEATHMATCH || mode == MODE_TDM) && server_scene_is_dm_map(g_server_match_scene)) {
+        if ((local_state.game_mode == MODE_DEATHMATCH || local_state.game_mode == MODE_TDM) && server_scene_is_dm_map(g_server_match_scene)) {
             int top_frags = 0;
             for (int i = 1; i < MAX_CLIENTS; i++) {
                 PlayerState *p = &local_state.players[i];
@@ -699,6 +886,23 @@ int main(int argc, char *argv[]) {
         }
 
         update_projectiles(now);
+        if (server_team_mode_enabled(local_state.game_mode)) {
+            for (int i = 0; i < MAX_CLIENTS; i++) {
+                PlayerState *pp = &local_state.players[i];
+                int prev = tdmb_last_kills[i];
+                if (pp->kills > prev && team_id_is_valid(pp->team_id)) {
+                    int delta = pp->kills - prev;
+                    local_state.team_scores[pp->team_id] += delta;
+                    if (!local_state.match_over &&
+                        local_state.score_limit > 0 &&
+                        local_state.team_scores[pp->team_id] >= local_state.score_limit) {
+                        local_state.match_over = 1;
+                        local_state.winning_team = pp->team_id;
+                    }
+                }
+                tdmb_last_kills[i] = pp->kills;
+            }
+        }
         recorder_write_frame(tick, now);
         if ((tick % SERVER_SNAPSHOT_INTERVAL_TICKS) == 0) {
             server_broadcast();

--- a/apps/server/src/server_mode.c
+++ b/apps/server/src/server_mode.c
@@ -11,6 +11,8 @@ int parse_server_mode(int argc, char **argv) {
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--tdm") == 0) {
             mode = MODE_TDM;
+        } else if (strcmp(argv[i], "--tdmo") == 0) {
+            mode = MODE_TDMO;
         } else if (strcmp(argv[i], "--deathmatch") == 0) {
             mode = MODE_DEATHMATCH;
         }

--- a/apps/tests/test_netcode.c
+++ b/apps/tests/test_netcode.c
@@ -59,7 +59,9 @@ void test_handshake_enums() {
     // Verify differentiation
     ASSERT_TRUE(PACKET_CONNECT != PACKET_USERCMD, "Connect != UserCmd");
     ASSERT_TRUE(PACKET_DISCONNECT != PACKET_USERCMD, "Disconnect != UserCmd");
+    ASSERT_EQ(MODE_TDMO, 102, "TDMO mode enum is stable");
 }
+
 
 void test_simulation_delta() {
     printf("--- Testing Delta Time Limits ---\n");
@@ -113,6 +115,10 @@ void test_scene_fields() {
     NetPlayer np;
     np.scene_id = SCENE_STADIUM;
     ASSERT_EQ(np.scene_id, SCENE_STADIUM, "NetPlayer stores scene_id");
+    np.is_bot = 1;
+    np.team_id = 1;
+    ASSERT_EQ(np.is_bot, 1, "NetPlayer stores bot identity");
+    ASSERT_EQ(np.team_id, 1, "NetPlayer stores team identity");
 }
 
 void test_katana_contract() {

--- a/apps/tests/test_server_mode.c
+++ b/apps/tests/test_server_mode.c
@@ -32,11 +32,19 @@ static void test_tdm_mode(void) {
     ASSERT_EQ(parse_server_mode(2, args), MODE_TDM, "TDM flag sets team deathmatch");
 }
 
+static void test_tdmo_mode(void) {
+    printf("--- Testing TDMO Server Mode ---\n");
+    char *args[] = { "server", "--tdmo" };
+    ASSERT_EQ(parse_server_mode(2, args), MODE_TDMO, "TDMO flag sets online team deathmatch");
+}
+
 int parse_server_mode(int argc, char **argv) {
     int mode = MODE_DEATHMATCH;
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--tdm") == 0) {
             mode = MODE_TDM;
+        } else if (strcmp(argv[i], "--tdmo") == 0) {
+            mode = MODE_TDMO;
         } else if (strcmp(argv[i], "--deathmatch") == 0) {
             mode = MODE_DEATHMATCH;
         }
@@ -48,6 +56,7 @@ int main(void) {
     printf("🛡️ SHANKPIT SERVER MODE CHECK 🛡️\n");
     test_default_mode();
     test_tdm_mode();
+    test_tdmo_mode();
     printf("\n--------------------------------------\n");
     printf("SUMMARY: %d/%d Tests Passed.\n", tests_passed, tests_run);
     return (tests_passed == tests_run) ? 0 : 1;

--- a/packages/common/physics.h
+++ b/packages/common/physics.h
@@ -329,7 +329,7 @@ float phys_rand_f() { return ((float)(rand()%1000)/500.0f) - 1.0f; }
 
 static int g_phys_game_mode = MODE_DEATHMATCH;
 static inline int phys_team_mode_enabled(void) {
-    return g_phys_game_mode == MODE_TDM || g_phys_game_mode == MODE_CTF || g_phys_game_mode == MODE_TDMB;
+    return g_phys_game_mode == MODE_TDM || g_phys_game_mode == MODE_CTF || g_phys_game_mode == MODE_TDMB || g_phys_game_mode == MODE_TDMO;
 }
 
 static inline int phys_is_friendly(const PlayerState *a, const PlayerState *b) {

--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -96,6 +96,8 @@ typedef struct {
 typedef struct {
     unsigned char id; 
     unsigned char scene_id;
+    unsigned char is_bot;
+    signed char team_id;
     unsigned int last_seq;
     float x, y, z; float yaw, pitch;
     unsigned char current_weapon;
@@ -211,7 +213,7 @@ typedef struct {
     HeliInputState input;
 } HelicopterState;
 
-typedef enum { MODE_DEATHMATCH=0, MODE_TDM=1, MODE_SURVIVAL=2, MODE_CTF=3, MODE_ODDBALL=4, MODE_LOCAL=98, MODE_NET=99, MODE_EVOLUTION=100, MODE_TDMB=101 } GameMode;
+typedef enum { MODE_DEATHMATCH=0, MODE_TDM=1, MODE_SURVIVAL=2, MODE_CTF=3, MODE_ODDBALL=4, MODE_LOCAL=98, MODE_NET=99, MODE_EVOLUTION=100, MODE_TDMB=101, MODE_TDMO=102 } GameMode;
 
 typedef struct {
     PlayerState players[MAX_CLIENTS];

--- a/packages/simulation/local_game.h
+++ b/packages/simulation/local_game.h
@@ -17,7 +17,7 @@ static int tdmb_last_kills[MAX_CLIENTS];
 #define TDMB_SCORE_LIMIT 25
 
 static int mode_uses_team_scores(int mode) {
-    return mode == MODE_TDM || mode == MODE_TDMB;
+    return mode == MODE_TDM || mode == MODE_TDMB || mode == MODE_TDMO;
 }
 
 static int team_id_is_valid(int team_id) {
@@ -150,7 +150,7 @@ void bot_think(int bot_idx, PlayerState *players, float *out_fwd, float *out_yaw
     PlayerState *me = &players[bot_idx];
     if (me->state == STATE_DEAD || local_state.match_over) { *out_buttons = 0; return; }
 
-    int team_mode = (local_state.game_mode == MODE_TDM || local_state.game_mode == MODE_CTF || local_state.game_mode == MODE_TDMB);
+    int team_mode = (local_state.game_mode == MODE_TDM || local_state.game_mode == MODE_CTF || local_state.game_mode == MODE_TDMB || local_state.game_mode == MODE_TDMO);
     int target_idx = -1;
     float min_dist = 9999.0f;
 
@@ -254,7 +254,7 @@ void update_entity(PlayerState *p, float dt, void *server_context, unsigned int 
 
 static void apply_projectile_damage(PlayerState *owner, PlayerState *target, int damage, unsigned int now_ms) {
     if (!target->active || target->state == STATE_DEAD) return;
-    int team_mode = (local_state.game_mode == MODE_TDM || local_state.game_mode == MODE_CTF || local_state.game_mode == MODE_TDMB);
+    int team_mode = (local_state.game_mode == MODE_TDM || local_state.game_mode == MODE_CTF || local_state.game_mode == MODE_TDMB || local_state.game_mode == MODE_TDMO);
     if (owner && team_mode && owner->team_id == target->team_id) return;
     target->shield_regen_timer = SHIELD_REGEN_DELAY;
     if (target->shield > 0) {
@@ -448,7 +448,7 @@ void local_init_match(int num_players, int mode) {
     local_state.pending_scene = -1;
     local_state.transition_timer = 0;
     local_state.winning_team = -1;
-    local_state.score_limit = (mode == MODE_TDMB) ? TDMB_SCORE_LIMIT : 0;
+    local_state.score_limit = (mode == MODE_TDMB || mode == MODE_TDMO) ? TDMB_SCORE_LIMIT : 0;
 
     if (mode == MODE_TDMB) {
         num_players = 1 + TDMB_BLUE_BOTS + TDMB_RED_BOTS;
@@ -464,7 +464,7 @@ void local_init_match(int num_players, int mode) {
 
     local_state.players[0].active = 1;
     local_state.players[0].is_bot = 0;
-    local_state.players[0].team_id = (mode == MODE_TDMB) ? TDMB_BLUE_TEAM : ((mode == MODE_TDM || mode == MODE_CTF) ? 0 : -1);
+    local_state.players[0].team_id = (mode == MODE_TDMB || mode == MODE_TDMO) ? TDMB_BLUE_TEAM : ((mode == MODE_TDM || mode == MODE_CTF) ? 0 : -1);
     local_state.players[0].scene_id = local_state.scene_id;
     phys_respawn(&local_state.players[0], 0);
 
@@ -474,7 +474,7 @@ void local_init_match(int num_players, int mode) {
         if (mode == MODE_TDMB) {
             local_state.players[i].team_id = (i <= TDMB_BLUE_BOTS) ? TDMB_BLUE_TEAM : TDMB_RED_TEAM;
         } else {
-            local_state.players[i].team_id = (mode == MODE_TDM || mode == MODE_CTF) ? (i % 2) : -1;
+            local_state.players[i].team_id = (mode == MODE_TDM || mode == MODE_CTF || mode == MODE_TDMO) ? (i % 2) : -1;
         }
         local_state.players[i].scene_id = local_state.scene_id;
         phys_respawn(&local_state.players[i], i*100);


### PR DESCRIPTION
### Motivation
- Introduce a first-pass online Team Deathmatch mode `TDMO` that uses authoritative server state and auto-fills empty slots with bots to solve cold-start and make online matches playable end-to-end.
- Ensure bots are visible in the scoreboard and that humans replace bots on join while preserving team balance and never kicking humans.

### Description
- Added a new game mode `MODE_TDMO` and wired it into team-mode helpers so physics/team scoring and UI paths treat TDMO as a team mode (`packages/common/protocol.h`, `packages/common/physics.h`, `packages/simulation/local_game.h`).
- Extended the wire `NetPlayer` snapshot with `is_bot` and `team_id`, updated snapshot packing/broadcast and client snapshot ingest so clients receive and apply bot/team identity (server sends `is_bot`/`team_id`, client applies them to `local_state.players`).
- Lobby/UI changes: added a top-level `TDMO` lobby entry and UI-bridge activation (`mode.tdmo`), and the client sends the requested mode byte on connect while the server includes the active mode byte in the welcome packet so client knows the authoritative mode on join (`apps/lobby/src/main.c`, `apps/server/src/main.c`).
- Implemented server-authoritative TDMO management: 6v6 target population, server bot spawning, deterministic human team assignment (fewest humans → fewest total → alternating tiebreak), bot removal on human join, bot refill on human disconnect, simple server-side bot AI ticking, and team score accumulation + score-limit win detection (`apps/server/src/main.c`).
- Scoreboard/HUD: updated client scoreboard render and HUD/team overlays to group by team and clearly label bots (`apps/lobby/src/main.c`).
- Mode parsing and tests: added `--tdmo` support and updated/added related unit tests to validate the new enum and `NetPlayer` fields (`apps/server/src/server_mode.c`, `apps/tests/*`).

### Testing
- Built the server with `make server`, which succeeded and produced the server binary (success).
- Ran server-mode unit tests by compiling and running `apps/tests/test_server_mode.c`, which passed (3/3 tests passed).
- Ran protocol/netcode tests by compiling and running `apps/tests/test_netcode.c`, which passed (27/27 tests passed) and verified `NetPlayer` extension and `MODE_TDMO` enum value.
- `make lobby` cannot be validated in this CI environment because SDL2 headers/libs are missing (build failed due to absent `SDL2/SDL.h`), so client binary and interactive runtime smoke tests were not executed (known environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfeafa76988327afd798785f53fdc7)