### PR TITLE
Tune retro fog haze with scene-aware near/far presets

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -247,6 +247,41 @@ static void retro_eval_terrain_vertex_rgb(const RetroLightingState *lighting,
     if (out_b) *out_b = material_b * light_b * ao;
 }
 
+/*
+ * Scene fog tuning seam:
+ * Keep per-world readability decisions data-driven while preserving the
+ * centralized RetroLightingState -> retro_apply_fog_rgb pipeline.
+ */
+static void retro_tune_world_fog(RetroLightingState *lighting, int scene_id) {
+    if (!lighting) return;
+
+    /* First pass global haze target. */
+    lighting->fog_near = 220.0f;
+    lighting->fog_far = 1600.0f;
+
+    /*
+     * Large outdoor worlds retain a bit more depth so portals and skyline
+     * silhouettes remain readable at gameplay ranges.
+     */
+    if (scene_id == SCENE_VOXWORLD || scene_id == SCENE_STADIUM || scene_id == SCENE_POO_POO_ISLAND) {
+        lighting->fog_near = 300.0f;
+        lighting->fog_far = 1900.0f;
+        lighting->fog_r *= 0.96f;
+        lighting->fog_g *= 0.98f;
+        lighting->fog_b = lighting->fog_b * 1.02f + 0.01f;
+    }
+
+    /* Tighter interior/garage volumes can carry denser haze. */
+    if (scene_id == SCENE_GARAGE_OSAKA) {
+        lighting->fog_near = 200.0f;
+        lighting->fog_far = 1450.0f;
+    }
+
+    lighting->fog_r = clamp01f(lighting->fog_r);
+    lighting->fog_g = clamp01f(lighting->fog_g);
+    lighting->fog_b = clamp01f(lighting->fog_b);
+}
+
 #define Z_FAR 8000.0f
 
 static void draw_box(float w, float h, float d);
@@ -3391,6 +3426,7 @@ void draw_scene(PlayerState *render_p) {
 
     RetroLightingState world_lighting;
     retro_lighting_eval(now_ms * 0.001f, g_world_lighting_preset, &world_lighting);
+    retro_tune_world_fog(&world_lighting, local_state.scene_id);
     
     draw_grid(); 
     update_and_draw_trails();


### PR DESCRIPTION
### Motivation
- Increase perceptible world haze using the existing retro atmosphere seam without changing renderer code. 
- Make fog start closer and reach full strength sooner (target mid-distance haze) while preserving gameplay readability (silhouettes, portals, landmarks). 
- Allow per-world tuning so large outdoor scenes remain less aggressive than tight interiors.

### Description
- Adds a focused tuning seam `retro_tune_world_fog(RetroLightingState *lighting, int scene_id)` in `apps/lobby/src/main.c` that adjusts fog parameters on the evaluated `RetroLightingState` before draw calls. 
- Sets the first-pass global targets to `fog_near = 220.0f` and `fog_far = 1600.0f`. 
- Applies per-scene adjustments: large outdoor scenes (`SCENE_VOXWORLD`, `SCENE_STADIUM`, `SCENE_POO_POO_ISLAND`) use `300/1900` and a slight cooler tint nudge, and the garage interior (`SCENE_GARAGE_OSAKA`) uses `200/1450`. 
- Keeps all blending through the existing `retro_apply_fog_rgb(...)` seam by calling `retro_tune_world_fog(&world_lighting, local_state.scene_id)` immediately after `retro_lighting_eval(...)` so no ad-hoc fog logic is duplicated.

### Testing
- Ran `make lobby` to validate the build; the build attempted to compile but failed in this environment due to missing SDL2 development headers (`SDL2/SDL.h`, `SDL2/SDL_opengl.h`), so an in-environment binary could not be produced. 
- Verified the new function and callsite were inserted into `apps/lobby/src/main.c` and confirmed the code paths still route fog through `RetroLightingState` and `retro_apply_fog_rgb` (static inspection/grep/sed checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3fe4529b48327a4f814161c05a39c)