### PR TITLE
Add standalone scene editor app and JSON scene format (first pass)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,16 +15,18 @@ LIBS_M   := -lm
 LOBBY_SRC    := apps/lobby/src/main.c packages/render/proc_tex.c packages/render/retro_material.c packages/render/retro_sky.c packages/render/retro_lighting.c packages/world/terrain.c
 SERVER_SRC   := apps/server/src/main.c packages/world/terrain.c
 SERVERCTL_SRC:= apps/server/serverctl.c
+SCENE_EDITOR_SRC := apps/scene_editor/main.c apps/scene_editor/editor_app.c apps/scene_editor/editor_camera.c apps/scene_editor/editor_selection.c apps/scene_editor/editor_move_tool.c apps/scene_editor/editor_ui.c apps/scene_editor/editor_scene_asset.c apps/scene_editor/editor_scene_json.c
 
 # ---- Outputs ----
 LOBBY_BIN    := $(BIN_DIR)/shank_lobby
 SERVER_BIN   := $(BIN_DIR)/shank_server
 SERVERCTL_BIN:= $(BIN_DIR)/serverctl
+SCENE_EDITOR_BIN := $(BIN_DIR)/shank_scene_editor
 
 # ---- Targets ----
-.PHONY: all lobby server serverctl clean setup print
+.PHONY: all lobby server serverctl scene_editor clean setup print
 
-all: $(LOBBY_BIN) $(SERVER_BIN)
+all: $(LOBBY_BIN) $(SERVER_BIN) $(SCENE_EDITOR_BIN)
 
 # Ensure bin/ exists even when building a single target
 $(BIN_DIR):
@@ -53,6 +55,13 @@ $(SERVERCTL_BIN): $(SERVERCTL_SRC) | $(BIN_DIR)
 	@echo "🖥️ Building Server Control (requires ncurses)..."
 	$(CC) -O2 $< -o $@ -lncurses
 
+# ---- SCENE EDITOR (STANDALONE TOOL) ----
+scene_editor: $(SCENE_EDITOR_BIN)
+
+$(SCENE_EDITOR_BIN): $(SCENE_EDITOR_SRC) | $(BIN_DIR)
+	@echo "🧰 Building Scene Editor..."
+	$(CC) $(CFLAGS) $(INCLUDES) $(SCENE_EDITOR_SRC) -o $@ $(LIBS_GL)
+
 clean:
 	@echo "🧹 Cleaning..."
 	rm -rf $(BIN_DIR)
@@ -60,3 +69,4 @@ clean:
 print:
 	@echo "LOBBY_BIN=$(LOBBY_BIN)"
 	@echo "SERVER_BIN=$(SERVER_BIN)"
+	@echo "SCENE_EDITOR_BIN=$(SCENE_EDITOR_BIN)"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,107 @@
 
 SHANKPIT is a fast-paced 3D multiplayer first-person shooter built with C, SDL2, and OpenGL. The game features physics-based movement, multiple weapons, shield mechanics, and support for both human players and AI bots (including neural network-powered agents).
 
+
+## Scene Editor (Standalone First Pass)
+
+This pass introduces a **standalone scene editor app** under `apps/scene_editor/` for authoring a proposed external scene format without changing the current runtime scene-loading/build path.
+
+> Current limitation: The editor currently edits the proposed external scene format as a standalone tool. Existing runtime maps/scenes still use the current path. Runtime adoption of this format will happen in a later change once the protocol is validated.
+
+### Build and run
+
+- Build everything (including editor artifact):
+  - `make all`
+- Build only editor:
+  - `make scene_editor`
+- Run editor against default sample:
+  - `./bin/shank_scene_editor`
+- Run editor against a specific scene file:
+  - `./bin/shank_scene_editor assets/scenes/test_room.json`
+
+### Editor controls (V1)
+
+- `Alt + Left Mouse Drag`: orbit camera around anchor.
+- `Mouse Wheel`: zoom.
+- `Middle Mouse Drag` or `Alt + Right Mouse Drag`: pan / move anchor.
+- `Left Mouse`: pick box.
+- `Left Mouse Drag`: move selected box (move tool).
+- `X` / `Y` / `Z`: axis lock for move tool.
+- `G`: clear axis lock (free move).
+- `F`: frame selected box.
+- `O`: load JSON from current path.
+- `P`: save JSON to current path.
+- `[` / `]`: select previous/next stage camera.
+- `N`: create stage camera from current viewport.
+- `C`: toggle selected stage camera driving viewport.
+- `KP 4/6`: yaw selected stage camera.
+- `KP 8/2`: pitch selected stage camera.
+- `+/-`: distance selected stage camera.
+- `PageUp/PageDown`: FOV selected stage camera.
+
+### Proposed scene/map format protocol (JSON V1)
+
+This section documents the proposed external authoring protocol for future runtime adoption.
+
+Top-level JSON object:
+
+- `version` (number)
+- `scene_name` (string)
+- `boxes` (array of box objects)
+- `stage_cameras` (array of stage camera objects)
+
+Each `boxes[]` entry:
+
+- `id` (number)
+- `name` (string)
+- `position` (`[x, y, z]` float array)
+- `size` (`[x, y, z]` float array)
+- `rotation_y_degrees` (float, **Y-axis only in V1**)
+- `color` (`[r, g, b, a]` float array)
+- `flags.solid` (0/1)
+- `flags.visible` (0/1)
+
+Each `stage_cameras[]` entry:
+
+- `id` (number)
+- `name` (string)
+- `target` (`[x, y, z]` float array)
+- `distance` (float)
+- `yaw_degrees` (float)
+- `pitch_degrees` (float)
+- `fov_degrees` (float)
+
+### Example scene JSON
+
+```json
+{
+  "version": 1,
+  "scene_name": "test_room",
+  "boxes": [
+    {
+      "id": 1,
+      "name": "floor",
+      "position": [0.0, -1.0, 0.0],
+      "size": [30.0, 1.0, 30.0],
+      "rotation_y_degrees": 0.0,
+      "color": [0.25, 0.28, 0.30, 1.0],
+      "flags": { "solid": 1, "visible": 1 }
+    }
+  ],
+  "stage_cameras": [
+    {
+      "id": 1,
+      "name": "overview",
+      "target": [0.0, 1.0, 0.0],
+      "distance": 28.0,
+      "yaw_degrees": 35.0,
+      "pitch_degrees": 24.0,
+      "fov_degrees": 60.0
+    }
+  ]
+}
+```
+
 ## Controls (Player + Vehicles)
 
 ### Core movement & combat

--- a/apps/scene_editor/editor_app.c
+++ b/apps/scene_editor/editor_app.c
@@ -1,0 +1,450 @@
+#define SDL_MAIN_HANDLED
+#include "editor_app.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_opengl.h>
+#include <GL/glu.h>
+
+#include "editor_camera.h"
+#include "editor_move_tool.h"
+#include "editor_scene_asset.h"
+#include "editor_scene_json.h"
+#include "editor_selection.h"
+#include "editor_ui.h"
+
+typedef struct {
+    SDL_Window *window;
+    SDL_GLContext gl;
+    int running;
+    int width;
+    int height;
+
+    char active_scene_path[256];
+    EditorSceneAsset scene;
+    EditorViewportCamera camera;
+    EditorMoveTool move_tool;
+
+    int selected_box;
+    int selected_stage_camera;
+    int stage_camera_drives_viewport;
+
+    int mouse_x;
+    int mouse_y;
+} EditorApp;
+
+static float clampf(float v, float lo, float hi) {
+    if (v < lo) return lo;
+    if (v > hi) return hi;
+    return v;
+}
+
+static void vec3_sub(const float a[3], const float b[3], float out[3]) {
+    out[0] = a[0] - b[0]; out[1] = a[1] - b[1]; out[2] = a[2] - b[2];
+}
+
+static float vec3_dot(const float a[3], const float b[3]) {
+    return a[0]*b[0] + a[1]*b[1] + a[2]*b[2];
+}
+
+static void vec3_cross(const float a[3], const float b[3], float out[3]) {
+    out[0] = a[1]*b[2] - a[2]*b[1];
+    out[1] = a[2]*b[0] - a[0]*b[2];
+    out[2] = a[0]*b[1] - a[1]*b[0];
+}
+
+static void vec3_norm(float v[3]) {
+    float len = sqrtf(vec3_dot(v, v));
+    if (len > 1e-6f) {
+        v[0] /= len; v[1] /= len; v[2] /= len;
+    }
+}
+
+static int ray_from_mouse(const EditorApp *app, int x, int y, float out_origin[3], float out_dir[3]) {
+    GLfloat model[16], proj[16];
+    GLint view[4];
+    glGetDoublev(GL_MODELVIEW_MATRIX, (GLdouble*)model);
+    glGetDoublev(GL_PROJECTION_MATRIX, (GLdouble*)proj);
+    glGetIntegerv(GL_VIEWPORT, view);
+
+    double near_x, near_y, near_z;
+    double far_x, far_y, far_z;
+    if (!gluUnProject((double)x, (double)(app->height - y), 0.0, (GLdouble*)model, (GLdouble*)proj, view, &near_x, &near_y, &near_z)) return 0;
+    if (!gluUnProject((double)x, (double)(app->height - y), 1.0, (GLdouble*)model, (GLdouble*)proj, view, &far_x, &far_y, &far_z)) return 0;
+
+    out_origin[0] = (float)near_x;
+    out_origin[1] = (float)near_y;
+    out_origin[2] = (float)near_z;
+    out_dir[0] = (float)(far_x - near_x);
+    out_dir[1] = (float)(far_y - near_y);
+    out_dir[2] = (float)(far_z - near_z);
+    vec3_norm(out_dir);
+    return 1;
+}
+
+static int ray_plane_hit(const float ro[3], const float rd[3], float plane_y, float hit[3]) {
+    if (fabsf(rd[1]) < 1e-6f) return 0;
+    float t = (plane_y - ro[1]) / rd[1];
+    if (t < 0.0f) return 0;
+    hit[0] = ro[0] + rd[0] * t;
+    hit[1] = ro[1] + rd[1] * t;
+    hit[2] = ro[2] + rd[2] * t;
+    return 1;
+}
+
+static void apply_view(const EditorApp *app) {
+    float eye[3];
+    editor_camera_eye_position(&app->camera, eye);
+
+    glMatrixMode(GL_PROJECTION);
+    glLoadIdentity();
+    gluPerspective(app->camera.fov_degrees, (double)app->width / (double)app->height, 0.1, 5000.0);
+
+    glMatrixMode(GL_MODELVIEW);
+    glLoadIdentity();
+    gluLookAt(eye[0], eye[1], eye[2],
+              app->camera.target[0], app->camera.target[1], app->camera.target[2],
+              0.0, 1.0, 0.0);
+}
+
+static void draw_grid(void) {
+    glColor3f(0.15f, 0.25f, 0.35f);
+    glBegin(GL_LINES);
+    for (int i = -100; i <= 100; i++) {
+        glVertex3f((float)i * 2.0f, 0.0f, -200.0f);
+        glVertex3f((float)i * 2.0f, 0.0f, 200.0f);
+        glVertex3f(-200.0f, 0.0f, (float)i * 2.0f);
+        glVertex3f(200.0f, 0.0f, (float)i * 2.0f);
+    }
+    glEnd();
+}
+
+static void draw_box(const EditorSceneBox *box, int selected) {
+    glPushMatrix();
+    glTranslatef(box->position[0], box->position[1], box->position[2]);
+    glRotatef(box->rotation_y_degrees, 0.0f, 1.0f, 0.0f);
+    glScalef(box->size[0], box->size[1], box->size[2]);
+
+    glColor4f(box->color[0], box->color[1], box->color[2], box->color[3]);
+    glBegin(GL_QUADS);
+    glVertex3f(-0.5f,-0.5f, 0.5f); glVertex3f( 0.5f,-0.5f, 0.5f); glVertex3f( 0.5f, 0.5f, 0.5f); glVertex3f(-0.5f, 0.5f, 0.5f);
+    glVertex3f(-0.5f,-0.5f,-0.5f); glVertex3f(-0.5f, 0.5f,-0.5f); glVertex3f( 0.5f, 0.5f,-0.5f); glVertex3f( 0.5f,-0.5f,-0.5f);
+    glVertex3f(-0.5f, 0.5f,-0.5f); glVertex3f(-0.5f, 0.5f, 0.5f); glVertex3f( 0.5f, 0.5f, 0.5f); glVertex3f( 0.5f, 0.5f,-0.5f);
+    glVertex3f(-0.5f,-0.5f,-0.5f); glVertex3f( 0.5f,-0.5f,-0.5f); glVertex3f( 0.5f,-0.5f, 0.5f); glVertex3f(-0.5f,-0.5f, 0.5f);
+    glVertex3f( 0.5f,-0.5f,-0.5f); glVertex3f( 0.5f, 0.5f,-0.5f); glVertex3f( 0.5f, 0.5f, 0.5f); glVertex3f( 0.5f,-0.5f, 0.5f);
+    glVertex3f(-0.5f,-0.5f,-0.5f); glVertex3f(-0.5f,-0.5f, 0.5f); glVertex3f(-0.5f, 0.5f, 0.5f); glVertex3f(-0.5f, 0.5f,-0.5f);
+    glEnd();
+
+    glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+    glColor3f(selected ? 1.0f : 0.0f, selected ? 1.0f : 0.8f, selected ? 0.2f : 0.9f);
+    glBegin(GL_QUADS);
+    glVertex3f(-0.5f,-0.5f, 0.5f); glVertex3f( 0.5f,-0.5f, 0.5f); glVertex3f( 0.5f, 0.5f, 0.5f); glVertex3f(-0.5f, 0.5f, 0.5f);
+    glVertex3f(-0.5f,-0.5f,-0.5f); glVertex3f(-0.5f, 0.5f,-0.5f); glVertex3f( 0.5f, 0.5f,-0.5f); glVertex3f( 0.5f,-0.5f,-0.5f);
+    glVertex3f(-0.5f, 0.5f,-0.5f); glVertex3f(-0.5f, 0.5f, 0.5f); glVertex3f( 0.5f, 0.5f, 0.5f); glVertex3f( 0.5f, 0.5f,-0.5f);
+    glVertex3f(-0.5f,-0.5f,-0.5f); glVertex3f( 0.5f,-0.5f,-0.5f); glVertex3f( 0.5f,-0.5f, 0.5f); glVertex3f(-0.5f,-0.5f, 0.5f);
+    glVertex3f( 0.5f,-0.5f,-0.5f); glVertex3f( 0.5f, 0.5f,-0.5f); glVertex3f( 0.5f, 0.5f, 0.5f); glVertex3f( 0.5f,-0.5f, 0.5f);
+    glVertex3f(-0.5f,-0.5f,-0.5f); glVertex3f(-0.5f,-0.5f, 0.5f); glVertex3f(-0.5f, 0.5f, 0.5f); glVertex3f(-0.5f, 0.5f,-0.5f);
+    glEnd();
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+    glPopMatrix();
+}
+
+static void draw_scene(const EditorApp *app) {
+    draw_grid();
+    for (size_t i = 0; i < app->scene.box_count; i++) {
+        const EditorSceneBox *box = &app->scene.boxes[i];
+        if (!box->flags.visible) continue;
+        draw_box(box, (int)i == app->selected_box);
+    }
+}
+
+static void frame_selected(EditorApp *app) {
+    if (app->selected_box < 0 || app->selected_box >= (int)app->scene.box_count) return;
+    const EditorSceneBox *box = &app->scene.boxes[app->selected_box];
+    app->camera.target[0] = box->position[0];
+    app->camera.target[1] = box->position[1];
+    app->camera.target[2] = box->position[2];
+    float max_dim = box->size[0];
+    if (box->size[1] > max_dim) max_dim = box->size[1];
+    if (box->size[2] > max_dim) max_dim = box->size[2];
+    app->camera.distance = clampf(max_dim * 4.0f, 6.0f, 120.0f);
+}
+
+static void apply_stage_camera_to_view(EditorApp *app, int idx) {
+    if (idx < 0 || idx >= (int)app->scene.stage_camera_count) return;
+    const EditorStageCamera *c = &app->scene.stage_cameras[idx];
+    app->camera.target[0] = c->target[0];
+    app->camera.target[1] = c->target[1];
+    app->camera.target[2] = c->target[2];
+    app->camera.distance = c->distance;
+    app->camera.yaw_degrees = c->yaw_degrees;
+    app->camera.pitch_degrees = c->pitch_degrees;
+    app->camera.fov_degrees = c->fov_degrees;
+}
+
+static void sync_view_to_stage_camera(EditorApp *app) {
+    if (!app->stage_camera_drives_viewport) return;
+    if (app->selected_stage_camera < 0 || app->selected_stage_camera >= (int)app->scene.stage_camera_count) return;
+    EditorStageCamera *c = &app->scene.stage_cameras[app->selected_stage_camera];
+    c->target[0] = app->camera.target[0];
+    c->target[1] = app->camera.target[1];
+    c->target[2] = app->camera.target[2];
+    c->distance = app->camera.distance;
+    c->yaw_degrees = app->camera.yaw_degrees;
+    c->pitch_degrees = app->camera.pitch_degrees;
+    c->fov_degrees = app->camera.fov_degrees;
+}
+
+static void create_default_scene(EditorApp *app) {
+    editor_scene_asset_init(&app->scene);
+    strncpy(app->scene.scene_name, "test_room", sizeof(app->scene.scene_name) - 1);
+    editor_scene_asset_add_default_box(&app->scene, "floor", 0.0f, -1.0f, 0.0f);
+    app->scene.boxes[0].size[0] = 30.0f;
+    app->scene.boxes[0].size[1] = 1.0f;
+    app->scene.boxes[0].size[2] = 30.0f;
+    app->scene.boxes[0].color[0] = 0.25f;
+    app->scene.boxes[0].color[1] = 0.28f;
+    app->scene.boxes[0].color[2] = 0.3f;
+
+    editor_scene_asset_add_default_box(&app->scene, "center_block", 0.0f, 2.0f, 0.0f);
+    app->scene.boxes[1].size[0] = 8.0f;
+    app->scene.boxes[1].size[1] = 4.0f;
+    app->scene.boxes[1].size[2] = 8.0f;
+    app->scene.boxes[1].color[0] = 0.7f;
+    app->scene.boxes[1].color[1] = 0.2f;
+    app->scene.boxes[1].color[2] = 0.2f;
+
+    editor_scene_asset_add_default_box(&app->scene, "catwalk", 10.0f, 4.0f, -8.0f);
+    app->scene.boxes[2].size[0] = 12.0f;
+    app->scene.boxes[2].size[1] = 1.0f;
+    app->scene.boxes[2].size[2] = 3.0f;
+    app->scene.boxes[2].rotation_y_degrees = 18.0f;
+
+    editor_scene_asset_add_default_stage_camera(&app->scene, "overview", 0.0f, 1.0f, 0.0f);
+    editor_scene_asset_add_default_stage_camera(&app->scene, "arena_focus", 8.0f, 2.0f, -3.0f);
+    app->scene.stage_cameras[1].yaw_degrees = -30.0f;
+    app->scene.stage_cameras[1].distance = 18.0f;
+
+    app->selected_box = 0;
+    app->selected_stage_camera = 0;
+}
+
+static void handle_camera_hotkeys(EditorApp *app, SDL_Keycode key) {
+    if (key == SDLK_LEFTBRACKET && app->scene.stage_camera_count > 0) {
+        app->selected_stage_camera = (app->selected_stage_camera - 1 + (int)app->scene.stage_camera_count) % (int)app->scene.stage_camera_count;
+        if (app->stage_camera_drives_viewport) apply_stage_camera_to_view(app, app->selected_stage_camera);
+    } else if (key == SDLK_RIGHTBRACKET && app->scene.stage_camera_count > 0) {
+        app->selected_stage_camera = (app->selected_stage_camera + 1) % (int)app->scene.stage_camera_count;
+        if (app->stage_camera_drives_viewport) apply_stage_camera_to_view(app, app->selected_stage_camera);
+    } else if (key == SDLK_c) {
+        app->stage_camera_drives_viewport = !app->stage_camera_drives_viewport;
+        if (app->stage_camera_drives_viewport) apply_stage_camera_to_view(app, app->selected_stage_camera);
+    } else if (key == SDLK_n) {
+        char name[64];
+        snprintf(name, sizeof(name), "camera_%d", (int)app->scene.stage_camera_count + 1);
+        editor_scene_asset_add_default_stage_camera(&app->scene, name, app->camera.target[0], app->camera.target[1], app->camera.target[2]);
+        if (app->scene.stage_camera_count > 0) {
+            app->selected_stage_camera = (int)app->scene.stage_camera_count - 1;
+            EditorStageCamera *c = &app->scene.stage_cameras[app->selected_stage_camera];
+            c->distance = app->camera.distance;
+            c->yaw_degrees = app->camera.yaw_degrees;
+            c->pitch_degrees = app->camera.pitch_degrees;
+            c->fov_degrees = app->camera.fov_degrees;
+        }
+    }
+}
+
+static void adjust_selected_stage_camera(EditorApp *app, SDL_Keycode key) {
+    if (app->selected_stage_camera < 0 || app->selected_stage_camera >= (int)app->scene.stage_camera_count) return;
+    EditorStageCamera *c = &app->scene.stage_cameras[app->selected_stage_camera];
+    if (key == SDLK_KP_4) c->yaw_degrees -= 1.0f;
+    else if (key == SDLK_KP_6) c->yaw_degrees += 1.0f;
+    else if (key == SDLK_KP_8) c->pitch_degrees = clampf(c->pitch_degrees + 1.0f, -89.0f, 89.0f);
+    else if (key == SDLK_KP_2) c->pitch_degrees = clampf(c->pitch_degrees - 1.0f, -89.0f, 89.0f);
+    else if (key == SDLK_KP_PLUS || key == SDLK_EQUALS) c->distance = clampf(c->distance - 0.5f, 2.0f, 500.0f);
+    else if (key == SDLK_KP_MINUS || key == SDLK_MINUS) c->distance = clampf(c->distance + 0.5f, 2.0f, 500.0f);
+    else if (key == SDLK_PAGEUP) c->fov_degrees = clampf(c->fov_degrees + 1.0f, 20.0f, 120.0f);
+    else if (key == SDLK_PAGEDOWN) c->fov_degrees = clampf(c->fov_degrees - 1.0f, 20.0f, 120.0f);
+    else return;
+
+    if (app->stage_camera_drives_viewport) apply_stage_camera_to_view(app, app->selected_stage_camera);
+}
+
+static void handle_event(EditorApp *app, SDL_Event *e) {
+    if (e->type == SDL_QUIT) {
+        app->running = 0;
+    } else if (e->type == SDL_WINDOWEVENT && e->window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
+        app->width = e->window.data1;
+        app->height = e->window.data2;
+        glViewport(0, 0, app->width, app->height);
+    } else if (e->type == SDL_MOUSEMOTION) {
+        app->mouse_x = e->motion.x;
+        app->mouse_y = e->motion.y;
+        Uint32 state = SDL_GetMouseState(NULL, NULL);
+        int alt = (SDL_GetModState() & KMOD_ALT) != 0;
+        if ((state & SDL_BUTTON(SDL_BUTTON_LEFT)) && alt) {
+            editor_camera_orbit(&app->camera, e->motion.xrel * 0.35f, -e->motion.yrel * 0.3f);
+        } else if ((state & SDL_BUTTON(SDL_BUTTON_MIDDLE)) || ((state & SDL_BUTTON(SDL_BUTTON_RIGHT)) && alt)) {
+            float speed = app->camera.distance * 0.004f;
+            editor_camera_pan(&app->camera, -e->motion.xrel * speed, e->motion.yrel * speed);
+        } else if ((state & SDL_BUTTON(SDL_BUTTON_LEFT)) && app->move_tool.active && app->selected_box >= 0) {
+            float ro[3], rd[3], hit[3];
+            if (ray_from_mouse(app, app->mouse_x, app->mouse_y, ro, rd)) {
+                float plane_y = app->scene.boxes[app->selected_box].position[1];
+                if (app->move_tool.axis == EDITOR_MOVE_AXIS_Y) {
+                    float yaw = app->camera.yaw_degrees * 0.017453292f;
+                    float plane_normal[3] = { cosf(yaw), 0.0f, -sinf(yaw) };
+                    float p0[3] = { app->scene.boxes[app->selected_box].position[0], plane_y, app->scene.boxes[app->selected_box].position[2] };
+                    float denom = vec3_dot(plane_normal, rd);
+                    if (fabsf(denom) > 1e-6f) {
+                        float w[3];
+                        vec3_sub(p0, ro, w);
+                        float t = vec3_dot(w, plane_normal) / denom;
+                        if (t > 0.0f) {
+                            hit[0] = ro[0] + rd[0] * t;
+                            hit[1] = ro[1] + rd[1] * t;
+                            hit[2] = ro[2] + rd[2] * t;
+                            editor_move_tool_apply(&app->move_tool, hit, app->scene.boxes[app->selected_box].position);
+                        }
+                    }
+                } else if (ray_plane_hit(ro, rd, plane_y, hit)) {
+                    editor_move_tool_apply(&app->move_tool, hit, app->scene.boxes[app->selected_box].position);
+                }
+            }
+        }
+        sync_view_to_stage_camera(app);
+    } else if (e->type == SDL_MOUSEWHEEL) {
+        editor_camera_zoom(&app->camera, -e->wheel.y * (app->camera.distance * 0.1f));
+        sync_view_to_stage_camera(app);
+    } else if (e->type == SDL_MOUSEBUTTONDOWN && e->button.button == SDL_BUTTON_LEFT) {
+        int alt = (SDL_GetModState() & KMOD_ALT) != 0;
+        if (!alt) {
+            float ro[3], rd[3], hit[3];
+            apply_view(app);
+            if (ray_from_mouse(app, e->button.x, e->button.y, ro, rd)) {
+                int idx = editor_selection_pick_box(&app->scene, ro, rd);
+                app->selected_box = idx;
+                if (idx >= 0 && ray_plane_hit(ro, rd, app->scene.boxes[idx].position[1], hit)) {
+                    editor_move_tool_begin(&app->move_tool, hit, app->scene.boxes[idx].position);
+                }
+            }
+        }
+    } else if (e->type == SDL_MOUSEBUTTONUP && e->button.button == SDL_BUTTON_LEFT) {
+        editor_move_tool_cancel(&app->move_tool);
+    } else if (e->type == SDL_KEYDOWN) {
+        SDL_Keycode key = e->key.keysym.sym;
+        if (key == SDLK_ESCAPE) app->running = 0;
+        else if (key == SDLK_f) frame_selected(app);
+        else if (key == SDLK_x) editor_move_tool_set_axis(&app->move_tool, EDITOR_MOVE_AXIS_X);
+        else if (key == SDLK_y) editor_move_tool_set_axis(&app->move_tool, EDITOR_MOVE_AXIS_Y);
+        else if (key == SDLK_z) editor_move_tool_set_axis(&app->move_tool, EDITOR_MOVE_AXIS_Z);
+        else if (key == SDLK_g) editor_move_tool_set_axis(&app->move_tool, EDITOR_MOVE_AXIS_FREE);
+        else if (key == SDLK_o) {
+            if (!editor_scene_json_load(app->active_scene_path, &app->scene)) {
+                fprintf(stderr, "[scene_editor] failed to load '%s'\n", app->active_scene_path);
+            }
+        } else if (key == SDLK_p) {
+            if (!editor_scene_json_save(app->active_scene_path, &app->scene)) {
+                fprintf(stderr, "[scene_editor] failed to save '%s'\n", app->active_scene_path);
+            }
+        } else {
+            handle_camera_hotkeys(app, key);
+            adjust_selected_stage_camera(app, key);
+        }
+    }
+}
+
+static int app_init(EditorApp *app, const char *path_override) {
+    memset(app, 0, sizeof(*app));
+    app->running = 1;
+    app->width = 1400;
+    app->height = 900;
+    app->selected_box = -1;
+    app->selected_stage_camera = -1;
+    app->active_scene_path[0] = '\0';
+    editor_camera_init(&app->camera);
+    app->move_tool.axis = EDITOR_MOVE_AXIS_FREE;
+
+    if (!SDL_Init(SDL_INIT_VIDEO)) {
+        fprintf(stderr, "[scene_editor] SDL_Init failed: %s\n", SDL_GetError());
+        return 0;
+    }
+
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+
+    app->window = SDL_CreateWindow("SHANKPIT Scene Editor",
+                                   SDL_WINDOWPOS_CENTERED,
+                                   SDL_WINDOWPOS_CENTERED,
+                                   app->width,
+                                   app->height,
+                                   SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+    if (!app->window) {
+        fprintf(stderr, "[scene_editor] SDL_CreateWindow failed: %s\n", SDL_GetError());
+        return 0;
+    }
+
+    app->gl = SDL_GL_CreateContext(app->window);
+    if (!app->gl) {
+        fprintf(stderr, "[scene_editor] SDL_GL_CreateContext failed: %s\n", SDL_GetError());
+        return 0;
+    }
+
+    SDL_GL_SetSwapInterval(1);
+
+    glViewport(0, 0, app->width, app->height);
+    glEnable(GL_DEPTH_TEST);
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+    if (path_override && path_override[0]) strncpy(app->active_scene_path, path_override, sizeof(app->active_scene_path)-1);
+    else strncpy(app->active_scene_path, "assets/scenes/test_room.json", sizeof(app->active_scene_path)-1);
+
+    if (!editor_scene_json_load(app->active_scene_path, &app->scene)) {
+        create_default_scene(app);
+        editor_scene_json_save(app->active_scene_path, &app->scene);
+    }
+    if (app->scene.box_count > 0) app->selected_box = 0;
+    if (app->scene.stage_camera_count > 0) app->selected_stage_camera = 0;
+
+    return 1;
+}
+
+static void app_shutdown(EditorApp *app) {
+    if (app->gl) SDL_GL_DeleteContext(app->gl);
+    if (app->window) SDL_DestroyWindow(app->window);
+    SDL_Quit();
+}
+
+int editor_app_run(const char *scene_path_override) {
+    EditorApp app;
+    if (!app_init(&app, scene_path_override)) {
+        app_shutdown(&app);
+        return 1;
+    }
+
+    while (app.running) {
+        SDL_Event e;
+        while (SDL_PollEvent(&e)) {
+            handle_event(&app, &e);
+        }
+
+        glClearColor(0.07f, 0.09f, 0.11f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+        apply_view(&app);
+        draw_scene(&app);
+        editor_ui_draw_overlay(app.width, app.height, &app.scene, app.selected_box,
+                               app.selected_stage_camera, app.stage_camera_drives_viewport,
+                               &app.move_tool, &app.camera, app.active_scene_path);
+
+        SDL_GL_SwapWindow(app.window);
+    }
+
+    app_shutdown(&app);
+    return 0;
+}

--- a/apps/scene_editor/editor_app.h
+++ b/apps/scene_editor/editor_app.h
@@ -1,0 +1,6 @@
+#ifndef SHANKPIT_EDITOR_APP_H
+#define SHANKPIT_EDITOR_APP_H
+
+int editor_app_run(const char *scene_path_override);
+
+#endif

--- a/apps/scene_editor/editor_camera.c
+++ b/apps/scene_editor/editor_camera.c
@@ -1,0 +1,52 @@
+#include "editor_camera.h"
+
+#include <math.h>
+
+static float clampf(float v, float lo, float hi) {
+    if (v < lo) return lo;
+    if (v > hi) return hi;
+    return v;
+}
+
+void editor_camera_init(EditorViewportCamera *camera) {
+    camera->target[0] = 0.0f;
+    camera->target[1] = 2.0f;
+    camera->target[2] = 0.0f;
+    camera->distance = 35.0f;
+    camera->yaw_degrees = 35.0f;
+    camera->pitch_degrees = 25.0f;
+    camera->fov_degrees = 60.0f;
+}
+
+void editor_camera_orbit(EditorViewportCamera *camera, float delta_yaw_deg, float delta_pitch_deg) {
+    camera->yaw_degrees += delta_yaw_deg;
+    camera->pitch_degrees += delta_pitch_deg;
+    camera->pitch_degrees = clampf(camera->pitch_degrees, -89.0f, 89.0f);
+}
+
+void editor_camera_zoom(EditorViewportCamera *camera, float delta) {
+    camera->distance = clampf(camera->distance + delta, 2.0f, 500.0f);
+}
+
+void editor_camera_eye_position(const EditorViewportCamera *camera, float out_eye[3]) {
+    float yaw = camera->yaw_degrees * 0.017453292f;
+    float pitch = camera->pitch_degrees * 0.017453292f;
+    float cp = cosf(pitch);
+    float sp = sinf(pitch);
+    float cy = cosf(yaw);
+    float sy = sinf(yaw);
+
+    out_eye[0] = camera->target[0] + camera->distance * cp * sy;
+    out_eye[1] = camera->target[1] + camera->distance * sp;
+    out_eye[2] = camera->target[2] + camera->distance * cp * cy;
+}
+
+void editor_camera_pan(EditorViewportCamera *camera, float right, float up) {
+    float yaw = camera->yaw_degrees * 0.017453292f;
+    float right_x = cosf(yaw);
+    float right_z = -sinf(yaw);
+
+    camera->target[0] += right_x * right;
+    camera->target[2] += right_z * right;
+    camera->target[1] += up;
+}

--- a/apps/scene_editor/editor_camera.h
+++ b/apps/scene_editor/editor_camera.h
@@ -1,0 +1,18 @@
+#ifndef SHANKPIT_EDITOR_CAMERA_H
+#define SHANKPIT_EDITOR_CAMERA_H
+
+typedef struct {
+    float target[3];
+    float distance;
+    float yaw_degrees;
+    float pitch_degrees;
+    float fov_degrees;
+} EditorViewportCamera;
+
+void editor_camera_init(EditorViewportCamera *camera);
+void editor_camera_orbit(EditorViewportCamera *camera, float delta_yaw_deg, float delta_pitch_deg);
+void editor_camera_zoom(EditorViewportCamera *camera, float delta);
+void editor_camera_pan(EditorViewportCamera *camera, float right, float up);
+void editor_camera_eye_position(const EditorViewportCamera *camera, float out_eye[3]);
+
+#endif

--- a/apps/scene_editor/editor_move_tool.c
+++ b/apps/scene_editor/editor_move_tool.c
@@ -1,0 +1,41 @@
+#include "editor_move_tool.h"
+
+void editor_move_tool_begin(EditorMoveTool *tool, const float hit_point[3], const float box_position[3]) {
+    tool->active = 1;
+    tool->start_hit[0] = hit_point[0];
+    tool->start_hit[1] = hit_point[1];
+    tool->start_hit[2] = hit_point[2];
+    tool->start_box[0] = box_position[0];
+    tool->start_box[1] = box_position[1];
+    tool->start_box[2] = box_position[2];
+}
+
+void editor_move_tool_cancel(EditorMoveTool *tool) {
+    tool->active = 0;
+}
+
+void editor_move_tool_set_axis(EditorMoveTool *tool, EditorMoveAxis axis) {
+    tool->axis = axis;
+}
+
+void editor_move_tool_apply(EditorMoveTool *tool, const float hit_point[3], float inout_box_position[3]) {
+    float delta[3] = {
+        hit_point[0] - tool->start_hit[0],
+        hit_point[1] - tool->start_hit[1],
+        hit_point[2] - tool->start_hit[2]
+    };
+
+    inout_box_position[0] = tool->start_box[0];
+    inout_box_position[1] = tool->start_box[1];
+    inout_box_position[2] = tool->start_box[2];
+
+    if (tool->axis == EDITOR_MOVE_AXIS_FREE || tool->axis == EDITOR_MOVE_AXIS_X) {
+        inout_box_position[0] += delta[0];
+    }
+    if (tool->axis == EDITOR_MOVE_AXIS_FREE || tool->axis == EDITOR_MOVE_AXIS_Y) {
+        inout_box_position[1] += delta[1];
+    }
+    if (tool->axis == EDITOR_MOVE_AXIS_FREE || tool->axis == EDITOR_MOVE_AXIS_Z) {
+        inout_box_position[2] += delta[2];
+    }
+}

--- a/apps/scene_editor/editor_move_tool.h
+++ b/apps/scene_editor/editor_move_tool.h
@@ -1,0 +1,23 @@
+#ifndef SHANKPIT_EDITOR_MOVE_TOOL_H
+#define SHANKPIT_EDITOR_MOVE_TOOL_H
+
+typedef enum {
+    EDITOR_MOVE_AXIS_FREE = 0,
+    EDITOR_MOVE_AXIS_X,
+    EDITOR_MOVE_AXIS_Y,
+    EDITOR_MOVE_AXIS_Z
+} EditorMoveAxis;
+
+typedef struct {
+    int active;
+    EditorMoveAxis axis;
+    float start_hit[3];
+    float start_box[3];
+} EditorMoveTool;
+
+void editor_move_tool_begin(EditorMoveTool *tool, const float hit_point[3], const float box_position[3]);
+void editor_move_tool_cancel(EditorMoveTool *tool);
+void editor_move_tool_set_axis(EditorMoveTool *tool, EditorMoveAxis axis);
+void editor_move_tool_apply(EditorMoveTool *tool, const float hit_point[3], float inout_box_position[3]);
+
+#endif

--- a/apps/scene_editor/editor_scene_asset.c
+++ b/apps/scene_editor/editor_scene_asset.c
@@ -1,0 +1,49 @@
+#include "editor_scene_asset.h"
+
+#include <string.h>
+
+void editor_scene_asset_init(EditorSceneAsset *scene) {
+    memset(scene, 0, sizeof(*scene));
+    scene->version = 1;
+    strncpy(scene->scene_name, "untitled_scene", sizeof(scene->scene_name) - 1);
+}
+
+void editor_scene_asset_add_default_box(EditorSceneAsset *scene, const char *name, float x, float y, float z) {
+    if (scene->box_count >= EDITOR_MAX_BOXES) {
+        return;
+    }
+    EditorSceneBox *box = &scene->boxes[scene->box_count++];
+    memset(box, 0, sizeof(*box));
+    box->id = (int)scene->box_count;
+    strncpy(box->name, name, sizeof(box->name) - 1);
+    box->position[0] = x;
+    box->position[1] = y;
+    box->position[2] = z;
+    box->size[0] = 4.0f;
+    box->size[1] = 2.0f;
+    box->size[2] = 4.0f;
+    box->rotation_y_degrees = 0.0f;
+    box->color[0] = 0.7f;
+    box->color[1] = 0.7f;
+    box->color[2] = 0.7f;
+    box->color[3] = 1.0f;
+    box->flags.solid = 1;
+    box->flags.visible = 1;
+}
+
+void editor_scene_asset_add_default_stage_camera(EditorSceneAsset *scene, const char *name, float tx, float ty, float tz) {
+    if (scene->stage_camera_count >= EDITOR_MAX_STAGE_CAMERAS) {
+        return;
+    }
+    EditorStageCamera *cam = &scene->stage_cameras[scene->stage_camera_count++];
+    memset(cam, 0, sizeof(*cam));
+    cam->id = (int)scene->stage_camera_count;
+    strncpy(cam->name, name, sizeof(cam->name) - 1);
+    cam->target[0] = tx;
+    cam->target[1] = ty;
+    cam->target[2] = tz;
+    cam->distance = 25.0f;
+    cam->yaw_degrees = 30.0f;
+    cam->pitch_degrees = 22.0f;
+    cam->fov_degrees = 60.0f;
+}

--- a/apps/scene_editor/editor_scene_asset.h
+++ b/apps/scene_editor/editor_scene_asset.h
@@ -1,0 +1,48 @@
+#ifndef SHANKPIT_EDITOR_SCENE_ASSET_H
+#define SHANKPIT_EDITOR_SCENE_ASSET_H
+
+#include <stddef.h>
+
+#define EDITOR_MAX_BOXES 512
+#define EDITOR_MAX_STAGE_CAMERAS 64
+#define EDITOR_NAME_LEN 64
+
+typedef struct {
+    int solid;
+    int visible;
+} EditorBoxFlags;
+
+typedef struct {
+    int id;
+    char name[EDITOR_NAME_LEN];
+    float position[3];
+    float size[3];
+    float rotation_y_degrees;
+    float color[4];
+    EditorBoxFlags flags;
+} EditorSceneBox;
+
+typedef struct {
+    int id;
+    char name[EDITOR_NAME_LEN];
+    float target[3];
+    float distance;
+    float yaw_degrees;
+    float pitch_degrees;
+    float fov_degrees;
+} EditorStageCamera;
+
+typedef struct {
+    int version;
+    char scene_name[EDITOR_NAME_LEN];
+    EditorSceneBox boxes[EDITOR_MAX_BOXES];
+    size_t box_count;
+    EditorStageCamera stage_cameras[EDITOR_MAX_STAGE_CAMERAS];
+    size_t stage_camera_count;
+} EditorSceneAsset;
+
+void editor_scene_asset_init(EditorSceneAsset *scene);
+void editor_scene_asset_add_default_box(EditorSceneAsset *scene, const char *name, float x, float y, float z);
+void editor_scene_asset_add_default_stage_camera(EditorSceneAsset *scene, const char *name, float tx, float ty, float tz);
+
+#endif

--- a/apps/scene_editor/editor_scene_json.c
+++ b/apps/scene_editor/editor_scene_json.c
@@ -1,0 +1,378 @@
+#include "editor_scene_json.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * Tiny local JSON parser (jsmn-style) to keep the editor standalone and
+ * avoid touching runtime serialization paths during the low-risk init pass.
+ */
+typedef enum {
+    JSMN_UNDEFINED = 0,
+    JSMN_OBJECT = 1,
+    JSMN_ARRAY = 2,
+    JSMN_STRING = 3,
+    JSMN_PRIMITIVE = 4
+} jsmntype_t;
+
+typedef struct {
+    jsmntype_t type;
+    int start;
+    int end;
+    int size;
+    int parent;
+} jsmntok_t;
+
+typedef struct {
+    unsigned int pos;
+    unsigned int toknext;
+    int toksuper;
+} jsmn_parser;
+
+static void jsmn_init(jsmn_parser *parser) {
+    parser->pos = 0;
+    parser->toknext = 0;
+    parser->toksuper = -1;
+}
+
+static jsmntok_t *jsmn_alloc_token(jsmn_parser *parser, jsmntok_t *tokens, size_t num_tokens) {
+    if (parser->toknext >= num_tokens) return NULL;
+    jsmntok_t *tok = &tokens[parser->toknext++];
+    tok->start = tok->end = -1;
+    tok->size = 0;
+    tok->parent = -1;
+    tok->type = JSMN_UNDEFINED;
+    return tok;
+}
+
+static void jsmn_fill_token(jsmntok_t *token, jsmntype_t type, int start, int end) {
+    token->type = type;
+    token->start = start;
+    token->end = end;
+    token->size = 0;
+}
+
+static int jsmn_parse_primitive(jsmn_parser *parser, const char *js, size_t len, jsmntok_t *tokens, size_t num_tokens) {
+    int start = (int)parser->pos;
+    for (; parser->pos < len; parser->pos++) {
+        char c = js[parser->pos];
+        if (c == ',' || c == ']' || c == '}' || isspace((unsigned char)c)) {
+            break;
+        }
+        if (c < 32 || c >= 127) {
+            parser->pos = (unsigned int)start;
+            return -1;
+        }
+    }
+    jsmntok_t *token = jsmn_alloc_token(parser, tokens, num_tokens);
+    if (!token) {
+        parser->pos = (unsigned int)start;
+        return -1;
+    }
+    jsmn_fill_token(token, JSMN_PRIMITIVE, start, (int)parser->pos);
+    token->parent = parser->toksuper;
+    parser->pos--;
+    return 0;
+}
+
+static int jsmn_parse_string(jsmn_parser *parser, const char *js, size_t len, jsmntok_t *tokens, size_t num_tokens) {
+    int start = (int)parser->pos;
+    parser->pos++;
+    for (; parser->pos < len; parser->pos++) {
+        char c = js[parser->pos];
+        if (c == '"') {
+            jsmntok_t *token = jsmn_alloc_token(parser, tokens, num_tokens);
+            if (!token) {
+                parser->pos = (unsigned int)start;
+                return -1;
+            }
+            jsmn_fill_token(token, JSMN_STRING, start + 1, (int)parser->pos);
+            token->parent = parser->toksuper;
+            return 0;
+        }
+        if (c == '\\') parser->pos++;
+    }
+    parser->pos = (unsigned int)start;
+    return -1;
+}
+
+static int jsmn_parse(jsmn_parser *parser, const char *js, size_t len, jsmntok_t *tokens, unsigned int num_tokens) {
+    for (; parser->pos < len; parser->pos++) {
+        char c = js[parser->pos];
+        jsmntok_t *token;
+        int i;
+        switch (c) {
+            case '{':
+            case '[':
+                token = jsmn_alloc_token(parser, tokens, num_tokens);
+                if (!token) return -1;
+                if (parser->toksuper != -1) tokens[parser->toksuper].size++;
+                token->type = (c == '{' ? JSMN_OBJECT : JSMN_ARRAY);
+                token->start = (int)parser->pos;
+                token->parent = parser->toksuper;
+                parser->toksuper = (int)(parser->toknext - 1);
+                break;
+            case '}':
+            case ']': {
+                jsmntype_t type = (c == '}' ? JSMN_OBJECT : JSMN_ARRAY);
+                for (i = (int)parser->toknext - 1; i >= 0; i--) {
+                    token = &tokens[i];
+                    if (token->start != -1 && token->end == -1) {
+                        if (token->type != type) return -1;
+                        token->end = (int)parser->pos + 1;
+                        parser->toksuper = token->parent;
+                        break;
+                    }
+                }
+                if (i == -1) return -1;
+                break;
+            }
+            case '"':
+                if (jsmn_parse_string(parser, js, len, tokens, num_tokens) < 0) return -1;
+                if (parser->toksuper != -1) tokens[parser->toksuper].size++;
+                break;
+            case '\t': case '\r': case '\n': case ' ': case ':': case ',':
+                break;
+            default:
+                if (jsmn_parse_primitive(parser, js, len, tokens, num_tokens) < 0) return -1;
+                if (parser->toksuper != -1) tokens[parser->toksuper].size++;
+                break;
+        }
+    }
+    for (unsigned int i = parser->toknext; i > 0; i--) {
+        if (tokens[i - 1].start != -1 && tokens[i - 1].end == -1) return -1;
+    }
+    return (int)parser->toknext;
+}
+
+static int token_str_eq(const char *json, const jsmntok_t *tok, const char *s) {
+    int len = tok->end - tok->start;
+    return (int)strlen(s) == len && strncmp(json + tok->start, s, (size_t)len) == 0;
+}
+
+static int token_to_int(const char *json, const jsmntok_t *tok, int *out) {
+    char buf[64];
+    int len = tok->end - tok->start;
+    if (len <= 0 || len >= (int)sizeof(buf)) return 0;
+    memcpy(buf, json + tok->start, (size_t)len);
+    buf[len] = '\0';
+    *out = atoi(buf);
+    return 1;
+}
+
+static int token_to_float(const char *json, const jsmntok_t *tok, float *out) {
+    char buf[64];
+    int len = tok->end - tok->start;
+    if (len <= 0 || len >= (int)sizeof(buf)) return 0;
+    memcpy(buf, json + tok->start, (size_t)len);
+    buf[len] = '\0';
+    *out = (float)atof(buf);
+    return 1;
+}
+
+static int token_to_string(const char *json, const jsmntok_t *tok, char *dst, size_t dst_size) {
+    int len = tok->end - tok->start;
+    if (len < 0 || (size_t)len >= dst_size) return 0;
+    memcpy(dst, json + tok->start, (size_t)len);
+    dst[len] = '\0';
+    return 1;
+}
+
+static int skip_token_tree(const jsmntok_t *tokens, int index, int count) {
+    int start = index;
+    int end = index + 1;
+    while (end < count && tokens[end].start < tokens[start].end) {
+        end++;
+    }
+    return end;
+}
+
+static int parse_float_array(const char *json, const jsmntok_t *tokens, int tok_count, int arr_index, float *out, int expected) {
+    if (arr_index < 0 || arr_index >= tok_count || tokens[arr_index].type != JSMN_ARRAY) return 0;
+    int idx = arr_index + 1;
+    for (int i = 0; i < expected; i++) {
+        if (idx >= tok_count || !token_to_float(json, &tokens[idx], &out[i])) return 0;
+        idx = skip_token_tree(tokens, idx, tok_count);
+    }
+    return 1;
+}
+
+int editor_scene_json_load(const char *path, EditorSceneAsset *out_scene) {
+    FILE *f = fopen(path, "rb");
+    if (!f) return 0;
+    fseek(f, 0, SEEK_END);
+    long len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (len <= 0 || len > 4 * 1024 * 1024) {
+        fclose(f);
+        return 0;
+    }
+
+    char *json = (char*)malloc((size_t)len + 1);
+    if (!json) {
+        fclose(f);
+        return 0;
+    }
+    if (fread(json, 1, (size_t)len, f) != (size_t)len) {
+        fclose(f);
+        free(json);
+        return 0;
+    }
+    fclose(f);
+    json[len] = '\0';
+
+    enum { MAX_TOKENS = 8192 };
+    jsmntok_t *tokens = (jsmntok_t*)calloc(MAX_TOKENS, sizeof(jsmntok_t));
+    if (!tokens) {
+        free(json);
+        return 0;
+    }
+
+    jsmn_parser parser;
+    jsmn_init(&parser);
+    int tok_count = jsmn_parse(&parser, json, (size_t)len, tokens, MAX_TOKENS);
+    if (tok_count <= 0 || tokens[0].type != JSMN_OBJECT) {
+        free(tokens);
+        free(json);
+        return 0;
+    }
+
+    editor_scene_asset_init(out_scene);
+    int i = 1;
+    while (i < tok_count && tokens[i].start < tokens[0].end) {
+        if (tokens[i].type != JSMN_STRING) {
+            i++;
+            continue;
+        }
+        int key = i;
+        int val = i + 1;
+        if (val >= tok_count) break;
+
+        if (token_str_eq(json, &tokens[key], "version")) {
+            token_to_int(json, &tokens[val], &out_scene->version);
+        } else if (token_str_eq(json, &tokens[key], "scene_name")) {
+            token_to_string(json, &tokens[val], out_scene->scene_name, sizeof(out_scene->scene_name));
+        } else if (token_str_eq(json, &tokens[key], "boxes") && tokens[val].type == JSMN_ARRAY) {
+            int bi = val + 1;
+            while (bi < tok_count && tokens[bi].start < tokens[val].end && out_scene->box_count < EDITOR_MAX_BOXES) {
+                if (tokens[bi].type != JSMN_OBJECT) {
+                    bi = skip_token_tree(tokens, bi, tok_count);
+                    continue;
+                }
+                EditorSceneBox *box = &out_scene->boxes[out_scene->box_count++];
+                memset(box, 0, sizeof(*box));
+                box->flags.solid = 1;
+                box->flags.visible = 1;
+                strcpy(box->name, "box");
+                box->size[0] = box->size[1] = box->size[2] = 1.0f;
+                box->color[0] = box->color[1] = box->color[2] = box->color[3] = 1.0f;
+
+                int fi = bi + 1;
+                while (fi < tok_count && tokens[fi].start < tokens[bi].end) {
+                    int fk = fi;
+                    int fv = fi + 1;
+                    if (fv >= tok_count) break;
+                    if (token_str_eq(json, &tokens[fk], "id")) token_to_int(json, &tokens[fv], &box->id);
+                    else if (token_str_eq(json, &tokens[fk], "name")) token_to_string(json, &tokens[fv], box->name, sizeof(box->name));
+                    else if (token_str_eq(json, &tokens[fk], "position")) parse_float_array(json, tokens, tok_count, fv, box->position, 3);
+                    else if (token_str_eq(json, &tokens[fk], "size")) parse_float_array(json, tokens, tok_count, fv, box->size, 3);
+                    else if (token_str_eq(json, &tokens[fk], "rotation_y_degrees")) token_to_float(json, &tokens[fv], &box->rotation_y_degrees);
+                    else if (token_str_eq(json, &tokens[fk], "color")) parse_float_array(json, tokens, tok_count, fv, box->color, 4);
+                    else if (token_str_eq(json, &tokens[fk], "flags") && tokens[fv].type == JSMN_OBJECT) {
+                        int gi = fv + 1;
+                        while (gi < tok_count && tokens[gi].start < tokens[fv].end) {
+                            int gk = gi;
+                            int gv = gi + 1;
+                            if (gv >= tok_count) break;
+                            if (token_str_eq(json, &tokens[gk], "solid")) token_to_int(json, &tokens[gv], &box->flags.solid);
+                            else if (token_str_eq(json, &tokens[gk], "visible")) token_to_int(json, &tokens[gv], &box->flags.visible);
+                            gi = skip_token_tree(tokens, gv, tok_count);
+                        }
+                    }
+                    fi = skip_token_tree(tokens, fv, tok_count);
+                }
+                bi = skip_token_tree(tokens, bi, tok_count);
+            }
+        } else if (token_str_eq(json, &tokens[key], "stage_cameras") && tokens[val].type == JSMN_ARRAY) {
+            int ci = val + 1;
+            while (ci < tok_count && tokens[ci].start < tokens[val].end && out_scene->stage_camera_count < EDITOR_MAX_STAGE_CAMERAS) {
+                if (tokens[ci].type != JSMN_OBJECT) {
+                    ci = skip_token_tree(tokens, ci, tok_count);
+                    continue;
+                }
+                EditorStageCamera *cam = &out_scene->stage_cameras[out_scene->stage_camera_count++];
+                memset(cam, 0, sizeof(*cam));
+                strcpy(cam->name, "camera");
+                cam->distance = 25.0f;
+                cam->pitch_degrees = 20.0f;
+                cam->yaw_degrees = 0.0f;
+                cam->fov_degrees = 60.0f;
+
+                int fi = ci + 1;
+                while (fi < tok_count && tokens[fi].start < tokens[ci].end) {
+                    int fk = fi;
+                    int fv = fi + 1;
+                    if (fv >= tok_count) break;
+                    if (token_str_eq(json, &tokens[fk], "id")) token_to_int(json, &tokens[fv], &cam->id);
+                    else if (token_str_eq(json, &tokens[fk], "name")) token_to_string(json, &tokens[fv], cam->name, sizeof(cam->name));
+                    else if (token_str_eq(json, &tokens[fk], "target")) parse_float_array(json, tokens, tok_count, fv, cam->target, 3);
+                    else if (token_str_eq(json, &tokens[fk], "distance")) token_to_float(json, &tokens[fv], &cam->distance);
+                    else if (token_str_eq(json, &tokens[fk], "yaw_degrees")) token_to_float(json, &tokens[fv], &cam->yaw_degrees);
+                    else if (token_str_eq(json, &tokens[fk], "pitch_degrees")) token_to_float(json, &tokens[fv], &cam->pitch_degrees);
+                    else if (token_str_eq(json, &tokens[fk], "fov_degrees")) token_to_float(json, &tokens[fv], &cam->fov_degrees);
+                    fi = skip_token_tree(tokens, fv, tok_count);
+                }
+                ci = skip_token_tree(tokens, ci, tok_count);
+            }
+        }
+        i = skip_token_tree(tokens, val, tok_count);
+    }
+
+    free(tokens);
+    free(json);
+    return 1;
+}
+
+int editor_scene_json_save(const char *path, const EditorSceneAsset *scene) {
+    FILE *f = fopen(path, "wb");
+    if (!f) return 0;
+
+    fprintf(f, "{\n");
+    fprintf(f, "  \"version\": %d,\n", scene->version);
+    fprintf(f, "  \"scene_name\": \"%s\",\n", scene->scene_name);
+    fprintf(f, "  \"boxes\": [\n");
+    for (size_t i = 0; i < scene->box_count; i++) {
+        const EditorSceneBox *b = &scene->boxes[i];
+        fprintf(f, "    {\n");
+        fprintf(f, "      \"id\": %d,\n", b->id);
+        fprintf(f, "      \"name\": \"%s\",\n", b->name);
+        fprintf(f, "      \"position\": [%.3f, %.3f, %.3f],\n", b->position[0], b->position[1], b->position[2]);
+        fprintf(f, "      \"size\": [%.3f, %.3f, %.3f],\n", b->size[0], b->size[1], b->size[2]);
+        fprintf(f, "      \"rotation_y_degrees\": %.3f,\n", b->rotation_y_degrees);
+        fprintf(f, "      \"color\": [%.3f, %.3f, %.3f, %.3f],\n", b->color[0], b->color[1], b->color[2], b->color[3]);
+        fprintf(f, "      \"flags\": { \"solid\": %d, \"visible\": %d }\n", b->flags.solid ? 1 : 0, b->flags.visible ? 1 : 0);
+        fprintf(f, "    }%s\n", (i + 1 < scene->box_count) ? "," : "");
+    }
+    fprintf(f, "  ],\n");
+
+    fprintf(f, "  \"stage_cameras\": [\n");
+    for (size_t i = 0; i < scene->stage_camera_count; i++) {
+        const EditorStageCamera *c = &scene->stage_cameras[i];
+        fprintf(f, "    {\n");
+        fprintf(f, "      \"id\": %d,\n", c->id);
+        fprintf(f, "      \"name\": \"%s\",\n", c->name);
+        fprintf(f, "      \"target\": [%.3f, %.3f, %.3f],\n", c->target[0], c->target[1], c->target[2]);
+        fprintf(f, "      \"distance\": %.3f,\n", c->distance);
+        fprintf(f, "      \"yaw_degrees\": %.3f,\n", c->yaw_degrees);
+        fprintf(f, "      \"pitch_degrees\": %.3f,\n", c->pitch_degrees);
+        fprintf(f, "      \"fov_degrees\": %.3f\n", c->fov_degrees);
+        fprintf(f, "    }%s\n", (i + 1 < scene->stage_camera_count) ? "," : "");
+    }
+    fprintf(f, "  ]\n");
+    fprintf(f, "}\n");
+
+    fclose(f);
+    return 1;
+}

--- a/apps/scene_editor/editor_scene_json.h
+++ b/apps/scene_editor/editor_scene_json.h
@@ -1,0 +1,9 @@
+#ifndef SHANKPIT_EDITOR_SCENE_JSON_H
+#define SHANKPIT_EDITOR_SCENE_JSON_H
+
+#include "editor_scene_asset.h"
+
+int editor_scene_json_load(const char *path, EditorSceneAsset *out_scene);
+int editor_scene_json_save(const char *path, const EditorSceneAsset *scene);
+
+#endif

--- a/apps/scene_editor/editor_selection.c
+++ b/apps/scene_editor/editor_selection.c
@@ -1,0 +1,47 @@
+#include "editor_selection.h"
+
+#include <float.h>
+#include <math.h>
+
+static int ray_aabb(const float ro[3], const float rd[3], const float bmin[3], const float bmax[3], float *out_t) {
+    float tmin = -FLT_MAX;
+    float tmax = FLT_MAX;
+    for (int i = 0; i < 3; i++) {
+        if (fabsf(rd[i]) < 1e-6f) {
+            if (ro[i] < bmin[i] || ro[i] > bmax[i]) return 0;
+            continue;
+        }
+        float inv = 1.0f / rd[i];
+        float t1 = (bmin[i] - ro[i]) * inv;
+        float t2 = (bmax[i] - ro[i]) * inv;
+        if (t1 > t2) {
+            float tmp = t1;
+            t1 = t2;
+            t2 = tmp;
+        }
+        if (t1 > tmin) tmin = t1;
+        if (t2 < tmax) tmax = t2;
+        if (tmin > tmax) return 0;
+    }
+    if (tmax < 0.0f) return 0;
+    *out_t = tmin > 0.0f ? tmin : tmax;
+    return 1;
+}
+
+int editor_selection_pick_box(const EditorSceneAsset *scene, const float ray_origin[3], const float ray_dir[3]) {
+    int best = -1;
+    float best_t = FLT_MAX;
+    for (size_t i = 0; i < scene->box_count; i++) {
+        const EditorSceneBox *box = &scene->boxes[i];
+        if (!box->flags.visible) continue;
+        float half[3] = { box->size[0] * 0.5f, box->size[1] * 0.5f, box->size[2] * 0.5f };
+        float bmin[3] = { box->position[0] - half[0], box->position[1] - half[1], box->position[2] - half[2] };
+        float bmax[3] = { box->position[0] + half[0], box->position[1] + half[1], box->position[2] + half[2] };
+        float t;
+        if (ray_aabb(ray_origin, ray_dir, bmin, bmax, &t) && t < best_t) {
+            best_t = t;
+            best = (int)i;
+        }
+    }
+    return best;
+}

--- a/apps/scene_editor/editor_selection.h
+++ b/apps/scene_editor/editor_selection.h
@@ -1,0 +1,8 @@
+#ifndef SHANKPIT_EDITOR_SELECTION_H
+#define SHANKPIT_EDITOR_SELECTION_H
+
+#include "editor_scene_asset.h"
+
+int editor_selection_pick_box(const EditorSceneAsset *scene, const float ray_origin[3], const float ray_dir[3]);
+
+#endif

--- a/apps/scene_editor/editor_ui.c
+++ b/apps/scene_editor/editor_ui.c
@@ -1,0 +1,103 @@
+#include "editor_ui.h"
+
+#include <stdio.h>
+
+#include "../../packages/ui/turtle_text.h"
+
+static void ui_text(float x, float y, float scale, const char *text) {
+    TurtlePen pen = turtle_pen_create(x, y, scale);
+    turtle_draw_text(&pen, text);
+}
+
+void editor_ui_draw_overlay(int width, int height,
+                            const EditorSceneAsset *scene,
+                            int selected_box,
+                            int selected_stage_camera,
+                            int stage_camera_drives_viewport,
+                            const EditorMoveTool *move_tool,
+                            const EditorViewportCamera *camera,
+                            const char *active_path) {
+    glMatrixMode(GL_PROJECTION);
+    glPushMatrix();
+    glLoadIdentity();
+    glOrtho(0, width, height, 0, -1, 1);
+    glMatrixMode(GL_MODELVIEW);
+    glPushMatrix();
+    glLoadIdentity();
+
+    glDisable(GL_DEPTH_TEST);
+    glColor4f(0.0f, 0.0f, 0.0f, 0.55f);
+    turtle_draw_rect(0, 0, 310, (float)height);
+    turtle_draw_rect((float)width - 340, 0, 340, (float)height);
+    glColor3f(0.94f, 0.94f, 0.94f);
+
+    char line[256];
+    int y = 18;
+    ui_text(10, (float)y, 2, "Scene Editor V1"); y += 16;
+    snprintf(line, sizeof(line), "scene: %s", scene->scene_name);
+    ui_text(10, (float)y, 2, line); y += 14;
+    snprintf(line, sizeof(line), "path: %s", active_path ? active_path : "(none)");
+    ui_text(10, (float)y, 2, line); y += 18;
+    snprintf(line, sizeof(line), "boxes: %d  cameras: %d", (int)scene->box_count, (int)scene->stage_camera_count);
+    ui_text(10, (float)y, 2, line); y += 14;
+    snprintf(line, sizeof(line), "selected box: %d", selected_box >= 0 ? selected_box : -1);
+    ui_text(10, (float)y, 2, line); y += 14;
+    snprintf(line, sizeof(line), "selected camera: %d %s", selected_stage_camera >= 0 ? selected_stage_camera : -1,
+             stage_camera_drives_viewport ? "(driving view)" : "");
+    ui_text(10, (float)y, 2, line); y += 22;
+
+    ui_text(10, (float)y, 2, "Controls"); y += 14;
+    ui_text(10, (float)y, 2, "Alt+LMB orbit"); y += 12;
+    ui_text(10, (float)y, 2, "MMB / Alt+RMB pan"); y += 12;
+    ui_text(10, (float)y, 2, "Wheel zoom"); y += 12;
+    ui_text(10, (float)y, 2, "LMB select / drag move"); y += 12;
+    ui_text(10, (float)y, 2, "F frame selected"); y += 12;
+    ui_text(10, (float)y, 2, "O load  P save"); y += 12;
+    ui_text(10, (float)y, 2, "N new camera from view"); y += 12;
+    ui_text(10, (float)y, 2, "[ ] select camera"); y += 12;
+    ui_text(10, (float)y, 2, "C toggle camera/view link"); y += 12;
+    ui_text(10, (float)y, 2, "X/Y/Z axis lock, G free"); y += 12;
+
+    int ry = 18;
+    ui_text((float)width - 330, (float)ry, 2, "Inspector"); ry += 16;
+    snprintf(line, sizeof(line), "view target: %.2f %.2f %.2f", camera->target[0], camera->target[1], camera->target[2]);
+    ui_text((float)width - 330, (float)ry, 2, line); ry += 14;
+    snprintf(line, sizeof(line), "distance %.2f yaw %.2f", camera->distance, camera->yaw_degrees);
+    ui_text((float)width - 330, (float)ry, 2, line); ry += 14;
+    snprintf(line, sizeof(line), "pitch %.2f fov %.2f", camera->pitch_degrees, camera->fov_degrees);
+    ui_text((float)width - 330, (float)ry, 2, line); ry += 20;
+
+    if (selected_box >= 0 && selected_box < (int)scene->box_count) {
+        const EditorSceneBox *box = &scene->boxes[selected_box];
+        snprintf(line, sizeof(line), "box %d: %s", box->id, box->name);
+        ui_text((float)width - 330, (float)ry, 2, line); ry += 14;
+        snprintf(line, sizeof(line), "pos: %.2f %.2f %.2f", box->position[0], box->position[1], box->position[2]);
+        ui_text((float)width - 330, (float)ry, 2, line); ry += 14;
+        snprintf(line, sizeof(line), "size: %.2f %.2f %.2f", box->size[0], box->size[1], box->size[2]);
+        ui_text((float)width - 330, (float)ry, 2, line); ry += 14;
+        snprintf(line, sizeof(line), "rotY: %.2f", box->rotation_y_degrees);
+        ui_text((float)width - 330, (float)ry, 2, line); ry += 14;
+    }
+
+    if (selected_stage_camera >= 0 && selected_stage_camera < (int)scene->stage_camera_count) {
+        const EditorStageCamera *cam = &scene->stage_cameras[selected_stage_camera];
+        ry += 6;
+        snprintf(line, sizeof(line), "stage cam %d: %s", cam->id, cam->name);
+        ui_text((float)width - 330, (float)ry, 2, line); ry += 14;
+        snprintf(line, sizeof(line), "target: %.2f %.2f %.2f", cam->target[0], cam->target[1], cam->target[2]);
+        ui_text((float)width - 330, (float)ry, 2, line); ry += 14;
+        snprintf(line, sizeof(line), "dist %.2f yaw %.2f", cam->distance, cam->yaw_degrees);
+        ui_text((float)width - 330, (float)ry, 2, line); ry += 14;
+        snprintf(line, sizeof(line), "pitch %.2f fov %.2f", cam->pitch_degrees, cam->fov_degrees);
+        ui_text((float)width - 330, (float)ry, 2, line); ry += 14;
+    }
+
+    snprintf(line, sizeof(line), "move axis: %d %s", (int)move_tool->axis, move_tool->active ? "(dragging)" : "");
+    ui_text((float)width - 330, (float)height - 20, 2, line);
+
+    glEnable(GL_DEPTH_TEST);
+    glPopMatrix();
+    glMatrixMode(GL_PROJECTION);
+    glPopMatrix();
+    glMatrixMode(GL_MODELVIEW);
+}

--- a/apps/scene_editor/editor_ui.h
+++ b/apps/scene_editor/editor_ui.h
@@ -1,0 +1,17 @@
+#ifndef SHANKPIT_EDITOR_UI_H
+#define SHANKPIT_EDITOR_UI_H
+
+#include "editor_camera.h"
+#include "editor_move_tool.h"
+#include "editor_scene_asset.h"
+
+void editor_ui_draw_overlay(int width, int height,
+                            const EditorSceneAsset *scene,
+                            int selected_box,
+                            int selected_stage_camera,
+                            int stage_camera_drives_viewport,
+                            const EditorMoveTool *move_tool,
+                            const EditorViewportCamera *camera,
+                            const char *active_path);
+
+#endif

--- a/apps/scene_editor/main.c
+++ b/apps/scene_editor/main.c
@@ -1,0 +1,10 @@
+#include <stddef.h>
+#include "editor_app.h"
+
+int main(int argc, char **argv) {
+    const char *scene_path = NULL;
+    if (argc > 1) {
+        scene_path = argv[1];
+    }
+    return editor_app_run(scene_path);
+}

--- a/assets/scenes/test_room.json
+++ b/assets/scenes/test_room.json
@@ -1,0 +1,53 @@
+{
+  "version": 1,
+  "scene_name": "test_room",
+  "boxes": [
+    {
+      "id": 1,
+      "name": "floor",
+      "position": [0.0, -1.0, 0.0],
+      "size": [30.0, 1.0, 30.0],
+      "rotation_y_degrees": 0.0,
+      "color": [0.25, 0.28, 0.30, 1.0],
+      "flags": { "solid": 1, "visible": 1 }
+    },
+    {
+      "id": 2,
+      "name": "center_block",
+      "position": [0.0, 2.0, 0.0],
+      "size": [8.0, 4.0, 8.0],
+      "rotation_y_degrees": 0.0,
+      "color": [0.70, 0.20, 0.20, 1.0],
+      "flags": { "solid": 1, "visible": 1 }
+    },
+    {
+      "id": 3,
+      "name": "catwalk",
+      "position": [10.0, 4.0, -8.0],
+      "size": [12.0, 1.0, 3.0],
+      "rotation_y_degrees": 18.0,
+      "color": [0.55, 0.55, 0.75, 1.0],
+      "flags": { "solid": 1, "visible": 1 }
+    }
+  ],
+  "stage_cameras": [
+    {
+      "id": 1,
+      "name": "overview",
+      "target": [0.0, 1.0, 0.0],
+      "distance": 28.0,
+      "yaw_degrees": 35.0,
+      "pitch_degrees": 24.0,
+      "fov_degrees": 60.0
+    },
+    {
+      "id": 2,
+      "name": "arena_focus",
+      "target": [8.0, 2.0, -3.0],
+      "distance": 18.0,
+      "yaw_degrees": -30.0,
+      "pitch_degrees": 22.0,
+      "fov_degrees": 55.0
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide a low-risk, standalone scene editor under `apps/scene_editor/` to author a proposed external scene/map format without changing the existing runtime scene-loading flow. 
- Document a simple JSON V1 protocol for authored maps so tooling and runtime can converge later with minimal risk.
- Keep blast radius minimal by keeping editor code local to `apps/scene_editor/` and avoiding runtime refactors.

### Description
- Add a new editor app at `apps/scene_editor/` with modular sources: `main.c`, `editor_app.{c,h}`, `editor_camera.{c,h}`, `editor_selection.{c,h}`, `editor_move_tool.{c,h}`, `editor_ui.{c,h}`, `editor_scene_asset.{c,h}`, and `editor_scene_json.{c,h}`; the app implements viewport orbit/zoom/pan, box selection/highlight, a move tool (with axis lock), and stage camera authoring. 
- Define and implement JSON V1 scene format (top-level `version` and `scene_name`, `boxes` array and `stage_cameras` array) and wire load/save in `editor_scene_json.c` using a tiny local parser to avoid touching runtime serialization paths; V1 boxes support only Y-axis rotation via `rotation_y_degrees`. 
- Add a sample scene asset at `assets/scenes/test_room.json` exercising multiple boxes and stage cameras. 
- Update `Makefile` to add a conservative `scene_editor` target and `bin/shank_scene_editor` artifact, and include the editor build in `make all` so the editor can be built alongside existing artifacts. 
- Update `README.md` with a new `Scene Editor (Standalone First Pass)` section documenting build/run instructions, controls, the JSON protocol schema, an example JSON blob, and an explicit note that runtime adoption is deferred.

### Testing
- Compiled editor translation units individually with `gcc -O2 -Wall -c` and these object builds succeeded for: `editor_scene_asset.c`, `editor_scene_json.c`, `editor_selection.c`, `editor_move_tool.c`, and `editor_camera.c` (local compile checks completed). 
- Ran `make scene_editor` to build the full editor binary; this failed in the current container because SDL2 development headers are not installed (`SDL2/SDL.h` and `SDL2/SDL_opengl.h` missing), so full binary linking could not be completed here. 
- No runtime/gameplay code was modified and existing build targets for the lobby/server were left unchanged by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3fbb90ae0832796d5a589a536ee7e)