### PR TITLE
Add Geisha and Alpine player skins

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -105,6 +105,8 @@ typedef enum {
     SKIN_GENIE,
     SKIN_WANDERER,
     SKIN_PINK,
+    SKIN_GEISHA,
+    SKIN_ALPINE,
     SKIN_COUNT
 } PlayerSkin;
 
@@ -120,7 +122,9 @@ static const char *SKIN_LABELS[SKIN_COUNT] = {
     "BILL",
     "GENIE",
     "WANDERER",
-    "PINK"
+    "PINK",
+    "GEISHA",
+    "ALPINE"
 };
 static const char *SKIN_CONFIG_PATH = "shankpit_skin.cfg";
 static void ensure_skin_selection_visible(void);
@@ -2112,6 +2116,82 @@ static void draw_player_skin_wanderer(PlayerState *p, float draw_pitch, float dr
     glScalef(0.8f, 0.8f, 0.8f); draw_gun_model(p->current_weapon); glPopMatrix();
 }
 
+static void draw_player_skin_geisha(PlayerState *p, float draw_pitch, float draw_recoil) {
+    glColor3f(0.76f, 0.08f, 0.08f);
+    glPushMatrix(); glTranslatef(0.0f, 0.80f, 0.0f); draw_box(1.26f, 1.52f, 0.72f); draw_box_outline(1.26f, 1.52f, 0.72f); glPopMatrix();
+    glColor3f(0.96f, 0.72f, 0.18f);
+    glPushMatrix(); glTranslatef(0.0f, 0.38f, 0.37f); draw_box(1.10f, 0.14f, 0.10f); draw_box_outline(1.10f, 0.14f, 0.10f); glPopMatrix();
+    glColor3f(0.58f, 0.03f, 0.05f);
+    glPushMatrix(); glTranslatef(-0.74f, 0.82f, 0.0f); draw_box(0.32f, 1.30f, 0.36f); draw_box_outline(0.32f, 1.30f, 0.36f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.74f, 0.82f, 0.0f); draw_box(0.32f, 1.30f, 0.36f); draw_box_outline(0.32f, 1.30f, 0.36f); glPopMatrix();
+    glColor3f(0.70f, 0.06f, 0.08f);
+    glPushMatrix(); glTranslatef(-0.35f, -0.10f, 0.0f); draw_box(0.46f, 1.40f, 0.46f); draw_box_outline(0.46f, 1.40f, 0.46f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.35f, -0.10f, 0.0f); draw_box(0.46f, 1.40f, 0.46f); draw_box_outline(0.46f, 1.40f, 0.46f); glPopMatrix();
+
+    glPushMatrix();
+    glTranslatef(0.0f, 1.96f, 0.0f);
+    glRotatef(draw_pitch, 1, 0, 0);
+    glColor3f(0.92f, 0.92f, 0.92f); draw_box(0.68f, 0.84f, 0.68f); draw_box_outline(0.68f, 0.84f, 0.68f);
+    glColor3f(0.02f, 0.02f, 0.03f);
+    glPushMatrix(); glTranslatef(0.0f, 0.32f, 0.0f); draw_box(0.94f, 0.34f, 0.86f); draw_box_outline(0.94f, 0.34f, 0.86f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.0f, 0.58f, 0.0f); draw_box(0.56f, 0.20f, 0.50f); draw_box_outline(0.56f, 0.20f, 0.50f); glPopMatrix();
+    glColor3f(0.72f, 0.06f, 0.10f);
+    glPushMatrix(); glTranslatef(-0.22f, 0.18f, 0.39f); draw_box(0.12f, 0.06f, 0.05f); draw_box_outline(0.12f, 0.06f, 0.05f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.22f, 0.18f, 0.39f); draw_box(0.12f, 0.06f, 0.05f); draw_box_outline(0.12f, 0.06f, 0.05f); glPopMatrix();
+    glColor3f(0.66f, 0.10f, 0.16f);
+    glPushMatrix(); glTranslatef(0.0f, -0.08f, 0.40f); draw_box(0.20f, 0.07f, 0.04f); draw_box_outline(0.20f, 0.07f, 0.04f); glPopMatrix();
+    glColor3f(0.84f, 0.70f, 0.76f);
+    glPushMatrix(); glTranslatef(0.36f, 0.30f, 0.28f); draw_box(0.16f, 0.16f, 0.14f); draw_box_outline(0.16f, 0.16f, 0.14f); glPopMatrix();
+    glColor3f(0.80f, 0.74f, 0.82f);
+    glPushMatrix(); glTranslatef(0.46f, 0.20f, 0.28f); draw_box(0.08f, 0.34f, 0.08f); draw_box_outline(0.08f, 0.34f, 0.08f); glPopMatrix();
+    glPopMatrix();
+
+    glPushMatrix(); glTranslatef(0.64f, 1.03f, 0.57f);
+    glRotatef(draw_pitch, 1, 0, 0);
+    glRotatef(-draw_recoil * 10.0f, 1, 0, 0);
+    glTranslatef(0.0f, 0.0f, -draw_recoil * 0.08f);
+    glScalef(0.8f, 0.8f, 0.8f); draw_gun_model(p->current_weapon); glPopMatrix();
+}
+
+static void draw_player_skin_alpine(PlayerState *p, float draw_pitch, float draw_recoil) {
+    glColor3f(0.26f, 0.46f, 0.24f);
+    glPushMatrix(); glTranslatef(0.0f, 0.82f, 0.0f); draw_box(1.22f, 1.44f, 0.70f); draw_box_outline(1.22f, 1.44f, 0.70f); glPopMatrix();
+    glColor3f(0.90f, 0.92f, 0.88f);
+    glPushMatrix(); glTranslatef(0.0f, 0.94f, 0.37f); draw_box(0.92f, 0.42f, 0.08f); draw_box_outline(0.92f, 0.42f, 0.08f); glPopMatrix();
+    glColor3f(0.14f, 0.30f, 0.12f);
+    glPushMatrix(); glTranslatef(-0.20f, 0.34f, 0.37f); draw_box(0.10f, 1.06f, 0.08f); draw_box_outline(0.10f, 1.06f, 0.08f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.20f, 0.34f, 0.37f); draw_box(0.10f, 1.06f, 0.08f); draw_box_outline(0.10f, 1.06f, 0.08f); glPopMatrix();
+    glColor3f(0.22f, 0.36f, 0.20f);
+    glPushMatrix(); glTranslatef(-0.72f, 0.84f, 0.0f); draw_box(0.30f, 1.24f, 0.34f); draw_box_outline(0.30f, 1.24f, 0.34f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.72f, 0.84f, 0.0f); draw_box(0.30f, 1.24f, 0.34f); draw_box_outline(0.30f, 1.24f, 0.34f); glPopMatrix();
+    glColor3f(0.16f, 0.28f, 0.14f);
+    glPushMatrix(); glTranslatef(-0.32f, -0.12f, 0.0f); draw_box(0.42f, 1.32f, 0.42f); draw_box_outline(0.42f, 1.32f, 0.42f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.32f, -0.12f, 0.0f); draw_box(0.42f, 1.32f, 0.42f); draw_box_outline(0.42f, 1.32f, 0.42f); glPopMatrix();
+    glColor3f(0.36f, 0.22f, 0.12f);
+    glPushMatrix(); glTranslatef(-0.32f, -0.82f, 0.0f); draw_box(0.46f, 0.28f, 0.46f); draw_box_outline(0.46f, 0.28f, 0.46f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.32f, -0.82f, 0.0f); draw_box(0.46f, 0.28f, 0.46f); draw_box_outline(0.46f, 0.28f, 0.46f); glPopMatrix();
+
+    glPushMatrix();
+    glTranslatef(0.0f, 1.94f, 0.0f);
+    glRotatef(draw_pitch, 1, 0, 0);
+    glColor3f(0.62f, 0.46f, 0.34f); draw_box(0.68f, 0.82f, 0.68f); draw_box_outline(0.68f, 0.82f, 0.68f);
+    glColor3f(0.24f, 0.12f, 0.06f);
+    glPushMatrix(); glTranslatef(0.0f, 0.08f, 0.40f); draw_box(0.56f, 0.20f, 0.06f); draw_box_outline(0.56f, 0.20f, 0.06f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.0f, -0.02f, 0.42f); draw_box(0.42f, 0.12f, 0.04f); draw_box_outline(0.42f, 0.12f, 0.04f); glPopMatrix();
+    glColor3f(0.08f, 0.26f, 0.08f);
+    glPushMatrix(); glTranslatef(0.0f, 0.58f, 0.0f); draw_box(1.04f, 0.16f, 0.90f); draw_box_outline(1.04f, 0.16f, 0.90f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.0f, 0.78f, 0.0f); draw_box(0.74f, 0.28f, 0.64f); draw_box_outline(0.74f, 0.28f, 0.64f); glPopMatrix();
+    glColor3f(0.72f, 0.14f, 0.10f);
+    glPushMatrix(); glTranslatef(0.44f, 0.80f, 0.10f); draw_box(0.10f, 0.34f, 0.10f); draw_box_outline(0.10f, 0.34f, 0.10f); glPopMatrix();
+    glPopMatrix();
+
+    glPushMatrix(); glTranslatef(0.64f, 1.03f, 0.57f);
+    glRotatef(draw_pitch, 1, 0, 0);
+    glRotatef(-draw_recoil * 10.0f, 1, 0, 0);
+    glTranslatef(0.0f, 0.0f, -draw_recoil * 0.08f);
+    glScalef(0.8f, 0.8f, 0.8f); draw_gun_model(p->current_weapon); glPopMatrix();
+}
+
 void draw_weapon_p(PlayerState *p) {
     if (p->in_vehicle) return; 
     glPushMatrix();
@@ -2215,6 +2295,12 @@ void draw_player_3rd(PlayerState *p) {
                 break;
             case SKIN_PINK:
                 draw_player_skin_pink(p, draw_pitch, draw_recoil);
+                break;
+            case SKIN_GEISHA:
+                draw_player_skin_geisha(p, draw_pitch, draw_recoil);
+                break;
+            case SKIN_ALPINE:
+                draw_player_skin_alpine(p, draw_pitch, draw_recoil);
                 break;
             case SKIN_BAT:
             default:


### PR DESCRIPTION
### Motivation
- Expose two new player appearance options in the lobby and render them in third-person so players can choose more variety in character skins when playing.

### Description
- Extended `PlayerSkin` enum with `SKIN_GEISHA` and `SKIN_ALPINE` and added corresponding entries to the `SKIN_LABELS` array so they appear in the skin chooser.
- Implemented `draw_player_skin_geisha(...)` which composes the kimono-inspired torso, head and accessory geometry and uses the existing `draw_box` helpers and color palette.
- Implemented `draw_player_skin_alpine(...)` which composes the alpine-themed torso, hat and suspenders geometry and uses the same rendering patterns as other skins.
- Wired both new draw functions into the third-person dispatch `switch` so the new skins are selected and rendered via `g_selected_skin`.

### Testing
- Attempted `make lobby` to build the client, which failed in this environment due to missing SDL2 development headers (`SDL2/SDL.h` and `SDL2/SDL_opengl.h`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2db4f69048327a0caa2affde9e485)