### PR TITLE
Terrain lighting: use shared RetroLightingState and remove fake canyon side-lighting

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -205,6 +205,54 @@ static void retro_eval_brush_lighting_rgb(const RetroLightingState *lighting, fl
     retro_lighting_eval_surface_rgb(lighting, nx, ny, nz, ambient_floor, out_r, out_g, out_b);
 }
 
+static void terrain_eval_material_rgb(float h_norm, float ny, float *out_r, float *out_g, float *out_b) {
+    float grass_mix = smoothstepf(0.62f, 0.92f, h_norm) * (0.55f + 0.45f * ny);
+    float dark_mix = smoothstepf(0.0f, 0.35f, 1.0f - h_norm) * (0.55f + 0.45f * (1.0f - ny));
+    float base_r = 0.58f, base_g = 0.49f, base_b = 0.37f;
+    float r = lerpf(base_r, 0.65f, grass_mix);
+    float g = lerpf(base_g, 0.62f, grass_mix);
+    float b = lerpf(base_b, 0.36f, grass_mix);
+    r = lerpf(r, 0.35f, dark_mix);
+    g = lerpf(g, 0.33f, dark_mix);
+    b = lerpf(b, 0.30f, dark_mix);
+    if (out_r) *out_r = r;
+    if (out_g) *out_g = g;
+    if (out_b) *out_b = b;
+}
+
+static void terrain_eval_vertex_rgb(const RetroLightingState *lighting, const PlayerState *rp,
+                                    float x, float z, float h_norm,
+                                    float nx, float ny, float nz,
+                                    float *out_r, float *out_g, float *out_b) {
+    float r = 0.58f, g = 0.49f, b = 0.37f;
+    terrain_eval_material_rgb(h_norm, ny, &r, &g, &b);
+
+    /* Terrain truth pass: directional light comes from shared world-light state. */
+    float light_r = 1.0f, light_g = 1.0f, light_b = 1.0f;
+    retro_lighting_eval_surface_rgb(lighting, nx, ny, nz, 0.66f, &light_r, &light_g, &light_b);
+
+    /* Keep AO as a restrained secondary cue, never a fake side-light. */
+    float slope_ao = smoothstepf(0.15f, 0.95f, 1.0f - ny) * 0.12f;
+    float basin_ao = smoothstepf(0.22f, 0.0f, h_norm) * 0.08f;
+    float ambient_occ = slope_ao + basin_ao;
+    if (ambient_occ > 0.22f) ambient_occ = 0.22f;
+    float ao = 1.0f - ambient_occ;
+
+    r *= light_r * ao;
+    g *= light_g * ao;
+    b *= light_b * ao;
+
+    if (rp) {
+        float dx = x - rp->x;
+        float dz = z - rp->z;
+        retro_apply_fog_rgb(&r, &g, &b, lighting, sqrtf(dx * dx + dz * dz));
+    }
+
+    if (out_r) *out_r = r;
+    if (out_g) *out_g = g;
+    if (out_b) *out_b = b;
+}
+
 #define Z_FAR 8000.0f
 
 static void draw_box(float w, float h, float d);
@@ -1067,25 +1115,8 @@ void draw_terrain(const RetroLightingState *lighting) {
                 glColor3f(shade0 * 0.92f, shade0 * 0.70f, shade0 * 0.48f);
             } else {
                 float h_norm0 = clamp01f((h0 - min_h) * inv_h_range);
-                float grass_mix0 = smoothstepf(0.62f, 0.92f, h_norm0) * (0.55f + 0.45f * ny0);
-                float dark_mix0 = smoothstepf(0.0f, 0.35f, 1.0f - h_norm0) * (0.55f + 0.45f * (1.0f - ny0));
-                float base_r0 = 0.58f, base_g0 = 0.49f, base_b0 = 0.37f;
-                float r0 = lerpf(base_r0, 0.65f, grass_mix0);
-                float g0 = lerpf(base_g0, 0.62f, grass_mix0);
-                float b0 = lerpf(base_b0, 0.36f, grass_mix0);
-                r0 = lerpf(r0, 0.35f, dark_mix0);
-                g0 = lerpf(g0, 0.33f, dark_mix0);
-                b0 = lerpf(b0, 0.30f, dark_mix0);
-                float sun0_r = 1.0f, sun0_g = 1.0f, sun0_b = 1.0f;
-                retro_eval_brush_lighting_rgb(lighting, nx0, ny0, nz0, 0.66f, &sun0_r, &sun0_g, &sun0_b);
-                float ambient_occ0 = smoothstepf(0.25f, 0.95f, ny0) * 0.08f + smoothstepf(0.16f, 0.0f, h_norm0) * 0.10f;
-                float lit0_occ = 0.98f - ambient_occ0;
-                r0 *= sun0_r * lit0_occ;
-                g0 *= sun0_g * lit0_occ * 0.98f;
-                b0 *= sun0_b * lit0_occ * 0.92f;
-                float dx0 = x - rp->x;
-                float dz0 = z0 - rp->z;
-                retro_apply_fog_rgb(&r0, &g0, &b0, lighting, sqrtf(dx0 * dx0 + dz0 * dz0));
+                float r0 = 1.0f, g0 = 1.0f, b0 = 1.0f;
+                terrain_eval_vertex_rgb(lighting, rp, x, z0, h_norm0, nx0, ny0, nz0, &r0, &g0, &b0);
                 glColor3f(r0, g0, b0);
             }
             glVertex3f(x, h0, z0);
@@ -1098,25 +1129,8 @@ void draw_terrain(const RetroLightingState *lighting) {
                 glColor3f(shade1 * 0.92f, shade1 * 0.70f, shade1 * 0.48f);
             } else {
                 float h_norm1 = clamp01f((h1 - min_h) * inv_h_range);
-                float grass_mix1 = smoothstepf(0.62f, 0.92f, h_norm1) * (0.55f + 0.45f * ny1);
-                float dark_mix1 = smoothstepf(0.0f, 0.35f, 1.0f - h_norm1) * (0.55f + 0.45f * (1.0f - ny1));
-                float base_r1 = 0.58f, base_g1 = 0.49f, base_b1 = 0.37f;
-                float r1 = lerpf(base_r1, 0.65f, grass_mix1);
-                float g1 = lerpf(base_g1, 0.62f, grass_mix1);
-                float b1 = lerpf(base_b1, 0.36f, grass_mix1);
-                r1 = lerpf(r1, 0.35f, dark_mix1);
-                g1 = lerpf(g1, 0.33f, dark_mix1);
-                b1 = lerpf(b1, 0.30f, dark_mix1);
-                float sun1_r = 1.0f, sun1_g = 1.0f, sun1_b = 1.0f;
-                retro_eval_brush_lighting_rgb(lighting, nx1, ny1, nz1, 0.66f, &sun1_r, &sun1_g, &sun1_b);
-                float ambient_occ1 = smoothstepf(0.25f, 0.95f, ny1) * 0.08f + smoothstepf(0.16f, 0.0f, h_norm1) * 0.10f;
-                float lit1_occ = 0.98f - ambient_occ1;
-                r1 *= sun1_r * lit1_occ;
-                g1 *= sun1_g * lit1_occ * 0.98f;
-                b1 *= sun1_b * lit1_occ * 0.92f;
-                float dx1 = x - rp->x;
-                float dz1 = z1 - rp->z;
-                retro_apply_fog_rgb(&r1, &g1, &b1, lighting, sqrtf(dx1 * dx1 + dz1 * dz1));
+                float r1 = 1.0f, g1 = 1.0f, b1 = 1.0f;
+                terrain_eval_vertex_rgb(lighting, rp, x, z1, h_norm1, nx1, ny1, nz1, &r1, &g1, &b1);
                 glColor3f(r1, g1, b1);
             }
             glVertex3f(x, h1, z1);


### PR DESCRIPTION
### Motivation
- Replace ad-hoc per-vertex "side" biasing with the shared `RetroLightingState` world-light rig so terrain (especially Voxworld canyons) responds to actual normals vs. sun/moon direction. 
- Preserve terrain macro material/readability while making directional lighting truthful and coherent with brush/box lighting.

### Description
- Added a small, local terrain lighting seam in `apps/lobby/src/main.c`: `terrain_eval_material_rgb(...)` to produce base material/macro color from height/slope, and `terrain_eval_vertex_rgb(...)` to apply world lighting, restrained AO, and fog to a single terrain sample. 
- Replaced the previous inline per-vertex lighting math inside `draw_terrain(const RetroLightingState *lighting)` with calls to the new `terrain_eval_vertex_rgb(...)`, so directional light now comes from `retro_lighting_eval_surface_rgb(...)` using sampled normals (`terrain_sample_normal(...)`). 
- Removed the prior hand-authored inlined lighting mix that biased color channels and acted like fake side-lighting; final color is now computed as: `material_color * world_light_rgb * restrained_AO`, then fogged via `retro_apply_fog_rgb(...)`. 
- Kept existing terrain material variation (height/slope-driven grass/dark mixes) and kept a restrained, secondary AO term (clamped) so creases remain readable without acting as directional sunlight.
- Files changed: `apps/lobby/src/main.c` (added helper functions and updated `draw_terrain`).

### Testing
- Attempted to run the project's test harness via `./run_tests`, but the test binary could not be executed in this environment (permission/format issue). 
- Performed a syntax-only check with `gcc -fsyntax-only apps/lobby/src/main.c -I...`, which failed in this environment due to missing system headers (`SDL2/SDL.h`) rather than changes introduced by this patch. 
- Verified the source diff and local build-level edits with `git diff`/file inspection to confirm the old fake per-vertex lighting was removed and replaced by the new terrain lighting seam.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3f57db8508327afa729700d0abacc)