### PR TITLE
Slim first-person magnum viewmodel silhouette

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -1462,11 +1462,12 @@ static void draw_viewmodel_accent_strip(const ViewmodelPalette *p, float w, floa
 }
 
 static void draw_viewmodel_magnum(const ViewmodelPalette *p) {
-    glPushMatrix(); glTranslatef(0.00f, 0.10f, -0.03f); draw_viewmodel_box_tone(p, 1.20f, 0.34f, 1.45f, 0); glPopMatrix();
-    glPushMatrix(); glTranslatef(0.00f, -0.24f, -0.08f); draw_viewmodel_box_tone(p, 0.66f, 0.62f, 0.68f, 1); glPopMatrix();
-    glPushMatrix(); glTranslatef(0.00f, 0.02f, 0.78f); draw_viewmodel_box_tone(p, 0.76f, 0.24f, 0.36f, 1); glPopMatrix();
-    glPushMatrix(); glTranslatef(0.00f, 0.31f, 0.97f); draw_viewmodel_box_tone(p, 0.22f, 0.12f, 0.15f, 1); glPopMatrix();
-    glPushMatrix(); glTranslatef(0.00f, 0.16f, -0.68f); draw_viewmodel_accent_strip(p, 0.22f, 0.05f, 0.22f); glPopMatrix();
+    // Slimmed silhouette pass: prioritize reduced lateral thickness while preserving length/readability.
+    glPushMatrix(); glTranslatef(0.00f, 0.09f, -0.03f); draw_viewmodel_box_tone(p, 0.94f, 0.31f, 1.45f, 0); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.00f, -0.24f, -0.08f); draw_viewmodel_box_tone(p, 0.52f, 0.56f, 0.68f, 1); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.00f, 0.01f, 0.78f); draw_viewmodel_box_tone(p, 0.58f, 0.21f, 0.36f, 1); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.00f, 0.28f, 0.97f); draw_viewmodel_box_tone(p, 0.16f, 0.10f, 0.15f, 1); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.00f, 0.14f, -0.68f); draw_viewmodel_accent_strip(p, 0.16f, 0.04f, 0.22f); glPopMatrix();
 }
 
 static void draw_viewmodel_ar(const ViewmodelPalette *p) {


### PR DESCRIPTION
### Motivation
- Reduce the magnum’s blocky first-person silhouette so it reads as a lean handgun while preserving identity and behavior.

### Description
- Adjusted `draw_viewmodel_magnum` in `apps/lobby/src/main.c` to slim each major mass (slide/upper, frame/receiver, barrel/muzzle block, front top block) and narrowed the accent strip while keeping length and overall proportions.
- Specific changes: upper/slide `w 1.20 -> 0.94`, `h 0.34 -> 0.31`; frame `w 0.66 -> 0.52`, `h 0.62 -> 0.56`; barrel block `w 0.76 -> 0.58`, `h 0.24 -> 0.21`; front top `w 0.22 -> 0.16`, `h 0.12 -> 0.10`; accent strip `w 0.22 -> 0.16`, `h 0.05 -> 0.04` with depth unchanged; small Y-offset tweaks to keep the weapon positioned in-frame (`y 0.10 -> 0.09`, `0.02 -> 0.01`, `0.31 -> 0.28`, `0.16 -> 0.14`).
- Change is purely viewmodel shaping in one function/file and does not touch gameplay, weapon IDs, ammo, networking, or other weapons.

### Testing
- Ran a repository diff/style check to ensure there are no trailing whitespace or immediate diff issues and it reported clean results.
- Performed a compilation sanity attempt (`gcc -fsyntax-only`) which failed in this environment due to missing SDL2 headers, not because of the changes made (no syntax issues introduced by the edit in context of the file).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a79693c483279adf78d6f3496401)