### PR TITLE
Rename Battle Bots menu label to TRAIN

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -430,7 +430,7 @@ char lobby_labels_mutable[LOBBY_COUNT][64];
 static const char *LOBBY_LABELS[LOBBY_COUNT] = {
     "JOIN",
     "SOLO",
-    "BATTLE (BOTS)",
+    "TRAIN",
     "TDMB",
     "LAN CTF"
 };

--- a/tools/ui_server/main.go
+++ b/tools/ui_server/main.go
@@ -139,7 +139,7 @@ func newServer() *Server {
 func defaultMenuEntries() []MenuEntry {
 	return []MenuEntry{
 		{ID: "mode.demo", Label: "DEMO (SOLO)", Kind: "action", Enabled: true},
-		{ID: "mode.battle", Label: "BATTLE (BOTS)", Kind: "action", Enabled: true},
+		{ID: "mode.battle", Label: "TRAIN", Kind: "action", Enabled: true},
 		{ID: "mode.tdm", Label: "TEAM DM (BOTS)", Kind: "action", Enabled: true},
 		{ID: "mode.ctf", Label: "LAN CTF", Kind: "action", Enabled: true},
 		{ID: "mode.training", Label: "TRAINING", Kind: "action", Enabled: true},


### PR DESCRIPTION
### Motivation
- Change the displayed menu label for the Battle/Bots mode to read `TRAIN` (text-only rename to match updated UI wording). 

### Description
- Replaced the `BATTLE (BOTS)` label with `TRAIN` in the native lobby client at `apps/lobby/src/main.c`.
- Updated the UI server default menu entry label in `tools/ui_server/main.go` so both menu sources remain consistent.

### Testing
- Ran `go test ./tools/ui_server/...` from the repository root which failed due to module context (expected for a nested module). 
- Ran `go test ./...` inside `/workspace/SHANKPIT/tools/ui_server` which completed successfully and reported the package has no test files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e021da43cc83278ca52b30cc100b8d)