### PR TITLE
TDMB: random local map selection and team spawns/markers for non-Voxworld maps

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -824,6 +824,56 @@ void draw_map() {
     }
 }
 
+
+static int get_team_base_marker(int scene_id, int team_id, float *x, float *y, float *z, float *sx, float *sy, float *sz) {
+    if (scene_id == SCENE_VOXWORLD) {
+        *x = (team_id == 0) ? VOXWORLD_BASE_RED_X : VOXWORLD_BASE_BLUE_X;
+        *z = VOXWORLD_BASE_Z;
+        *y = voxworld_height_at(*x, *z) + 9.0f;
+        *sx = 22.0f; *sy = 8.0f; *sz = 22.0f;
+        return 1;
+    }
+    if (scene_id == SCENE_DUST_COMPOUND) {
+        *x = (team_id == 0) ? -430.0f : 430.0f;
+        *z = (team_id == 0) ? -220.0f : 220.0f;
+        *y = dust_height_at(*x, *z) + 8.0f;
+        *sx = 24.0f; *sy = 14.0f; *sz = 24.0f;
+        return 1;
+    }
+    if (scene_id == SCENE_OIL_TANKER) {
+        *x = (team_id == 0) ? -270.0f : 270.0f;
+        *z = 0.0f;
+        *y = 9.0f;
+        *sx = 26.0f; *sy = 12.0f; *sz = 22.0f;
+        return 1;
+    }
+    if (scene_id == SCENE_STADIUM) {
+        *x = (team_id == 0) ? -310.0f : 310.0f;
+        *z = 0.0f;
+        *y = 6.5f;
+        *sx = 24.0f; *sy = 12.0f; *sz = 24.0f;
+        return 1;
+    }
+    return 0;
+}
+
+static void draw_team_map_markers(int scene_id, int game_mode) {
+    if (game_mode != MODE_TDMB && game_mode != MODE_TDMO) return;
+    for (int team = 0; team <= 1; team++) {
+        float x = 0.0f, y = 0.0f, z = 0.0f;
+        float sx = 0.0f, sy = 0.0f, sz = 0.0f;
+        if (!get_team_base_marker(scene_id, team, &x, &y, &z, &sx, &sy, &sz)) continue;
+
+        if (team == 0) glColor3f(1.0f, 0.25f, 0.25f);
+        else glColor3f(0.28f, 0.55f, 1.0f);
+        glPushMatrix(); glTranslatef(x, y, z); draw_box(sx, sy, sz); glPopMatrix();
+
+        if (team == 0) glColor3f(1.0f, 0.40f, 0.30f);
+        else glColor3f(0.36f, 0.72f, 1.0f);
+        glPushMatrix(); glTranslatef(x, y + sy * 0.9f, z); draw_box(sx * 0.28f, sy * 1.4f, sz * 0.28f); glPopMatrix();
+    }
+}
+
 void draw_terrain() {
     TerrainHeightfield *t = scene_active_terrain();
     if (!t || !t->active || !t->heights || t->width < 2 || t->height < 2) return;
@@ -2615,14 +2665,7 @@ void draw_scene(PlayerState *render_p) {
     draw_terrain();
     draw_voxworld_bushes();
     draw_map();
-    if ((local_state.game_mode == MODE_TDMB || local_state.game_mode == MODE_TDMO) && local_state.scene_id == SCENE_VOXWORLD) {
-        float ry = voxworld_height_at(VOXWORLD_BASE_RED_X, VOXWORLD_BASE_Z) + 9.0f;
-        float by = voxworld_height_at(VOXWORLD_BASE_BLUE_X, VOXWORLD_BASE_Z) + 9.0f;
-        glColor3f(1.0f, 0.25f, 0.25f);
-        glPushMatrix(); glTranslatef(VOXWORLD_BASE_RED_X, ry, VOXWORLD_BASE_Z); draw_box(22.0f, 8.0f, 22.0f); glPopMatrix();
-        glColor3f(0.28f, 0.55f, 1.0f);
-        glPushMatrix(); glTranslatef(VOXWORLD_BASE_BLUE_X, by, VOXWORLD_BASE_Z); draw_box(22.0f, 8.0f, 22.0f); glPopMatrix();
-    }
+    draw_team_map_markers(local_state.scene_id, local_state.game_mode);
     draw_garage_vehicle_pads();
     draw_garage_portal_frame();
     for (int hi = 0; hi < MAX_HELICOPTERS; hi++) {

--- a/packages/common/physics.h
+++ b/packages/common/physics.h
@@ -307,6 +307,27 @@ static const Vec2 tanker_spawn_points_dm[] = {
     {-110.0f, 140.0f}, {-30.0f, -72.0f}, {-20.0f, 82.0f}, {80.0f, -155.0f},
     {90.0f, 155.0f}, {150.0f, -30.0f}, {155.0f, 35.0f}, {220.0f, 0.0f}
 };
+static const Vec2 tanker_spawn_points_red[] = {
+    {-265.0f, -92.0f}, {-258.0f, 88.0f}, {-225.0f, 0.0f},
+    {-190.0f, -130.0f}, {-185.0f, 128.0f}, {-150.0f, 0.0f}
+};
+static const Vec2 tanker_spawn_points_blue[] = {
+    {265.0f, 92.0f}, {258.0f, -88.0f}, {225.0f, 0.0f},
+    {190.0f, 130.0f}, {185.0f, -128.0f}, {150.0f, 0.0f}
+};
+static const Vec2 stadium_spawn_points_dm[] = {
+    {-250.0f, -120.0f}, {-240.0f, 120.0f}, {-160.0f, -220.0f}, {-160.0f, 220.0f},
+    {-80.0f, -160.0f}, {-80.0f, 160.0f}, {0.0f, -220.0f}, {0.0f, 220.0f},
+    {80.0f, -160.0f}, {80.0f, 160.0f}, {160.0f, -220.0f}, {160.0f, 220.0f}
+};
+static const Vec2 stadium_spawn_points_red[] = {
+    {-295.0f, -140.0f}, {-285.0f, 140.0f}, {-250.0f, 0.0f},
+    {-210.0f, -220.0f}, {-210.0f, 220.0f}, {-160.0f, 0.0f}
+};
+static const Vec2 stadium_spawn_points_blue[] = {
+    {295.0f, 140.0f}, {285.0f, -140.0f}, {250.0f, 0.0f},
+    {210.0f, 220.0f}, {210.0f, -220.0f}, {160.0f, 0.0f}
+};
 static const VoxRouteAnchor dust_route_anchors[] = {
     {DUST_MID_X, DUST_MID_Z, "MID"},
     {DUST_UNDERPASS_X, DUST_UNDERPASS_Z, "UNDERPASS"},
@@ -982,6 +1003,14 @@ static inline void scene_spawn_point(int scene_id, int slot, float *out_x, float
         *out_y = 6.0f;
         return;
     }
+    if (scene_id == SCENE_STADIUM) {
+        int count = (int)(sizeof(stadium_spawn_points_dm) / sizeof(Vec2));
+        int idx = slot % count;
+        *out_x = stadium_spawn_points_dm[idx].x;
+        *out_z = stadium_spawn_points_dm[idx].y;
+        *out_y = 3.0f;
+        return;
+    }
     if (slot % 2 == 0) {
         *out_x = 0.0f; *out_z = 0.0f; *out_y = 80.0f;
     } else {
@@ -993,19 +1022,28 @@ static inline void scene_spawn_point(int scene_id, int slot, float *out_x, float
 }
 
 static inline void scene_spawn_for_player(PlayerState *p, float *out_x, float *out_y, float *out_z) {
-    if (p->scene_id != SCENE_VOXWORLD && p->scene_id != SCENE_DUST_COMPOUND && p->scene_id != SCENE_OIL_TANKER) {
+    if (p->scene_id != SCENE_VOXWORLD && p->scene_id != SCENE_DUST_COMPOUND &&
+        p->scene_id != SCENE_OIL_TANKER && p->scene_id != SCENE_STADIUM) {
         scene_spawn_point(p->scene_id, p->id, out_x, out_y, out_z);
         return;
     }
-    const Vec2 *pts = (p->scene_id == SCENE_DUST_COMPOUND) ? dust_spawn_points_dm
-                    : (p->scene_id == SCENE_OIL_TANKER ? tanker_spawn_points_dm : voxworld_spawn_points_ffa);
-    int count = (p->scene_id == SCENE_DUST_COMPOUND)
-        ? (int)(sizeof(dust_spawn_points_dm) / sizeof(Vec2))
-        : (p->scene_id == SCENE_OIL_TANKER ? (int)(sizeof(tanker_spawn_points_dm) / sizeof(Vec2))
-                                           : (int)(sizeof(voxworld_spawn_points_ffa) / sizeof(Vec2)));
+    const Vec2 *pts = voxworld_spawn_points_ffa;
+    int count = (int)(sizeof(voxworld_spawn_points_ffa) / sizeof(Vec2));
     int team_mode = phys_team_mode_enabled();
     int team = p->team_id;
     if (team_mode && (team != 0 && team != 1)) team = (p->id % 2);
+
+    if (p->scene_id == SCENE_DUST_COMPOUND) {
+        pts = dust_spawn_points_dm;
+        count = (int)(sizeof(dust_spawn_points_dm) / sizeof(Vec2));
+    } else if (p->scene_id == SCENE_OIL_TANKER) {
+        pts = tanker_spawn_points_dm;
+        count = (int)(sizeof(tanker_spawn_points_dm) / sizeof(Vec2));
+    } else if (p->scene_id == SCENE_STADIUM) {
+        pts = stadium_spawn_points_dm;
+        count = (int)(sizeof(stadium_spawn_points_dm) / sizeof(Vec2));
+    }
+
     if (team_mode && p->scene_id == SCENE_VOXWORLD) {
         if (team == 0) {
             pts = voxworld_spawn_points_red;
@@ -1022,13 +1060,37 @@ static inline void scene_spawn_for_player(PlayerState *p, float *out_x, float *o
             pts = dust_spawn_points_defend;
             count = (int)(sizeof(dust_spawn_points_defend) / sizeof(Vec2));
         }
+    } else if (team_mode && p->scene_id == SCENE_OIL_TANKER) {
+        if (team == 0) {
+            pts = tanker_spawn_points_red;
+            count = (int)(sizeof(tanker_spawn_points_red) / sizeof(Vec2));
+        } else if (team == 1) {
+            pts = tanker_spawn_points_blue;
+            count = (int)(sizeof(tanker_spawn_points_blue) / sizeof(Vec2));
+        }
+    } else if (team_mode && p->scene_id == SCENE_STADIUM) {
+        if (team == 0) {
+            pts = stadium_spawn_points_red;
+            count = (int)(sizeof(stadium_spawn_points_red) / sizeof(Vec2));
+        } else if (team == 1) {
+            pts = stadium_spawn_points_blue;
+            count = (int)(sizeof(stadium_spawn_points_blue) / sizeof(Vec2));
+        }
     }
+
     int idx = (p->id + (int)(p->deaths * 3)) % count;
     *out_x = pts[idx].x;
     *out_z = pts[idx].y;
     *out_y = (p->scene_id == SCENE_DUST_COMPOUND)
         ? (dust_height_at(*out_x, *out_z) + 5.5f)
-        : (p->scene_id == SCENE_OIL_TANKER ? 6.0f : (voxworld_height_at(*out_x, *out_z) + 6.0f));
+        : (p->scene_id == SCENE_OIL_TANKER ? 6.0f : (p->scene_id == SCENE_STADIUM ? 3.0f : (voxworld_height_at(*out_x, *out_z) + 6.0f)));
+
+    if (team_mode && (p->scene_id == SCENE_OIL_TANKER || p->scene_id == SCENE_STADIUM) && p->deaths == 0) {
+        printf("[%s] team spawn sets red=%d blue=%d\n",
+               p->scene_id == SCENE_OIL_TANKER ? "OIL_TANKER" : "STADIUM",
+               p->scene_id == SCENE_OIL_TANKER ? (int)(sizeof(tanker_spawn_points_red) / sizeof(Vec2)) : (int)(sizeof(stadium_spawn_points_red) / sizeof(Vec2)),
+               p->scene_id == SCENE_OIL_TANKER ? (int)(sizeof(tanker_spawn_points_blue) / sizeof(Vec2)) : (int)(sizeof(stadium_spawn_points_blue) / sizeof(Vec2)));
+    }
 }
 
 static inline void scene_force_spawn(PlayerState *p) {

--- a/packages/simulation/local_game.h
+++ b/packages/simulation/local_game.h
@@ -5,6 +5,8 @@
 #include "../common/physics.h"
 #include "../common/shared_movement.h"
 #include <string.h>
+#include <stdlib.h>
+#include <time.h>
 
 ServerState local_state;
 int was_holding_jump = 0;
@@ -18,6 +20,31 @@ static int tdmb_last_kills[MAX_CLIENTS];
 
 static int mode_uses_team_scores(int mode) {
     return mode == MODE_TDM || mode == MODE_TDMB || mode == MODE_TDMO;
+}
+
+static int scene_random_tdmb_map(void) {
+    static int seeded = 0;
+    static const int tdmb_maps[] = {
+        SCENE_DUST_COMPOUND,
+        SCENE_OIL_TANKER,
+        SCENE_STADIUM,
+        SCENE_VOXWORLD
+    };
+    if (!seeded) {
+        srand((unsigned int)time(NULL));
+        seeded = 1;
+    }
+    return tdmb_maps[rand() % (int)(sizeof(tdmb_maps) / sizeof(tdmb_maps[0]))];
+}
+
+static const char *scene_name_debug(int scene_id) {
+    switch (scene_id) {
+        case SCENE_DUST_COMPOUND: return "DUST_COMPOUND";
+        case SCENE_OIL_TANKER: return "OIL_TANKER";
+        case SCENE_STADIUM: return "STADIUM";
+        case SCENE_VOXWORLD: return "VOXWORLD";
+        default: return "UNKNOWN";
+    }
 }
 
 static int team_id_is_valid(int team_id) {
@@ -452,7 +479,8 @@ void local_init_match(int num_players, int mode) {
 
     if (mode == MODE_TDMB) {
         num_players = 1 + TDMB_BLUE_BOTS + TDMB_RED_BOTS;
-        local_state.scene_id = SCENE_VOXWORLD;
+        local_state.scene_id = scene_random_tdmb_map();
+        printf("[TDMB] random map selected: %s\n", scene_name_debug(local_state.scene_id));
     } else {
         local_state.scene_id = SCENE_GARAGE_OSAKA;
     }


### PR DESCRIPTION
### Motivation
- TDMB was hard-locked to Voxworld and lacked full team spawn/visual cues on other maps, making local TDMB one-map only and confusing for players.
- The goal is to pick a random TDMB scene at match init and make Dust, Oil Tanker, and Stadium behave as readable team maps with proper team spawns and simple base markers.

### Description
- Added a one-time-seeded helper `scene_random_tdmb_map()` and `scene_name_debug()` and replaced the Voxworld hard-lock in `local_init_match()` so TDMB chooses randomly from `SCENE_DUST_COMPOUND`, `SCENE_OIL_TANKER`, `SCENE_STADIUM`, and `SCENE_VOXWORLD`, while preserving the same bot-count behavior and logging the chosen map with `printf("[TDMB] random map selected: ...")` (file: `packages/simulation/local_game.h`).
- Expanded spawn data and routing in `packages/common/physics.h` by adding `tanker_spawn_points_red/blue`, `stadium_spawn_points_dm`, `stadium_spawn_points_red/blue`, adding a `SCENE_STADIUM` branch inside `scene_spawn_point()`, and updating `scene_spawn_for_player()` so team modes select red/blue pools for Voxworld, Dust, Oil Tanker, and Stadium (no generic fallback for these team maps).
- Generalized TDMB/TDMO base landmark rendering in the lobby renderer by adding `get_team_base_marker()` and `draw_team_map_markers()` and replacing the old Voxworld-only marker block, so all four TDMB maps draw simple red/blue base markers (file: `apps/lobby/src/main.c`).
- Preserved non-TDMB flows, left online `TDMO` logic unchanged (helpers are safe to share), and did not modify scoreboard or team-scoring logic.

### Testing
- Built the game server with `make server`, which succeeded after the changes (server binary compiled successfully).
- Ran a full `make` in this environment which failed due to missing SDL2 development headers (`SDL2/SDL.h` and `SDL2/SDL_opengl.h`), so the lobby client could not be built here.
- Attempts to run the repository test harness (`run_tests`) were not executed due to execution permission/environment limitations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e03068efe48327985c86bfb8a9a2fa)