### PR TITLE
Add retro sun-linked atmosphere, fog and cheap brush lighting

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -176,6 +176,32 @@ static float smoothstepf(float edge0, float edge1, float x) {
     return t * t * (3.0f - 2.0f * t);
 }
 
+/*
+ * Retro atmosphere seam:
+ * Keep all cheap "fake baked" lighting/fog math centralized so we can
+ * iterate style without changing world/gameplay data paths.
+ */
+static void retro_eval_sun_dir(float *out_x, float *out_y, float *out_z) {
+    retro_sky_eval_sun_dir(SDL_GetTicks() * 0.001f, out_x, out_y, out_z);
+}
+
+static void retro_eval_fog_rgb(float *out_r, float *out_g, float *out_b) {
+    retro_sky_eval_fog_rgb(SDL_GetTicks() * 0.001f, out_r, out_g, out_b);
+}
+
+static void retro_apply_fog_rgb(float *r, float *g, float *b, float fog_r, float fog_g, float fog_b, float dist) {
+    float haze = smoothstepf(420.0f, 2800.0f, dist);
+    *r = lerpf(*r, fog_r, haze);
+    *g = lerpf(*g, fog_g, haze);
+    *b = lerpf(*b, fog_b, haze);
+}
+
+static float retro_eval_brush_lighting(float nx, float ny, float nz, float ambient_floor, float sun_x, float sun_y, float sun_z) {
+    float ndotl = nx * sun_x + ny * sun_y + nz * sun_z;
+    float diffuse = clamp01f(ndotl * 0.5f + 0.5f);
+    return ambient_floor + diffuse * (1.0f - ambient_floor);
+}
+
 #define Z_FAR 8000.0f
 
 static void draw_box(float w, float h, float d);
@@ -868,7 +894,10 @@ void draw_map() {
         return;
     }
 
-    const float sky_r = 0.18f, sky_g = 0.25f, sky_b = 0.36f;
+    float fog_r = 0.18f, fog_g = 0.25f, fog_b = 0.36f;
+    float sun_x = 0.0f, sun_y = 1.0f, sun_z = 0.0f;
+    retro_eval_sun_dir(&sun_x, &sun_y, &sun_z);
+    retro_eval_fog_rgb(&fog_r, &fog_g, &fog_b);
     int ref_id = (my_client_id >= 0 && my_client_id < MAX_CLIENTS) ? my_client_id : 0;
     const PlayerState *rp = &local_state.players[ref_id];
 
@@ -882,14 +911,35 @@ void draw_map() {
         float side_r = base_r * 0.82f, side_g = base_g * 0.84f, side_b = base_b * 0.90f;
         float back_r = base_r * 0.73f, back_g = base_g * 0.77f, back_b = base_b * 0.84f;
 
+        float ground_ao = smoothstepf(12.0f, -14.0f, b.y - b.h * 0.5f);
+        float top_lit = retro_eval_brush_lighting(0.0f, 1.0f, 0.0f, 0.72f, sun_x, sun_y, sun_z);
+        float bot_lit = retro_eval_brush_lighting(0.0f, -1.0f, 0.0f, 0.58f, sun_x, sun_y, sun_z);
+        float front_lit = retro_eval_brush_lighting(0.0f, 0.0f, 1.0f, 0.64f, sun_x, sun_y, sun_z);
+        float back_lit = retro_eval_brush_lighting(0.0f, 0.0f, -1.0f, 0.62f, sun_x, sun_y, sun_z);
+        float left_lit = retro_eval_brush_lighting(-1.0f, 0.0f, 0.0f, 0.60f, sun_x, sun_y, sun_z);
+        float right_lit = retro_eval_brush_lighting(1.0f, 0.0f, 0.0f, 0.60f, sun_x, sun_y, sun_z);
+        bot_lit *= 0.86f - ground_ao * 0.18f;
+        front_lit *= 0.98f - ground_ao * 0.08f;
+        back_lit *= 0.96f - ground_ao * 0.10f;
+        left_lit *= 0.97f - ground_ao * 0.10f;
+        right_lit *= 0.99f - ground_ao * 0.08f;
+
         float dx = b.x - rp->x;
         float dz = b.z - rp->z;
         float dist = sqrtf(dx * dx + dz * dz);
-        float haze = clamp01f((dist - 450.0f) / 2200.0f);
-        top_r = lerpf(top_r, sky_r, haze); top_g = lerpf(top_g, sky_g, haze); top_b = lerpf(top_b, sky_b, haze);
-        base_r = lerpf(base_r, sky_r, haze); base_g = lerpf(base_g, sky_g, haze); base_b = lerpf(base_b, sky_b, haze);
-        side_r = lerpf(side_r, sky_r, haze); side_g = lerpf(side_g, sky_g, haze); side_b = lerpf(side_b, sky_b, haze);
-        back_r = lerpf(back_r, sky_r, haze); back_g = lerpf(back_g, sky_g, haze); back_b = lerpf(back_b, sky_b, haze);
+
+        top_r *= top_lit; top_g *= top_lit; top_b *= top_lit;
+        float bot_r = back_r * 0.85f * bot_lit, bot_g = back_g * 0.85f * bot_lit, bot_b = back_b * 0.85f * bot_lit;
+        float front_r = base_r * front_lit, front_g = base_g * front_lit, front_b = base_b * front_lit;
+        float rear_r = back_r * back_lit, rear_g = back_g * back_lit, rear_b = back_b * back_lit;
+        float left_r = side_r * left_lit, left_g = side_g * left_lit, left_b = side_b * left_lit;
+        float right_r = side_r * 0.95f * right_lit, right_g = side_g * 0.95f * right_lit, right_b = side_b * 0.95f * right_lit;
+        retro_apply_fog_rgb(&top_r, &top_g, &top_b, fog_r, fog_g, fog_b, dist);
+        retro_apply_fog_rgb(&bot_r, &bot_g, &bot_b, fog_r, fog_g, fog_b, dist);
+        retro_apply_fog_rgb(&front_r, &front_g, &front_b, fog_r, fog_g, fog_b, dist);
+        retro_apply_fog_rgb(&rear_r, &rear_g, &rear_b, fog_r, fog_g, fog_b, dist);
+        retro_apply_fog_rgb(&left_r, &left_g, &left_b, fog_r, fog_g, fog_b, dist);
+        retro_apply_fog_rgb(&right_r, &right_g, &right_b, fog_r, fog_g, fog_b, dist);
 
         glPushMatrix(); 
         glTranslatef(b.x, b.y, b.z); 
@@ -898,20 +948,20 @@ void draw_map() {
         glBegin(GL_QUADS);
         glColor3f(top_r, top_g, top_b);
         glVertex3f(-0.5,0.5,0.5); glVertex3f(0.5,0.5,0.5); glVertex3f(0.5,0.5,-0.5); glVertex3f(-0.5,0.5,-0.5);
-        glColor3f(back_r * 0.85f, back_g * 0.85f, back_b * 0.85f);
+        glColor3f(bot_r, bot_g, bot_b);
         glVertex3f(-0.5,-0.5,0.5); glVertex3f(0.5,-0.5,0.5); glVertex3f(0.5,-0.5,-0.5); glVertex3f(-0.5,-0.5,-0.5);
-        glColor3f(base_r, base_g, base_b);
+        glColor3f(front_r, front_g, front_b);
         glVertex3f(-0.5,-0.5,0.5); glVertex3f(0.5,-0.5,0.5); glVertex3f(0.5,0.5,0.5); glVertex3f(-0.5,0.5,0.5);
-        glColor3f(back_r, back_g, back_b);
+        glColor3f(rear_r, rear_g, rear_b);
         glVertex3f(-0.5,-0.5,-0.5); glVertex3f(0.5,-0.5,-0.5); glVertex3f(0.5,0.5,-0.5); glVertex3f(-0.5,0.5,-0.5);
-        glColor3f(side_r, side_g, side_b);
+        glColor3f(left_r, left_g, left_b);
         glVertex3f(-0.5,-0.5,-0.5); glVertex3f(-0.5,-0.5,0.5); glVertex3f(-0.5,0.5,0.5); glVertex3f(-0.5,0.5,-0.5);
-        glColor3f(side_r * 0.95f, side_g * 0.95f, side_b * 0.95f);
+        glColor3f(right_r, right_g, right_b);
         glVertex3f(0.5,-0.5,0.5); glVertex3f(0.5,-0.5,-0.5); glVertex3f(0.5,0.5,-0.5); glVertex3f(0.5,0.5,0.5);
         glEnd();
 
         glLineWidth(1.2f);
-        glColor3f(back_r * 0.7f, back_g * 0.75f, back_b * 0.8f);
+        glColor3f(rear_r * 0.76f, rear_g * 0.80f, rear_b * 0.84f);
         glBegin(GL_LINE_LOOP);
         glVertex3f(-0.5, 0.5, 0.5); glVertex3f(0.5, 0.5, 0.5); glVertex3f(0.5, 0.5, -0.5); glVertex3f(-0.5, 0.5, -0.5);
         glEnd();
@@ -977,6 +1027,12 @@ static void draw_team_map_markers(int scene_id, int game_mode) {
 void draw_terrain() {
     TerrainHeightfield *t = scene_active_terrain();
     if (!t || !t->active || !t->heights || t->width < 2 || t->height < 2) return;
+    int ref_id = (my_client_id >= 0 && my_client_id < MAX_CLIENTS) ? my_client_id : 0;
+    const PlayerState *rp = &local_state.players[ref_id];
+    float sun_x = 0.0f, sun_y = 1.0f, sun_z = 0.0f;
+    float fog_r = 0.18f, fog_g = 0.25f, fog_b = 0.36f;
+    retro_eval_sun_dir(&sun_x, &sun_y, &sun_z);
+    retro_eval_fog_rgb(&fog_r, &fog_g, &fog_b);
 
     float min_h = terrain_get_height(t, 0, 0);
     float max_h = min_h;
@@ -1013,7 +1069,6 @@ void draw_terrain() {
                 float h_norm0 = clamp01f((h0 - min_h) * inv_h_range);
                 float grass_mix0 = smoothstepf(0.62f, 0.92f, h_norm0) * (0.55f + 0.45f * ny0);
                 float dark_mix0 = smoothstepf(0.0f, 0.35f, 1.0f - h_norm0) * (0.55f + 0.45f * (1.0f - ny0));
-                float sun0 = clamp01f(0.55f + nx0 * 0.23f + ny0 * 0.42f + nz0 * 0.14f);
                 float base_r0 = 0.58f, base_g0 = 0.49f, base_b0 = 0.37f;
                 float r0 = lerpf(base_r0, 0.65f, grass_mix0);
                 float g0 = lerpf(base_g0, 0.62f, grass_mix0);
@@ -1021,9 +1076,15 @@ void draw_terrain() {
                 r0 = lerpf(r0, 0.35f, dark_mix0);
                 g0 = lerpf(g0, 0.33f, dark_mix0);
                 b0 = lerpf(b0, 0.30f, dark_mix0);
-                r0 *= 0.72f + sun0 * 0.32f;
-                g0 *= 0.72f + sun0 * 0.30f;
-                b0 *= 0.76f + sun0 * 0.24f;
+                float sun0 = retro_eval_brush_lighting(nx0, ny0, nz0, 0.66f, sun_x, sun_y, sun_z);
+                float ambient_occ0 = smoothstepf(0.25f, 0.95f, ny0) * 0.08f + smoothstepf(0.16f, 0.0f, h_norm0) * 0.10f;
+                float lit0 = sun0 * (0.98f - ambient_occ0);
+                r0 *= lit0;
+                g0 *= lit0 * 0.98f;
+                b0 *= lit0 * 0.92f;
+                float dx0 = x - rp->x;
+                float dz0 = z0 - rp->z;
+                retro_apply_fog_rgb(&r0, &g0, &b0, fog_r, fog_g, fog_b, sqrtf(dx0 * dx0 + dz0 * dz0));
                 glColor3f(r0, g0, b0);
             }
             glVertex3f(x, h0, z0);
@@ -1038,7 +1099,6 @@ void draw_terrain() {
                 float h_norm1 = clamp01f((h1 - min_h) * inv_h_range);
                 float grass_mix1 = smoothstepf(0.62f, 0.92f, h_norm1) * (0.55f + 0.45f * ny1);
                 float dark_mix1 = smoothstepf(0.0f, 0.35f, 1.0f - h_norm1) * (0.55f + 0.45f * (1.0f - ny1));
-                float sun1 = clamp01f(0.55f + nx1 * 0.23f + ny1 * 0.42f + nz1 * 0.14f);
                 float base_r1 = 0.58f, base_g1 = 0.49f, base_b1 = 0.37f;
                 float r1 = lerpf(base_r1, 0.65f, grass_mix1);
                 float g1 = lerpf(base_g1, 0.62f, grass_mix1);
@@ -1046,9 +1106,15 @@ void draw_terrain() {
                 r1 = lerpf(r1, 0.35f, dark_mix1);
                 g1 = lerpf(g1, 0.33f, dark_mix1);
                 b1 = lerpf(b1, 0.30f, dark_mix1);
-                r1 *= 0.72f + sun1 * 0.32f;
-                g1 *= 0.72f + sun1 * 0.30f;
-                b1 *= 0.76f + sun1 * 0.24f;
+                float sun1 = retro_eval_brush_lighting(nx1, ny1, nz1, 0.66f, sun_x, sun_y, sun_z);
+                float ambient_occ1 = smoothstepf(0.25f, 0.95f, ny1) * 0.08f + smoothstepf(0.16f, 0.0f, h_norm1) * 0.10f;
+                float lit1 = sun1 * (0.98f - ambient_occ1);
+                r1 *= lit1;
+                g1 *= lit1 * 0.98f;
+                b1 *= lit1 * 0.92f;
+                float dx1 = x - rp->x;
+                float dz1 = z1 - rp->z;
+                retro_apply_fog_rgb(&r1, &g1, &b1, fog_r, fog_g, fog_b, sqrtf(dx1 * dx1 + dz1 * dz1));
                 glColor3f(r1, g1, b1);
             }
             glVertex3f(x, h1, z1);

--- a/packages/render/retro_sky.c
+++ b/packages/render/retro_sky.c
@@ -24,6 +24,35 @@ static float fracf(float v) {
     return v - floorf(v);
 }
 
+void retro_sky_eval_sun_dir(float time_sec, float *out_x, float *out_y, float *out_z) {
+    float orbit_t = time_sec * 0.025f;
+    float tilt = 0.40f;
+    float sun_x = cosf(orbit_t);
+    float sun_y = sinf(orbit_t) * cosf(tilt);
+    float sun_z = sinf(orbit_t) * sinf(tilt);
+
+    if (out_x) *out_x = sun_x;
+    if (out_y) *out_y = sun_y;
+    if (out_z) *out_z = sun_z;
+}
+
+void retro_sky_eval_fog_rgb(float time_sec, float *out_r, float *out_g, float *out_b) {
+    float sun_y = 0.0f;
+    retro_sky_eval_sun_dir(time_sec, NULL, &sun_y, NULL);
+
+    float daylight = smoothstepf(-0.22f, 0.35f, sun_y);
+    float sky_top_r = (1.0f - daylight) * 0.05f + daylight * 0.60f;
+    float sky_top_g = (1.0f - daylight) * 0.08f + daylight * 0.76f;
+    float sky_top_b = (1.0f - daylight) * 0.15f + daylight * 0.94f;
+    float sky_low_r = (1.0f - daylight) * 0.08f + daylight * 0.65f;
+    float sky_low_g = (1.0f - daylight) * 0.10f + daylight * 0.78f;
+    float sky_low_b = (1.0f - daylight) * 0.16f + daylight * 0.93f;
+
+    if (out_r) *out_r = sky_low_r * 0.70f + sky_top_r * 0.30f;
+    if (out_g) *out_g = sky_low_g * 0.70f + sky_top_g * 0.30f;
+    if (out_b) *out_b = sky_low_b * 0.70f + sky_top_b * 0.30f;
+}
+
 static void fill_cloud_texture(ProcTexture *t) {
     if (!t || !t->pixels) return;
     for (int y = 0; y < t->height; ++y) {
@@ -70,10 +99,16 @@ static void fill_disc_texture(ProcTexture *t, float r, float g, float b, float e
     }
 }
 
-static void draw_sky_cube(float s) {
-    const float top_r = 0.60f, top_g = 0.76f, top_b = 0.94f;
-    const float mid_r = 0.56f, mid_g = 0.73f, mid_b = 0.92f;
-    const float low_r = 0.65f, low_g = 0.78f, low_b = 0.93f;
+static void draw_sky_cube(float s, float daylight) {
+    float top_r = (1.0f - daylight) * 0.05f + daylight * 0.60f;
+    float top_g = (1.0f - daylight) * 0.08f + daylight * 0.76f;
+    float top_b = (1.0f - daylight) * 0.15f + daylight * 0.94f;
+    float mid_r = (1.0f - daylight) * 0.07f + daylight * 0.56f;
+    float mid_g = (1.0f - daylight) * 0.09f + daylight * 0.73f;
+    float mid_b = (1.0f - daylight) * 0.16f + daylight * 0.92f;
+    float low_r = (1.0f - daylight) * 0.08f + daylight * 0.65f;
+    float low_g = (1.0f - daylight) * 0.10f + daylight * 0.78f;
+    float low_b = (1.0f - daylight) * 0.16f + daylight * 0.93f;
 
     glBegin(GL_QUADS);
     glColor3f(top_r, top_g, top_b);
@@ -220,21 +255,15 @@ void retro_sky_draw(RetroSky *sky, float cam_x, float cam_y, float cam_z, float 
     glPushMatrix();
     glTranslatef(cam_x, cam_y, cam_z);
 
-    draw_sky_cube(3200.0f);
+    float sun_dir_x = 0.0f, sun_dir_y = 1.0f, sun_dir_z = 0.0f;
+    retro_sky_eval_sun_dir(time_sec, &sun_dir_x, &sun_dir_y, &sun_dir_z);
+    float daylight = smoothstepf(-0.22f, 0.35f, sun_dir_y);
+    draw_sky_cube(3200.0f, daylight);
 
     float cloud_scroll = fracf(time_sec * 0.0016f);
-    draw_cloud_layer(sky->cloud_tex.tex_id, 1800.0f, 940.0f, cloud_scroll, 0.22f);
-    draw_cloud_layer(sky->cloud_tex.tex_id, 1500.0f, 880.0f, fracf(-time_sec * 0.0011f), 0.16f);
+    draw_cloud_layer(sky->cloud_tex.tex_id, 1800.0f, 940.0f, cloud_scroll, 0.10f + daylight * 0.16f);
+    draw_cloud_layer(sky->cloud_tex.tex_id, 1500.0f, 880.0f, fracf(-time_sec * 0.0011f), 0.08f + daylight * 0.12f);
 
-    /*
-     * Sun/moon move on one tilted circular orbit and are always opposite vectors.
-     * This gives a simple, stable day-night motion suitable for a retro style.
-     */
-    float orbit_t = time_sec * 0.025f;
-    float tilt = 0.40f;
-    float sun_dir_x = cosf(orbit_t);
-    float sun_dir_y = sinf(orbit_t) * cosf(tilt);
-    float sun_dir_z = sinf(orbit_t) * sinf(tilt);
     float sun_dist = 2200.0f;
     float moon_dist = 2160.0f;
 

--- a/packages/render/retro_sky.h
+++ b/packages/render/retro_sky.h
@@ -12,6 +12,8 @@ typedef struct RetroSky {
 
 int retro_sky_init(RetroSky *sky);
 void retro_sky_shutdown(RetroSky *sky);
+void retro_sky_eval_sun_dir(float time_sec, float *out_x, float *out_y, float *out_z);
+void retro_sky_eval_fog_rgb(float time_sec, float *out_r, float *out_g, float *out_b);
 
 /*
  * Sky is rendered camera-centered so it appears infinitely far away:


### PR DESCRIPTION
### Motivation
- Ground the scene with an old-school sun/fog system so sky, fog and lighting feel coherent without adding PBR or shadow maps. 
- Provide a small, centralized retro-atmosphere seam so future stylistic tweaks (fog color, sun orbit, AO heuristics) can be iterated without changing world data paths. 
- Improve readability of map boxes and terrain using restrained directional + strong ambient floor lighting, subtle AO-like darkening, and distance haze that harmonizes with the sky.

### Description
- Exposed reusable sky evaluators `retro_sky_eval_sun_dir` and `retro_sky_eval_fog_rgb` in `packages/render/retro_sky.h` and implemented them in `packages/render/retro_sky.c` so the sky and atmosphere share the same sun orbit and daylight evaluation. 
- Enhanced sky rendering in `packages/render/retro_sky.c` to compute a `daylight` factor, tint the sky cube based on time of day, and modulate cloud alpha to match day/night. 
- Added a small retro-atmosphere seam in `apps/lobby/src/main.c` with helpers `retro_eval_sun_dir`, `retro_eval_fog_rgb`, `retro_apply_fog_rgb`, and `retro_eval_brush_lighting` to keep cheap baked-like lighting/fog math centralized. 
- Updated `draw_map()` (box/brush renderer) to apply directional lighting tied to the sky sun, a strong base ambient floor for readability, simple AO-like darkening near bottoms, and distance fog blended toward the sky-derived fog color while preserving immediate-mode GL and original draw order. 
- Updated `draw_terrain()` to reuse the same sun/fog seam for per-vertex lighting and small ambient occlusion heuristics, and to blend distant verts toward the sky/fog color.

### Testing
- Attempted a native build with `make -j4`, which could not complete in this environment due to missing development headers for SDL2/OpenGL (`SDL2/SDL.h` and `SDL2/SDL_opengl.h`), so runtime rendering validation could not be performed here. 
- No automated unit tests were added in this change and no other CI checks were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3e389760083278b85ea62847595a4)