### PR TITLE
Add focused net diagnostics for join handshake, snapshot sync, and early usercmd flow

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -37,6 +37,36 @@
 #include "../../../packages/simulation/local_game.h"
 #include "../../../packages/render/proc_tex.h"
 
+#ifndef NET_VERBOSE_LOG
+#define NET_VERBOSE_LOG 1
+#endif
+#ifndef NET_LOG_HANDSHAKE
+#define NET_LOG_HANDSHAKE 1
+#endif
+#ifndef NET_LOG_SNAPSHOT
+#define NET_LOG_SNAPSHOT 1
+#endif
+#ifndef NET_LOG_USERCMD
+#define NET_LOG_USERCMD 1
+#endif
+#ifndef NET_LOG_TIMEOUT
+#define NET_LOG_TIMEOUT 1
+#endif
+
+#if NET_VERBOSE_LOG
+#define NET_CLIENT_LOG(fmt, ...) printf("[NET_CLIENT] " fmt "\n", ##__VA_ARGS__)
+#define NET_SERVER_LOG(fmt, ...) printf("[NET_SERVER] " fmt "\n", ##__VA_ARGS__)
+#define NET_WARN_LOG(fmt, ...)   printf("[NET_WARN] " fmt "\n", ##__VA_ARGS__)
+#define NET_ERR_LOG(fmt, ...)    printf("[NET_ERR] " fmt "\n", ##__VA_ARGS__)
+#define NET_SUMMARY_LOG(fmt, ...) printf("[NET_SUMMARY] " fmt "\n", ##__VA_ARGS__)
+#else
+#define NET_CLIENT_LOG(fmt, ...)
+#define NET_SERVER_LOG(fmt, ...)
+#define NET_WARN_LOG(fmt, ...)
+#define NET_ERR_LOG(fmt, ...)
+#define NET_SUMMARY_LOG(fmt, ...)
+#endif
+
 #define STATE_LOBBY 0
 #define STATE_GAME_NET 1
 #define STATE_GAME_LOCAL 2
@@ -192,6 +222,76 @@ static unsigned char net_last_life_state = STATE_DEAD;
 static unsigned char net_last_scene_id = 255;
 static unsigned char net_prev_is_shooting[MAX_CLIENTS];
 static int last_applied_scene_id = -999;
+
+typedef struct {
+    unsigned int connect_start_ms;
+    unsigned int welcome_ms;
+    int connect_started;
+    int got_welcome;
+    int got_any_snapshot;
+    int got_local_snapshot;
+    int control_unlocked_logged;
+    int first_cmd_sent_logged;
+    unsigned int tx_cmds;
+    unsigned int snapshots_rx;
+    int latest_snapshot_len;
+    int latest_entity_count;
+    unsigned int last_usercmd_summary_ms;
+    unsigned int last_snapshot_summary_ms;
+    unsigned int last_welcome_timeout_log_ms;
+    unsigned int last_snapshot_sync_timeout_log_ms;
+    unsigned int last_blocked_input_log_ms;
+    unsigned int last_dup_welcome_log_ms;
+    unsigned int last_invalid_packet_log_ms;
+} NetClientDiag;
+
+static NetClientDiag net_diag;
+
+static int net_should_log_every(unsigned int *last_ms, unsigned int interval_ms, unsigned int now_ms) {
+    if (now_ms - *last_ms < interval_ms) return 0;
+    *last_ms = now_ms;
+    return 1;
+}
+
+static void net_format_addr(const struct sockaddr_in *addr, char *out, size_t out_sz) {
+    if (!out || out_sz == 0) return;
+    out[0] = '\0';
+    if (!addr) return;
+    char ip_buf[INET_ADDRSTRLEN] = {0};
+    if (!inet_ntop(AF_INET, &addr->sin_addr, ip_buf, sizeof(ip_buf))) {
+        snprintf(ip_buf, sizeof(ip_buf), "?.?.?.?");
+    }
+    snprintf(out, out_sz, "%s:%d", ip_buf, ntohs(addr->sin_port));
+}
+
+static void net_emit_client_summaries(unsigned int now_ms) {
+    if (net_should_log_every(&net_diag.last_usercmd_summary_ms, 1000, now_ms)) {
+        NET_SUMMARY_LOG("USERCMD tx_cmds=%u last_seq=%u got_welcome=%d got_any_snapshot=%d got_local_snapshot=%d my_client_id=%d local_pid=%d",
+                        net_diag.tx_cmds, net_latest_seq_sent, net_diag.got_welcome, net_diag.got_any_snapshot,
+                        net_diag.got_local_snapshot, my_client_id, net_local_pid);
+    }
+    if (net_should_log_every(&net_diag.last_snapshot_summary_ms, 1000, now_ms)) {
+        NET_SUMMARY_LOG("SNAPSHOT snapshots_rx=%u latest_len=%d latest_entity_count=%d local_seen=%d scene_id=%d last_reconciled_ack=%u",
+                        net_diag.snapshots_rx, net_diag.latest_snapshot_len, net_diag.latest_entity_count,
+                        net_diag.got_local_snapshot, local_state.scene_id, net_last_reconciled_ack);
+    }
+}
+
+static void net_check_diag_timeouts(unsigned int now_ms) {
+    if (!net_diag.connect_started) return;
+#if NET_LOG_TIMEOUT
+    if (!net_diag.got_welcome && now_ms - net_diag.connect_start_ms >= 1500 &&
+        net_should_log_every(&net_diag.last_welcome_timeout_log_ms, 1000, now_ms)) {
+        NET_WARN_LOG("WELCOME_TIMEOUT host=%s port=%d dt_ms=%u", SERVER_HOST, SERVER_PORT, now_ms - net_diag.connect_start_ms);
+    }
+    if (net_diag.got_welcome && !net_diag.got_local_snapshot && now_ms - net_diag.welcome_ms >= 1500 &&
+        net_should_log_every(&net_diag.last_snapshot_sync_timeout_log_ms, 1000, now_ms)) {
+        NET_WARN_LOG("SNAPSHOT_SYNC_TIMEOUT client_id=%d dt_ms=%u", my_client_id, now_ms - net_diag.welcome_ms);
+    }
+#else
+    (void)now_ms;
+#endif
+}
 
 #ifndef NET_PARITY_DEBUG
 #define NET_PARITY_DEBUG 0
@@ -366,6 +466,7 @@ static void reset_client_render_state_for_net() {
     net_last_life_state = STATE_DEAD;
     net_last_scene_id = 255;
     memset(net_prev_is_shooting, 0, sizeof(net_prev_is_shooting));
+    memset(&net_diag, 0, sizeof(net_diag));
     travel_overlay_until_ms = 0;
     local_state.pending_scene = -1;
     local_state.scene_id = SCENE_GARAGE_OSAKA;
@@ -3276,6 +3377,11 @@ void net_init() {
     WSADATA wsa; WSAStartup(MAKEWORD(2,2), &wsa);
     #endif
     sock = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sock < 0) {
+        NET_ERR_LOG("SOCKET_CREATE_FAILED host=%s port=%d", SERVER_HOST, SERVER_PORT);
+        return;
+    }
+    NET_CLIENT_LOG("SOCKET_CREATE_OK fd=%d", sock);
     #ifdef _WIN32
     u_long mode = 1;
     ioctlsocket(sock, FIONBIO, &mode);
@@ -3304,22 +3410,44 @@ void net_shutdown() {
 
 void net_connect() {
     if (sock < 0) net_init();
+    if (sock < 0) return;
     local_state.game_mode = net_requested_mode;
+    NET_CLIENT_LOG("CONNECT_BEGIN host=%s port=%d mode=%d", SERVER_HOST, SERVER_PORT, net_requested_mode);
     struct hostent *he = gethostbyname(SERVER_HOST);
     if (he) {
         server_addr.sin_family = AF_INET; 
         server_addr.sin_port = htons(SERVER_PORT); 
         memcpy(&server_addr.sin_addr, he->h_addr_list[0], he->h_length);
+        char ip_buf[INET_ADDRSTRLEN] = {0};
+        inet_ntop(AF_INET, &server_addr.sin_addr, ip_buf, sizeof(ip_buf));
+        NET_CLIENT_LOG("DNS_OK host=%s ip=%s", SERVER_HOST, ip_buf);
         char buffer[128];
         NetHeader *h = (NetHeader*)buffer;
         memset(buffer, 0, sizeof(buffer));
         h->type = PACKET_CONNECT;
         h->scene_id = 0;
         buffer[sizeof(NetHeader)] = (unsigned char)(net_requested_mode & 0xFF);
-        sendto(sock, buffer, sizeof(NetHeader) + 1, 0, (struct sockaddr*)&server_addr, sizeof(server_addr));
-        printf("Connected to %s...\n", SERVER_HOST);
+        int packet_len = (int)sizeof(NetHeader) + 1;
+        int sent = sendto(sock, buffer, packet_len, 0, (struct sockaddr*)&server_addr, sizeof(server_addr));
+        if (sent < 0) {
+            NET_ERR_LOG("CONNECT_SEND_FAILED host=%s ip=%s port=%d mode=%d", SERVER_HOST, ip_buf, SERVER_PORT, net_requested_mode);
+            return;
+        }
+        NET_CLIENT_LOG("CONNECT_BYTES b0=%u b1=%u b2=%u b3=%u b4=%u b5=%u b6=%u b7=%u len=%d",
+                       (unsigned char)buffer[0], (unsigned char)buffer[1], (unsigned char)buffer[2], (unsigned char)buffer[3],
+                       (unsigned char)buffer[4], (unsigned char)buffer[5], (unsigned char)buffer[6], (unsigned char)buffer[7], sent);
+        net_diag.connect_started = 1;
+        net_diag.connect_start_ms = SDL_GetTicks();
+        net_diag.got_welcome = 0;
+        net_diag.got_any_snapshot = 0;
+        net_diag.got_local_snapshot = 0;
+        net_diag.control_unlocked_logged = 0;
+        net_diag.first_cmd_sent_logged = 0;
+        net_diag.tx_cmds = 0;
+        net_diag.snapshots_rx = 0;
+        NET_CLIENT_LOG("CONNECT_SENT host=%s ip=%s port=%d mode=%d", SERVER_HOST, ip_buf, SERVER_PORT, net_requested_mode);
     } else {
-        printf("Failed to resolve %s\n", SERVER_HOST);
+        NET_ERR_LOG("DNS_FAIL host=%s port=%d", SERVER_HOST, SERVER_PORT);
     }
 }
 
@@ -3579,6 +3707,11 @@ void net_send_cmd(UserCmd cmd) {
     }
 
     sendto(sock, packet_data, cursor, 0, (struct sockaddr*)&server_addr, sizeof(server_addr));
+    net_diag.tx_cmds++;
+    if (!net_diag.first_cmd_sent_logged) {
+        net_diag.first_cmd_sent_logged = 1;
+        NET_CLIENT_LOG("USERCMD_TX_FIRST seq=%u payload_bytes=%d history_count=%d", cmd.sequence, cursor, net_cmd_history_count);
+    }
 }
 
 void net_process_snapshot(char *buffer, int len) {
@@ -3693,6 +3826,13 @@ void net_process_snapshot(char *buffer, int len) {
                     : "spawn_transition";
                 client_apply_spawn_transition_sync(p, np, reason);
             }
+            if (first_local_snapshot_sync) {
+                net_diag.got_local_snapshot = 1;
+                unsigned int now_ms = SDL_GetTicks();
+                unsigned int dt_ms = net_diag.connect_started ? (now_ms - net_diag.connect_start_ms) : 0;
+                NET_CLIENT_LOG("LOCAL_SNAPSHOT_SYNC client_id=%d scene_id=%d ack=%u last_seq=%u dt_ms=%u",
+                               my_client_id, (int)np->scene_id, local_ack_seq, net_latest_seq_sent, dt_ms);
+            }
         } else {
             RemoteInterp *ri = &rinterp[id];
             if (!ri->has_a) {
@@ -3803,15 +3943,39 @@ void net_tick() {
         }
 
         if (len < (int)sizeof(NetHeader)) {
+            unsigned int now_ms = SDL_GetTicks();
+            if (net_should_log_every(&net_diag.last_invalid_packet_log_ms, 1000, now_ms)) {
+                NET_WARN_LOG("SHORT_PACKET len=%d min=%zu", len, sizeof(NetHeader));
+            }
             continue;
         }
 
         NetHeader *head = (NetHeader*)buffer;
         if (head->type == PACKET_SNAPSHOT) {
+            unsigned int now_ms = SDL_GetTicks();
+            if (!net_diag.got_any_snapshot) {
+                net_diag.got_any_snapshot = 1;
+                unsigned int dt_ms = net_diag.connect_started ? (now_ms - net_diag.connect_start_ms) : 0;
+                NET_CLIENT_LOG("SNAPSHOT_RX_FIRST len=%d dt_ms=%u", len, dt_ms);
+            }
+            net_diag.snapshots_rx++;
+            net_diag.latest_snapshot_len = len;
+            net_diag.latest_entity_count = (int)head->entity_count;
             net_process_snapshot(buffer, len);
-        }
-        if (head->type == PACKET_WELCOME) {
+        } else if (head->type == PACKET_WELCOME) {
             my_client_id = head->client_id;
+            unsigned int now_ms = SDL_GetTicks();
+            char sender_buf[64];
+            net_format_addr(&sender, sender_buf, sizeof(sender_buf));
+            if (!net_diag.got_welcome) {
+                net_diag.got_welcome = 1;
+                net_diag.welcome_ms = now_ms;
+                unsigned int dt_ms = net_diag.connect_started ? (now_ms - net_diag.connect_start_ms) : 0;
+                NET_CLIENT_LOG("WELCOME_RX_FIRST client_id=%d scene_id=%d from=%s dt_ms=%u",
+                               my_client_id, head->scene_id, sender_buf, dt_ms);
+            } else if (net_should_log_every(&net_diag.last_dup_welcome_log_ms, 1000, now_ms)) {
+                NET_WARN_LOG("WELCOME_DUPLICATE client_id=%d scene_id=%d from=%s", my_client_id, head->scene_id, sender_buf);
+            }
 
             // Server-assigned identity becomes our local simulation/render identity
             net_local_pid = my_client_id;
@@ -3839,11 +4003,16 @@ void net_tick() {
                 net_local_pid = -1;
             }
 
-            printf("[NET] WELCOME my_client_id=%d net_local_pid=%d\n", my_client_id, net_local_pid);
+            NET_CLIENT_LOG("WELCOME_APPLIED my_client_id=%d net_local_pid=%d", my_client_id, net_local_pid);
             if (len >= (int)sizeof(NetHeader) + 1) {
                 local_state.game_mode = (unsigned char)buffer[sizeof(NetHeader)];
             }
-            printf("✅ JOINED SERVER AS CLIENT ID: %d\n", my_client_id);
+            printf("✅ JOINED SERVER AS CLIENT ID: %d (welcome received)\n", my_client_id);
+        } else {
+            unsigned int now_ms = SDL_GetTicks();
+            if (net_should_log_every(&net_diag.last_invalid_packet_log_ms, 1000, now_ms)) {
+                NET_WARN_LOG("UNKNOWN_PACKET type=%d len=%d", head->type, len);
+            }
         }
     }
 }
@@ -4120,18 +4289,32 @@ int main(int argc, char* argv[]) {
             if (app_state == STATE_GAME_NET) {
                 net_local_pid = (my_client_id > 0 && my_client_id < MAX_CLIENTS) ? my_client_id : -1;
                 net_tick();
+                unsigned int now_ms = SDL_GetTicks();
+                net_check_diag_timeouts(now_ms);
                 if (net_local_pid > 0 && net_have_initial_local_snapshot_sync) {
-                    unsigned int now_ms = SDL_GetTicks();
                     if (now_ms - net_last_cmd_send_ms >= CLIENT_USERCMD_INTERVAL_MS) {
+                        if (!net_diag.control_unlocked_logged) {
+                            net_diag.control_unlocked_logged = 1;
+                            NET_CLIENT_LOG("CONTROL_UNLOCKED client_id=%d local_pid=%d dt_ms=%u",
+                                           my_client_id, net_local_pid,
+                                           net_diag.connect_started ? (now_ms - net_diag.connect_start_ms) : 0);
+                        }
                         UserCmd cmd = client_create_cmd(fwd, str, cam_yaw, cam_pitch, shoot, jump, crouch, reload, use, ability, wpn_req);
                         client_apply_cmd_movement(&local_state.players[net_local_pid], &cmd, now_ms);
                         net_send_cmd(cmd);
                         net_last_cmd_send_ms = now_ms;
                         if (net_spawn_protect_cmds > 0) net_spawn_protect_cmds--;
                     }
+                } else if (net_should_log_every(&net_diag.last_blocked_input_log_ms, 1000, now_ms)) {
+                    if (!(net_local_pid > 0)) {
+                        NET_WARN_LOG("INPUT_BLOCKED reason=invalid_client_id my_client_id=%d local_pid=%d", my_client_id, net_local_pid);
+                    } else if (!net_have_initial_local_snapshot_sync) {
+                        NET_WARN_LOG("INPUT_BLOCKED reason=awaiting_local_snapshot_sync client_id=%d", my_client_id);
+                    }
                 }
-                client_decay_pending_correction(SDL_GetTicks());
-                net_apply_remote_interpolation(SDL_GetTicks());
+                client_decay_pending_correction(now_ms);
+                net_apply_remote_interpolation(now_ms);
+                net_emit_client_summaries(now_ms);
             } else {
                 local_state.players[0].in_use = use;
                 if (use && local_state.players[0].vehicle_cooldown == 0 && local_state.transition_timer == 0) {

--- a/apps/server/src/main.c
+++ b/apps/server/src/main.c
@@ -25,6 +25,36 @@
 #include "server_mode.h"
 #include "server_state.h"
 
+#ifndef NET_VERBOSE_LOG
+#define NET_VERBOSE_LOG 1
+#endif
+#ifndef NET_LOG_HANDSHAKE
+#define NET_LOG_HANDSHAKE 1
+#endif
+#ifndef NET_LOG_SNAPSHOT
+#define NET_LOG_SNAPSHOT 1
+#endif
+#ifndef NET_LOG_USERCMD
+#define NET_LOG_USERCMD 1
+#endif
+#ifndef NET_LOG_TIMEOUT
+#define NET_LOG_TIMEOUT 1
+#endif
+
+#if NET_VERBOSE_LOG
+#define NET_CLIENT_LOG(fmt, ...) printf("[NET_CLIENT] " fmt "\n", ##__VA_ARGS__)
+#define NET_SERVER_LOG(fmt, ...) printf("[NET_SERVER] " fmt "\n", ##__VA_ARGS__)
+#define NET_WARN_LOG(fmt, ...)   printf("[NET_WARN] " fmt "\n", ##__VA_ARGS__)
+#define NET_ERR_LOG(fmt, ...)    printf("[NET_ERR] " fmt "\n", ##__VA_ARGS__)
+#define NET_SUMMARY_LOG(fmt, ...) printf("[NET_SUMMARY] " fmt "\n", ##__VA_ARGS__)
+#else
+#define NET_CLIENT_LOG(fmt, ...)
+#define NET_SERVER_LOG(fmt, ...)
+#define NET_WARN_LOG(fmt, ...)
+#define NET_ERR_LOG(fmt, ...)
+#define NET_SUMMARY_LOG(fmt, ...)
+#endif
+
 int sock = -1;
 struct sockaddr_in bind_addr;
 unsigned int client_last_seq[MAX_CLIENTS];
@@ -55,6 +85,24 @@ typedef struct {
 static RecorderState recorder = {0};
 #define HELI_NET_DEBUG 0
 
+typedef struct {
+    unsigned int connects;
+    unsigned int welcomes;
+    unsigned int snapshots_tx;
+    unsigned int snapshot_ents_total;
+    unsigned int usercmd_pkts;
+    unsigned int usercmds_applied;
+    unsigned int stale_cmds;
+    unsigned int malformed;
+    unsigned int last_summary_ms;
+    unsigned int first_snapshot_logged[MAX_CLIENTS];
+    unsigned int connect_ms[MAX_CLIENTS];
+    unsigned int first_usercmd_pkt_seen[MAX_CLIENTS];
+    unsigned int stale_warn_last_ms[MAX_CLIENTS];
+} NetServerDiag;
+
+static NetServerDiag g_net_diag;
+
 #define SERVER_SNAPSHOT_INTERVAL_TICKS 3
 #define SERVER_DM_FRAG_LIMIT 25
 #define SERVER_DM_ROUND_MS (6 * 60 * 1000)
@@ -83,6 +131,43 @@ unsigned int get_server_time() {
 
 static double now_seconds(void) {
     return (double)get_server_time() / 1000.0;
+}
+
+static int net_should_log_every(unsigned int *last_ms, unsigned int interval_ms, unsigned int now_ms) {
+    if (now_ms - *last_ms < interval_ms) return 0;
+    *last_ms = now_ms;
+    return 1;
+}
+
+static void net_format_addr(const struct sockaddr_in *addr, char *out, size_t out_sz) {
+    if (!out || out_sz == 0) return;
+    out[0] = '\0';
+    if (!addr) return;
+    char ip_buf[INET_ADDRSTRLEN] = {0};
+    if (!inet_ntop(AF_INET, &addr->sin_addr, ip_buf, sizeof(ip_buf))) {
+        snprintf(ip_buf, sizeof(ip_buf), "?.?.?.?");
+    }
+    snprintf(out, out_sz, "%s:%d", ip_buf, ntohs(addr->sin_port));
+}
+
+static void net_server_emit_summary(unsigned int now_ms) {
+    if (!net_should_log_every(&g_net_diag.last_summary_ms, 1000, now_ms)) return;
+    unsigned int avg_ents = g_net_diag.snapshots_tx ? (g_net_diag.snapshot_ents_total / g_net_diag.snapshots_tx) : 0;
+    int clients = 0;
+    for (int i = 1; i < MAX_CLIENTS; i++) {
+        if (slots[i].active && slots[i].welcomed) clients++;
+    }
+    NET_SUMMARY_LOG("SERVER clients=%d connects=%u welcomes=%u snapshots_tx=%u avg_ents=%u usercmd_pkts=%u usercmds_applied=%u stale_cmds=%u malformed=%u",
+                    clients, g_net_diag.connects, g_net_diag.welcomes, g_net_diag.snapshots_tx, avg_ents,
+                    g_net_diag.usercmd_pkts, g_net_diag.usercmds_applied, g_net_diag.stale_cmds, g_net_diag.malformed);
+    g_net_diag.connects = 0;
+    g_net_diag.welcomes = 0;
+    g_net_diag.snapshots_tx = 0;
+    g_net_diag.snapshot_ents_total = 0;
+    g_net_diag.usercmd_pkts = 0;
+    g_net_diag.usercmds_applied = 0;
+    g_net_diag.stale_cmds = 0;
+    g_net_diag.malformed = 0;
 }
 
 static int server_scene_is_dm_map(int scene_id) {
@@ -262,6 +347,10 @@ static int alloc_slot(const struct sockaddr_in *addr) {
             local_state.client_meta[i].active = 0;
             local_state.client_meta[i].last_heard_ms = get_server_time();
             client_last_seq[i] = 0;
+            g_net_diag.first_snapshot_logged[i] = 0;
+            g_net_diag.first_usercmd_pkt_seen[i] = 0;
+            g_net_diag.stale_warn_last_ms[i] = 0;
+            g_net_diag.connect_ms[i] = get_server_time();
 
             return i;
         }
@@ -284,6 +373,11 @@ static void free_slot(int slot) {
     memset(&slots[slot].addr, 0, sizeof(struct sockaddr_in));
     slots[slot].last_heard = 0.0;
     slots[slot].player_id = -1;
+    g_net_diag.first_snapshot_logged[slot] = 0;
+    g_net_diag.first_usercmd_pkt_seen[slot] = 0;
+    g_net_diag.stale_warn_last_ms[slot] = 0;
+    g_net_diag.connect_ms[slot] = 0;
+    NET_SERVER_LOG("SLOT_FREE client_id=%d", slot);
     server_disconnect(slot, client_last_seq);
     if (local_state.game_mode == MODE_TDMO && was_human && team_id_is_valid(prev_team)) {
         tdmo_spawn_bot_on_team(prev_team, get_server_time());
@@ -336,6 +430,10 @@ static void send_welcome(const struct sockaddr_in *addr, int client_id) {
            (const struct sockaddr*)addr, sizeof(struct sockaddr_in));
     if (client_id > 0 && client_id < MAX_CLIENTS) {
         slots[client_id].welcomed = 1;
+        g_net_diag.welcomes++;
+        char addr_buf[64];
+        net_format_addr(addr, addr_buf, sizeof(addr_buf));
+        NET_SERVER_LOG("WELCOME_TX client_id=%d scene_id=%d dst=%s", client_id, (int)h->scene_id, addr_buf);
     }
 }
 
@@ -344,15 +442,22 @@ static int ensure_slot_for_sender(const struct sockaddr_in *sender) {
     if (slot != -1) {
         slots[slot].last_heard = now_seconds();
         local_state.client_meta[slot].last_heard_ms = get_server_time();
+        char addr_buf[64];
+        net_format_addr(sender, addr_buf, sizeof(addr_buf));
+        NET_SERVER_LOG("SLOT_REUSE client_id=%d addr=%s", slot, addr_buf);
         return slot;
     }
 
     int new_slot = alloc_slot(sender);
     if (new_slot != -1) {
-        char ip_buf[INET_ADDRSTRLEN] = {0};
-        inet_ntop(AF_INET, &sender->sin_addr, ip_buf, sizeof(ip_buf));
-        printf("CLIENT %d CONNECTED (%s:%d)\n", new_slot, ip_buf, ntohs(sender->sin_port));
-        send_welcome(sender, new_slot);
+        char addr_buf[64];
+        net_format_addr(sender, addr_buf, sizeof(addr_buf));
+        NET_SERVER_LOG("SLOT_ASSIGN client_id=%d addr=%s reason=new_sender", new_slot, addr_buf);
+        g_net_diag.connects++;
+    } else {
+        char addr_buf[64];
+        net_format_addr(sender, addr_buf, sizeof(addr_buf));
+        NET_WARN_LOG("SLOT_FULL addr=%s", addr_buf);
     }
     return new_slot;
 }
@@ -482,6 +587,10 @@ void server_net_init() {
     WSADATA wsa; WSAStartup(MAKEWORD(2,2), &wsa);
     #endif
     sock = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sock < 0) {
+        NET_ERR_LOG("SOCKET_CREATE_FAILED");
+        exit(1);
+    }
     #ifdef _WIN32
     u_long mode = 1; ioctlsocket(sock, FIONBIO, &mode);
     #else
@@ -490,23 +599,37 @@ void server_net_init() {
     bind_addr.sin_family = AF_INET;
     bind_addr.sin_port = htons(6969);
     bind_addr.sin_addr.s_addr = INADDR_ANY;
+    NET_SERVER_LOG("STARTUP mode=pending bind_addr=0.0.0.0 port=%d scene=%d", 6969, g_server_match_scene);
     if (bind(sock, (struct sockaddr*)&bind_addr, sizeof(bind_addr)) < 0) {
-        printf("FAILED TO BIND PORT 6969\n");
+        NET_ERR_LOG("BIND_FAILED port=%d", 6969);
         exit(1);
     } else {
-        printf("SERVER LISTENING ON PORT 6969\nWaiting...\n");
+        NET_SERVER_LOG("SERVER_STARTED bind_addr=0.0.0.0 port=%d", 6969);
     }
 }
 
-void process_user_cmd(int client_id, UserCmd *cmd) {
-    if (cmd->sequence <= client_last_seq[client_id]) return;
+int process_user_cmd(int client_id, UserCmd *cmd) {
+    if (cmd->sequence <= client_last_seq[client_id]) {
+        g_net_diag.stale_cmds++;
+        unsigned int now_ms = get_server_time();
+        if (net_should_log_every(&g_net_diag.stale_warn_last_ms[client_id], 1000, now_ms)) {
+            NET_WARN_LOG("USERCMD_STALE client_id=%d seq=%u last_seq=%u", client_id, cmd->sequence, client_last_seq[client_id]);
+        }
+        return 0;
+    }
     PlayerState *p = &local_state.players[client_id];
     shankpit_apply_usercmd_inputs(p, cmd);
     client_last_seq[client_id] = cmd->sequence;
+    g_net_diag.usercmds_applied++;
+    return 1;
 }
 
 void server_handle_packet(struct sockaddr_in *sender, char *buffer, int size) {
-    if (size < (int)sizeof(NetHeader)) return;
+    if (size < (int)sizeof(NetHeader)) {
+        g_net_diag.malformed++;
+        NET_WARN_LOG("SHORT_PACKET size=%d min=%zu", size, sizeof(NetHeader));
+        return;
+    }
     NetHeader *head = (NetHeader*)buffer;
     int client_id = -1;
 
@@ -516,10 +639,14 @@ void server_handle_packet(struct sockaddr_in *sender, char *buffer, int size) {
     if (client_id == -1) return;
 
     if (head->type == PACKET_CONNECT) {
+        char addr_buf[64];
+        net_format_addr(sender, addr_buf, sizeof(addr_buf));
         int requested_mode = MODE_DEATHMATCH;
         if (size >= (int)sizeof(NetHeader) + 1) {
             requested_mode = (unsigned char)buffer[sizeof(NetHeader)];
         }
+        NET_SERVER_LOG("CONNECT_RX src=%s size=%d requested_mode=%d", addr_buf, size, requested_mode);
+        int mode_before = local_state.game_mode;
         if (requested_mode == MODE_TDMO && local_state.game_mode != MODE_TDMO) {
             tdmo_activate_match(get_server_time());
         }
@@ -553,6 +680,9 @@ void server_handle_packet(struct sockaddr_in *sender, char *buffer, int size) {
         p->use_was_down = 0;
         p->portal_cooldown_until_ms = 0;
         p->vehicle_cooldown = 0;
+        NET_SERVER_LOG("CONNECT_ACCEPT client_id=%d scene_id=%d team=%d mode_before=%d mode_after=%d mode_coerced=%d",
+                       client_id, p->scene_id, p->team_id, mode_before, local_state.game_mode,
+                       (requested_mode != local_state.game_mode));
         send_welcome(sender, client_id);
     }
 
@@ -563,26 +693,40 @@ void server_handle_packet(struct sockaddr_in *sender, char *buffer, int size) {
 
     // --- USER COMMANDS ---
     if (client_id != -1 && head->type == PACKET_USERCMD) {
+        g_net_diag.usercmd_pkts++;
         int cursor = (int)sizeof(NetHeader);
-        if (size < cursor + 1) return;
+        if (size < cursor + 1) {
+            g_net_diag.malformed++;
+            NET_WARN_LOG("USERCMD_MALFORMED client_id=%d reason=missing_count size=%d", client_id, size);
+            return;
+        }
 
         unsigned char count = *(unsigned char*)(buffer + cursor); cursor += 1;
+        int needed = cursor + (int)(count * sizeof(UserCmd));
+        if (needed > size) {
+            g_net_diag.malformed++;
+            NET_WARN_LOG("USERCMD_MALFORMED client_id=%d count=%u size=%d needed=%d", client_id, count, size, needed);
+            return;
+        }
 
-        if (size >= cursor + (int)(count * sizeof(UserCmd))) {
-            UserCmd *cmds = (UserCmd*)(buffer + cursor);
+        UserCmd *cmds = (UserCmd*)(buffer + cursor);
+        if (!g_net_diag.first_usercmd_pkt_seen[client_id]) {
+            g_net_diag.first_usercmd_pkt_seen[client_id] = 1;
+            unsigned int newest_seq = count > 0 ? cmds[0].sequence : 0;
+            NET_SERVER_LOG("USERCMD_RX_FIRST client_id=%d count=%u newest_seq=%u size=%d", client_id, count, newest_seq, size);
+        }
 
-            // process oldest->newest to preserve chronological intent
-            for (int i = (int)count - 1; i >= 0; i--) {
-                process_user_cmd(client_id, &cmds[i]);
-            }
+        // process oldest->newest to preserve chronological intent
+        for (int i = (int)count - 1; i >= 0; i--) {
+            process_user_cmd(client_id, &cmds[i]);
+        }
 
-            slots[client_id].last_heard = now_seconds();
-            local_state.client_meta[client_id].last_heard_ms = get_server_time();
-            slots[client_id].cmd_seen = 1;
-            if (local_state.game_mode != MODE_TDMO) {
-                local_state.players[client_id].active = slots[client_id].welcomed && slots[client_id].cmd_seen;
-                local_state.client_meta[client_id].active = local_state.players[client_id].active;
-            }
+        slots[client_id].last_heard = now_seconds();
+        local_state.client_meta[client_id].last_heard_ms = get_server_time();
+        slots[client_id].cmd_seen = 1;
+        if (local_state.game_mode != MODE_TDMO) {
+            local_state.players[client_id].active = slots[client_id].welcomed && slots[client_id].cmd_seen;
+            local_state.client_meta[client_id].active = local_state.players[client_id].active;
         }
     }
 }
@@ -613,6 +757,15 @@ void server_broadcast() {
         head.timestamp = get_server_time();
         head.scene_id = (unsigned char)(recipient_scene < 0 ? 0 : recipient_scene);
         head.entity_count = count;
+        g_net_diag.snapshots_tx++;
+        g_net_diag.snapshot_ents_total += count;
+        if (!g_net_diag.first_snapshot_logged[i]) {
+            g_net_diag.first_snapshot_logged[i] = 1;
+            unsigned int now_ms = get_server_time();
+            unsigned int dt_ms = g_net_diag.connect_ms[i] ? (now_ms - g_net_diag.connect_ms[i]) : 0;
+            NET_SERVER_LOG("SNAPSHOT_TX_FIRST client_id=%d ents=%u scene=%d dt_since_connect=%u",
+                           i, count, recipient_scene, dt_ms);
+        }
 
         memcpy(buffer + cursor, &head, sizeof(NetHeader)); cursor += (int)sizeof(NetHeader);
         memcpy(buffer + cursor, &count, 1); cursor += 1;
@@ -710,6 +863,7 @@ int main(int argc, char *argv[]) {
 
     server_net_init();
     int mode = parse_server_mode(argc, argv);
+    NET_SERVER_LOG("MODE_SELECTED mode=%d", mode);
     local_init_match(1, mode);
     if (mode == MODE_TDMO) {
         tdmo_activate_match(get_server_time());
@@ -726,12 +880,13 @@ int main(int argc, char *argv[]) {
     local_state.players[0].active = 0;
     local_state.players[0].health = 0;
     local_state.players[0].state = STATE_DEAD;
+    NET_SERVER_LOG("SCENE_SELECTED scene=%d", g_server_match_scene);
     if (mode == MODE_TDM) {
-        printf("SERVER MODE: TEAM DEATHMATCH\n");
+        NET_SERVER_LOG("SERVER_MODE TEAM_DEATHMATCH");
     } else if (mode == MODE_TDMO) {
-        printf("SERVER MODE: ONLINE TEAM DEATHMATCH (TDMO)\n");
+        NET_SERVER_LOG("SERVER_MODE ONLINE_TEAM_DEATHMATCH");
     } else {
-        printf("SERVER MODE: DEATHMATCH\n");
+        NET_SERVER_LOG("SERVER_MODE DEATHMATCH");
     }
 
     int running = 1;
@@ -755,6 +910,7 @@ int main(int argc, char *argv[]) {
         // TIMEOUT_SWEEP
         for (int i = 1; i < MAX_CLIENTS; i++) {
             if (slots[i].active && now_seconds() - slots[i].last_heard > 5.0) {
+                NET_WARN_LOG("SLOT_TIMEOUT client_id=%d idle_s=%.2f", i, now_seconds() - slots[i].last_heard);
                 free_slot(i);
             }
         }
@@ -909,6 +1065,7 @@ int main(int argc, char *argv[]) {
         if ((tick % SERVER_SNAPSHOT_INTERVAL_TICKS) == 0) {
             server_broadcast();
         }
+        net_server_emit_summary(now);
 
         int connected = 0;
         for (int i = 1; i < MAX_CLIENTS; i++) {


### PR DESCRIPTION
### Motivation

- Improve observability of the online join path and early gameplay net flow so failures (missing WELCOME, missing snapshot sync, blocked input, stale/malformed usercmds) can be diagnosed without flooding logs.
- Make client UI wording truthful: indicate `CONNECT_SENT` instead of implying a full connection before `PACKET_WELCOME`.
- Keep logic/semantics unchanged; only add diagnostics and small, safe hardening (minor malformed checks and rate-limited warnings).

### Description

- Added compile-time flags (`NET_VERBOSE_LOG`, `NET_LOG_HANDSHAKE`, `NET_LOG_SNAPSHOT`, `NET_LOG_USERCMD`, `NET_LOG_TIMEOUT`) and tagged logging macros (`[NET_CLIENT]`, `[NET_SERVER]`, `[NET_WARN]`, `[NET_ERR]`, `[NET_SUMMARY]`) to `apps/lobby/src/main.c` and `apps/server/src/main.c` for unified diagnostics.
- Client (`apps/lobby/src/main.c`): instrumented `net_init()`/`net_connect()` with socket/DNS/send diagnostics and `CONNECT_SENT` semantics; added a `NetClientDiag` struct, rate-limited timeout checks (`WELCOME_TIMEOUT`, `SNAPSHOT_SYNC_TIMEOUT`), first-receive logs for `PACKET_WELCOME` and `PACKET_SNAPSHOT`, local snapshot-sync confirmation log (`LOCAL_SNAPSHOT_SYNC`), one-time `CONTROL_UNLOCKED` and `USERCMD_TX_FIRST` logs, once-per-second `USERCMD` and `SNAPSHOT` summaries, short/unknown packet warnings, and replaced the misleading "Connected to..." message.
- Server (`apps/server/src/main.c`): added `NetServerDiag` counters and helpers, startup logs (bind/port/mode/scene), slot lifecycle logs (`SLOT_ASSIGN`, `SLOT_REUSE`, `SLOT_FREE`, `SLOT_FULL`, `SLOT_TIMEOUT`), connect-path logs (`CONNECT_RX`, `CONNECT_ACCEPT`, `WELCOME_TX`), per-client first-snapshot transmit log (`SNAPSHOT_TX_FIRST`), per-client first-usercmd packet log (`USERCMD_RX_FIRST`), malformed usercmd detection and rate-limited stale-usercmd warnings, and once-per-second server net summary (`[NET_SUMMARY] SERVER ...`).
- Safety/fix: removed the earlier immediate `send_welcome()` from the raw slot-allocation path so welcome is sent only from the authoritative `PACKET_CONNECT` accept path to avoid duplicate/misleading welcomes.
- Rate-limiting helpers were added and used to avoid log floods (most repeated warnings are limited to once-per-second per category).

### Testing

- Built server-only binary successfully with: `gcc -O2 -Wall -D_REENTRANT -Ipackages/common -Ipackages/simulation -Ipackages/render -Ipackages/world apps/server/src/main.c packages/world/terrain.c -o /tmp/shank_server_test -lm` which compiled without errors.
- Ran the repository `make -j2`; lobby build failed in this environment due to missing SDL2 headers (expected in CI/dev machines), and server build is otherwise covered by the successful direct `gcc` compile above.
- Ran `git diff --check` and basic static checks; no whitespace/diff errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a6d6a3e483279d30beb4a04786c5)