### PR TITLE
CTFB: 3s respawn delay and guaranteed flag drop on death

### DIFF
--- a/apps/tests/test_ctfb_respawn.c
+++ b/apps/tests/test_ctfb_respawn.c
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include <math.h>
+#include <netinet/in.h>
+
+#include "../../packages/common/net_sim.h"
+#include "../../packages/simulation/local_game.h"
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define ASSERT_TRUE(cond, msg) do { \
+    tests_run++; \
+    if (!(cond)) { \
+        printf("❌ %s\n", msg); \
+    } else { \
+        printf("✅ %s\n", msg); \
+        tests_passed++; \
+    } \
+} while (0)
+
+int main(void) {
+    printf("--- CTFB Respawn/Flag Drop Regression ---\n");
+
+    local_init_match(12, MODE_CTFB);
+
+    PlayerState *carrier = &local_state.players[0];
+    PlayerState *attacker = &local_state.players[6];
+    unsigned int death_ms = 1000;
+
+    carrier->x = 123.0f;
+    carrier->y = 45.0f;
+    carrier->z = -77.0f;
+    carrier->health = 40;
+    carrier->shield = 0;
+    carrier->state = STATE_ALIVE;
+
+    carrier->carried_flag_team_id = TDMB_RED_TEAM;
+    CtfFlagState *enemy_flag = &local_state.ctf.flags[TDMB_RED_TEAM];
+    enemy_flag->state = FLAG_CARRIED;
+    enemy_flag->carrier_id = carrier->id;
+
+    apply_projectile_damage(attacker, carrier, 50, death_ms);
+
+    ASSERT_TRUE(carrier->state == STATE_DEAD, "Carrier is dead immediately after lethal hit");
+    ASSERT_TRUE(carrier->respawn_time == death_ms + CTFB_RESPAWN_DELAY_MS, "Carrier respawn is scheduled 3000ms later");
+    ASSERT_TRUE(carrier->carried_flag_team_id == -1, "Carrier flag state is cleared on death");
+
+    ASSERT_TRUE(enemy_flag->state == FLAG_DROPPED, "Enemy flag is dropped on carrier death");
+    ASSERT_TRUE(enemy_flag->carrier_id == -1, "Dropped flag has no carrier");
+    ASSERT_TRUE(fabsf(enemy_flag->x - carrier->x) < 0.01f && fabsf(enemy_flag->z - carrier->z) < 0.01f,
+                "Dropped flag is placed at carrier death x/z");
+    ASSERT_TRUE(enemy_flag->dropped_until_ms == death_ms + CTFB_DROPPED_RETURN_MS,
+                "Dropped flag return timer is updated");
+
+    local_update(0, 0, carrier->yaw, carrier->pitch, 0, carrier->current_weapon, 0, 0, 0, 0, NULL, death_ms + 1000);
+    ASSERT_TRUE(carrier->state == STATE_DEAD, "Carrier stays dead before 3000ms delay expires");
+
+    local_update(0, 0, carrier->yaw, carrier->pitch, 0, carrier->current_weapon, 0, 0, 0, 0, NULL, death_ms + CTFB_RESPAWN_DELAY_MS);
+    ASSERT_TRUE(carrier->state == STATE_ALIVE, "Carrier respawns after 3000ms delay");
+    ASSERT_TRUE(carrier->carried_flag_team_id == -1, "Respawned carrier does not keep enemy flag state");
+
+    int blue_score_before = local_state.team_scores[TDMB_BLUE_TEAM];
+    ctf_try_capture(carrier, death_ms + CTFB_RESPAWN_DELAY_MS + 1);
+    ASSERT_TRUE(local_state.team_scores[TDMB_BLUE_TEAM] == blue_score_before,
+                "Respawned carrier cannot capture without re-picking up flag");
+
+    printf("SUMMARY: %d/%d Tests Passed.\n", tests_passed, tests_run);
+    return (tests_passed == tests_run) ? 0 : 1;
+}

--- a/packages/simulation/local_game.h
+++ b/packages/simulation/local_game.h
@@ -19,10 +19,12 @@ static int tdmb_last_kills[MAX_CLIENTS];
 #define TDMB_SCORE_LIMIT 25
 #define CTFB_SCORE_LIMIT 3
 #define CTFB_DROPPED_RETURN_MS 12000
+#define CTFB_RESPAWN_DELAY_MS 3000
 #define CTFB_USE_RADIUS 28.0f
 #define CTFB_CAPTURE_RADIUS 40.0f
 #define CTFB_CARRY_MELEE_DAMAGE 80
 #define CTFB_CARRY_MELEE_COOLDOWN_MS 450
+#define CTFB_RESPAWN_DEBUG_LOG 0
 
 static int mode_uses_team_scores(int mode) {
     return mode == MODE_TDM || mode == MODE_TDMB || mode == MODE_TDMO || mode == MODE_CTFB;
@@ -289,6 +291,30 @@ static void ctf_drop_flag_from_carrier(int player_id, unsigned int now_ms) {
     p->carried_flag_team_id = -1;
 }
 
+static void ctf_schedule_respawn(PlayerState *victim, unsigned int now_ms) {
+    if (!victim) return;
+#if CTFB_RESPAWN_DEBUG_LOG
+    int dropped_team = victim->carried_flag_team_id;
+#endif
+    victim->state = STATE_DEAD;
+    victim->respawn_time = now_ms + CTFB_RESPAWN_DELAY_MS;
+    victim->carried_flag_team_id = -1;
+    victim->in_shoot = 0;
+    victim->in_reload = 0;
+    victim->in_use = 0;
+    victim->in_jump = 0;
+    victim->in_ability = 0;
+    victim->is_shooting = 0;
+    victim->attack_cooldown = 0;
+    victim->reload_timer = 0;
+    victim->stunned_until_ms = 0;
+    victim->stun_immune_until_ms = 0;
+#if CTFB_RESPAWN_DEBUG_LOG
+    printf("[CTFB] carrier %d died, dropped flag team %d, respawn in %d ms\n",
+           victim->id, dropped_team, CTFB_RESPAWN_DELAY_MS);
+#endif
+}
+
 static void build_ctf_bot_observation(int bot_id, CtfBotObservation *out) {
     memset(out, 0, sizeof(*out));
     PlayerState *p = &local_state.players[bot_id];
@@ -434,7 +460,7 @@ static void ctf_try_carry_melee(PlayerState *attacker, unsigned int now_ms) {
             ctf_drop_flag_from_carrier(t->id, now_ms);
             attacker->kills++;
             t->deaths++;
-            phys_respawn(t, now_ms);
+            ctf_schedule_respawn(t, now_ms);
         }
     }
 }
@@ -594,16 +620,18 @@ static void apply_projectile_damage(PlayerState *owner, PlayerState *target, int
     target->health -= damage;
     if (target->health <= 0) {
         if (local_state.game_mode == MODE_CTFB) {
+            int carried_flag_team_id = target->carried_flag_team_id;
             ctf_drop_flag_from_carrier(target->id, now_ms);
             if (owner && local_state.ctf.flags[target->team_id].carrier_id == target->id) ctf_add_reward(owner->id, 25.0f, "kill_enemy_carrier", NULL);
-            if (target->carried_flag_team_id >= 0) ctf_add_reward(target->id, -20.0f, "died_with_flag", NULL);
+            if (carried_flag_team_id >= 0) ctf_add_reward(target->id, -20.0f, "died_with_flag", NULL);
         }
         if (owner) {
             owner->kills++;
             owner->accumulated_reward += 500.0f;
         }
         target->deaths++;
-        phys_respawn(target, now_ms);
+        if (local_state.game_mode == MODE_CTFB) ctf_schedule_respawn(target, now_ms);
+        else phys_respawn(target, now_ms);
     }
 
     if (now_ms >= target->stun_immune_until_ms) {
@@ -735,6 +763,28 @@ void local_update(float fwd, float str, float yaw, float pitch, int shoot, int w
     for(int i=0; i<MAX_CLIENTS; i++) {
         PlayerState *p = &local_state.players[i];
         if (!p->active) continue;
+        if (local_state.game_mode == MODE_CTFB && p->state == STATE_DEAD) {
+            if (p->respawn_time != 0 && cmd_time >= p->respawn_time) {
+                phys_respawn(p, cmd_time);
+                p->respawn_time = 0;
+                p->carried_flag_team_id = -1;
+                p->in_shoot = 0;
+                p->in_reload = 0;
+                p->in_use = 0;
+                p->in_jump = 0;
+                p->in_ability = 0;
+                p->is_shooting = 0;
+                p->attack_cooldown = 0;
+                p->reload_timer = 0;
+                p->stunned_until_ms = 0;
+                p->stun_immune_until_ms = 0;
+#if CTFB_RESPAWN_DEBUG_LOG
+                printf("[CTFB] respawn player %d at %u\n", p->id, cmd_time);
+#endif
+            } else {
+                continue;
+            }
+        }
         if (p->in_vehicle && p->vehicle_type == VEH_HELICOPTER) {
             continue;
         }


### PR DESCRIPTION
### Motivation
- Prevent instant respawn in CTFB that can leave a player appearing to still carry the flag by enforcing a clear death window and clearing carry state immediately on death. 
- Address race where `phys_respawn` ran immediately during CTFB lethal paths causing carried_flag_team_id to survive across the death/respawn boundary.

### Description
- Add a CTFB respawn constant: `#define CTFB_RESPAWN_DELAY_MS 3000`. (file: `packages/simulation/local_game.h`).
- Add an optional compile-time debug macro `CTFB_RESPAWN_DEBUG_LOG` for concise logs about carrier death/respawn. (file: `packages/simulation/local_game.h`).
- Introduce `ctf_schedule_respawn(PlayerState *victim, unsigned int now_ms)` to mark the victim `STATE_DEAD`, set `respawn_time = now + CTFB_RESPAWN_DELAY_MS`, clear `carried_flag_team_id`, and scrub transient combat/input state so nothing leaks into the respawned state. (file: `packages/simulation/local_game.h`).
- Change lethal flows for CTFB only: calls to `phys_respawn(...)` on lethal carry-melee and projectile kills are replaced with `ctf_schedule_respawn(...)`; non-CTFB modes retain immediate `phys_respawn`. (file: `packages/simulation/local_game.h`).
- Ensure `ctf_drop_flag_from_carrier(...)` is executed before scheduling respawn and that it sets `flag->state = FLAG_DROPPED`, `flag->carrier_id = -1`, places flag at death coordinates and sets `dropped_until_ms` and `last_interaction_ms`, then clears `player->carried_flag_team_id`. (file: `packages/simulation/local_game.h`).
- Add delayed respawn processing to the per-tick loop in `local_update(...)`: for CTFB, dead players are skipped until `cmd_time >= respawn_time`, at which point `phys_respawn(...)` is invoked and transient/flag state is cleared again. (file: `packages/simulation/local_game.h`).
- Add a focused regression test `apps/tests/test_ctfb_respawn.c` that simulates: blue picks up red flag, blue dies, red flag becomes `FLAG_DROPPED` at death location, blue remains dead for ~3s, blue respawns with `carried_flag_team_id == -1`, and cannot capture without re-picking up the flag. (file: `apps/tests/test_ctfb_respawn.c`).
- Files changed: `packages/simulation/local_game.h`, `apps/tests/test_ctfb_respawn.c`.
- Death/respawn flow before vs after: before, CTFB lethal paths sometimes called `phys_respawn(...)` immediately, collapsing death window and allowing carry-state to survive visually/semantically; after, the flag is dropped immediately and the player is scheduled to respawn after 3000 ms, with carried-flag and transient states cleared both on death and on final respawn.
- Remaining edge notes: `ctf_tick_flags` still keeps its defensive fallback for invalid/dead carriers (keeps correctness if other code paths set inconsistent state); debug lines are gated by `CTFB_RESPAWN_DEBUG_LOG` and off by default.

### Testing
- Run the new regression test binary: `gcc -O2 -Wall -Ipackages/common -Ipackages/simulation -Ipackages/world apps/tests/test_ctfb_respawn.c packages/world/terrain.c -lm -o /tmp/test_ctfb_respawn && /tmp/test_ctfb_respawn` — result: test executed and reported `SUMMARY: 11/11 Tests Passed.`
- Built the server to ensure no regressions in build: `make server` — result: game server binary built successfully (`bin/shank_server`).
- All automated checks run during development passed; the focused regression test confirms the requested sequence and the CTFB-only behavior changes succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a7f77bd08327a0101e1ff5a110a9)