### PR TITLE
Add CTFB flag-carry viewmodel and reuse knife melee envelope for carry attacks

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -1728,6 +1728,15 @@ static ViewmodelTuning viewmodel_tuning_for_weapon(int weapon_id) {
     return t;
 }
 
+static int player_is_flag_carrying_viewmodel(const PlayerState *p) {
+    return (local_state.game_mode == MODE_CTFB && p->carried_flag_team_id >= 0);
+}
+
+static ViewmodelTuning viewmodel_tuning_for_flag_carry(int carried_flag_team_id) {
+    (void)carried_flag_team_id;
+    return (ViewmodelTuning){0.30f, -0.46f, -0.98f, 0.0f, 0.0f, 0.0f, 0.0f, 0.12f};
+}
+
 static void draw_viewmodel_box_tone(const ViewmodelPalette *p, float w, float h, float d, int support_tone) {
     float base_r = support_tone ? p->support_r : p->body_r;
     float base_g = support_tone ? p->support_g : p->body_g;
@@ -1844,6 +1853,35 @@ static void draw_viewmodel_weapon(int weapon_id) {
         case WPN_KNIFE: draw_viewmodel_knife_firstperson(); break;
         default: draw_viewmodel_magnum(&p); break;
     }
+}
+
+static void draw_viewmodel_flag_carry(int carried_flag_team_id) {
+    float cloth_r = 0.82f, cloth_g = 0.15f, cloth_b = 0.14f;
+    if (carried_flag_team_id == 1) {
+        cloth_r = 0.16f; cloth_g = 0.34f; cloth_b = 0.86f;
+    }
+
+    glScalef(0.86f, 0.86f, 0.86f);
+
+    glColor3f(0.42f, 0.30f, 0.22f);
+    glPushMatrix(); glTranslatef(-0.42f, -0.24f, -0.02f); glRotatef(-14.0f, 1, 0, 0); draw_box(0.24f, 0.25f, 0.96f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.18f, -0.30f, -0.16f); glRotatef(-10.0f, 1, 0, 0); draw_box(0.24f, 0.24f, 0.88f); glPopMatrix();
+
+    glColor3f(0.10f, 0.11f, 0.13f);
+    glPushMatrix(); glTranslatef(-0.44f, -0.35f, 0.38f); draw_box(0.27f, 0.16f, 0.30f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.14f, -0.38f, 0.28f); draw_box(0.26f, 0.17f, 0.30f); glPopMatrix();
+
+    glPushMatrix();
+    glTranslatef(-0.12f, -0.10f, 0.18f);
+    glRotatef(24.0f, 0, 0, 1);
+    glRotatef(-15.0f, 1, 0, 0);
+    glColor3f(0.16f, 0.14f, 0.12f);
+    glPushMatrix(); glTranslatef(0.02f, 0.02f, 0.60f); draw_box(0.09f, 0.09f, 1.78f); glPopMatrix();
+    glColor3f(cloth_r, cloth_g, cloth_b);
+    glPushMatrix(); glTranslatef(-0.26f, 0.46f, 1.12f); glRotatef(8.0f, 0, 1, 0); draw_box(0.70f, 0.42f, 0.12f); glPopMatrix();
+    glColor3f(cloth_r * 0.85f, cloth_g * 0.85f, cloth_b * 0.85f);
+    glPushMatrix(); glTranslatef(-0.20f, 0.31f, 1.08f); draw_box(0.58f, 0.08f, 0.08f); glPopMatrix();
+    glPopMatrix();
 }
 
 static void draw_weapon_muzzle_flash(int weapon_id, float intensity) {
@@ -2519,15 +2557,20 @@ static void draw_player_skin_alpine(PlayerState *p, float draw_pitch, float draw
 void draw_weapon_p(PlayerState *p) {
     static int prev_weapon = -1;
     static int prev_shooting = 0;
+    static int prev_flag_carrying = 0;
     static Uint32 knife_stab_start_ms = 0;
+    static Uint32 flag_swing_start_ms = 0;
     if (p->in_vehicle) return; 
     glPushMatrix();
     glLoadIdentity();
     const float viewmodel_global_scale = 0.72f;
-    ViewmodelTuning tune = viewmodel_tuning_for_weapon(p->current_weapon);
     Uint32 now_ms = SDL_GetTicks();
+    int flag_carrying_vm = player_is_flag_carrying_viewmodel(p);
+    ViewmodelTuning tune = flag_carrying_vm ? viewmodel_tuning_for_flag_carry(p->carried_flag_team_id) : viewmodel_tuning_for_weapon(p->current_weapon);
 
-    if (p->current_weapon == WPN_KNIFE) {
+    if (flag_carrying_vm) {
+        knife_stab_start_ms = 0;
+    } else if (p->current_weapon == WPN_KNIFE) {
         if (prev_weapon != WPN_KNIFE) knife_stab_start_ms = 0;
         if (p->is_shooting > 0 && prev_shooting <= 0) knife_stab_start_ms = now_ms;
     } else if (prev_weapon == WPN_KNIFE) {
@@ -2540,7 +2583,14 @@ void draw_weapon_p(PlayerState *p) {
         if (knife_stab_t >= 1.0f) knife_stab_start_ms = 0;
     }
 
-    float kick = (p->current_weapon == WPN_KNIFE) ? 0.0f : p->recoil_anim * tune.kick_scale;
+    if (flag_carrying_vm) {
+        if (!prev_flag_carrying) flag_swing_start_ms = 0;
+        if (p->is_shooting > 0 && prev_shooting <= 0) flag_swing_start_ms = now_ms;
+    } else {
+        flag_swing_start_ms = 0;
+    }
+
+    float kick = (p->current_weapon == WPN_KNIFE || flag_carrying_vm) ? 0.0f : p->recoil_anim * tune.kick_scale;
     float reload_dip = (p->reload_timer > 0) ? sinf(p->reload_timer * 0.2f) * 0.5f - 0.5f : 0.0f;
     float slash_swing = (p->current_weapon == WPN_KATANA && p->katana_slash_timer > 0) ? ((float)p->katana_slash_timer / (float)KATANA_SLASH_ACTIVE_TICKS) : 0.0f;
     float dash_push = (p->current_weapon == WPN_KATANA && p->dash_timer > 0) ? 0.22f : 0.0f;
@@ -2556,31 +2606,55 @@ void draw_weapon_p(PlayerState *p) {
     float knife_anim_drop = (knife_drive * 0.13f) - (knife_recover * 0.05f);
     float knife_anim_pitch = (knife_drive * 30.0f) - (knife_recover * 10.0f);
     float knife_anim_roll = (knife_drive * 7.0f) - (knife_recover * 3.0f);
+
+    float flag_swing_t = 0.0f;
+    if (flag_carrying_vm && flag_swing_start_ms > 0) {
+        flag_swing_t = clamp01f((float)(now_ms - flag_swing_start_ms) / 250.0f);
+        if (flag_swing_t >= 1.0f) flag_swing_start_ms = 0;
+    }
+    float flag_wind = clamp01f(flag_swing_t / 0.20f);
+    float flag_drive = clamp01f((flag_swing_t - 0.12f) / 0.36f);
+    float flag_recover = clamp01f((flag_swing_t - 0.48f) / 0.52f);
+    flag_wind = flag_wind * flag_wind;
+    flag_drive = 1.0f - (1.0f - flag_drive) * (1.0f - flag_drive);
+    flag_recover = flag_recover * flag_recover;
+    float flag_anim_x = (-0.06f * flag_wind) + (0.20f * flag_drive) - (0.13f * flag_recover);
+    float flag_anim_y = (0.04f * flag_wind) - (0.11f * flag_drive) + (0.05f * flag_recover);
+    float flag_anim_z = (0.09f * flag_wind) - (0.56f * flag_drive) + (0.20f * flag_recover);
+    float flag_anim_pitch = (5.0f * flag_wind) + (26.0f * flag_drive) - (10.0f * flag_recover);
+    float flag_anim_yaw = (-8.0f * flag_wind) + (-34.0f * flag_drive) + (14.0f * flag_recover);
+    float flag_anim_roll = (4.0f * flag_wind) + (18.0f * flag_drive) - (8.0f * flag_recover);
+
     float speed = sqrtf(p->vx*p->vx + p->vz*p->vz);
     float bob = sinf(SDL_GetTicks() * 0.015f) * speed * tune.idle_scale;
     float ads_blend = (current_fov < 50.0f) ? 0.22f : 0.0f;
+    if (flag_carrying_vm) ads_blend = 0.0f;
     glTranslatef(
-        tune.base_x - ads_blend + slash_swing * 0.18f,
-        tune.base_y + kick + reload_dip * 0.7f + (bob * 0.4f) - knife_anim_drop,
-        tune.base_z + (kick * 0.45f) + bob - dash_push - p->recoil_anim * tune.recoil_back - knife_anim_forward
+        tune.base_x - ads_blend + slash_swing * 0.18f + flag_anim_x,
+        tune.base_y + kick + reload_dip * 0.7f + (bob * (flag_carrying_vm ? 0.55f : 0.4f)) - knife_anim_drop + flag_anim_y,
+        tune.base_z + (kick * 0.45f) + (bob * (flag_carrying_vm ? 1.15f : 1.0f)) - dash_push - p->recoil_anim * tune.recoil_back - knife_anim_forward + flag_anim_z
     );
-    glRotatef(-p->recoil_anim * tune.recoil_pitch - slash_swing * 65.0f - knife_anim_pitch, 1, 0, 0);
-    glRotatef(-p->recoil_anim * tune.recoil_roll - knife_anim_roll, 0, 0, 1);
+    glRotatef(-p->recoil_anim * tune.recoil_pitch - slash_swing * 65.0f - knife_anim_pitch + flag_anim_pitch, 1, 0, 0);
+    glRotatef(flag_anim_yaw, 0, 1, 0);
+    glRotatef(-p->recoil_anim * tune.recoil_roll - knife_anim_roll + flag_anim_roll, 0, 0, 1);
     glRotatef(-slash_swing * 40.0f, 0, 0, 1);
-    if (p->current_weapon == WPN_KNIFE) glRotatef(-12.0f, 0, 1, 0);
+    if (flag_carrying_vm) glRotatef(-14.0f, 0, 1, 0);
+    else if (p->current_weapon == WPN_KNIFE) glRotatef(-12.0f, 0, 1, 0);
     glScalef(viewmodel_global_scale, viewmodel_global_scale, viewmodel_global_scale);
-    draw_viewmodel_weapon(p->current_weapon);
-    if (p->is_shooting > 0) {
+    if (flag_carrying_vm) draw_viewmodel_flag_carry(p->carried_flag_team_id);
+    else draw_viewmodel_weapon(p->current_weapon);
+    if (!flag_carrying_vm && p->is_shooting > 0) {
         float flash = 1.0f;
         if (p->current_weapon == WPN_AR) flash = 0.85f;
         else if (p->current_weapon == WPN_SHOTGUN) flash = 1.25f;
         else if (p->current_weapon == WPN_SNIPER) flash = 0.95f;
         draw_weapon_muzzle_flash(p->current_weapon, flash);
-    } else if (p->recoil_anim > 0.0f) {
+    } else if (!flag_carrying_vm && p->recoil_anim > 0.0f) {
         draw_weapon_muzzle_flash(p->current_weapon, p->recoil_anim * 0.55f);
     }
     prev_weapon = p->current_weapon;
     prev_shooting = p->is_shooting;
+    prev_flag_carrying = flag_carrying_vm;
     glPopMatrix();
 }
 

--- a/apps/tests/test_ctfb_carry_melee.c
+++ b/apps/tests/test_ctfb_carry_melee.c
@@ -1,0 +1,58 @@
+#include <stdio.h>
+#include <netinet/in.h>
+
+#include "../../packages/common/net_sim.h"
+#include "../../packages/simulation/local_game.h"
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define ASSERT_TRUE(cond, msg) do { \
+    tests_run++; \
+    if (!(cond)) { \
+        printf("❌ %s\n", msg); \
+    } else { \
+        printf("✅ %s\n", msg); \
+        tests_passed++; \
+    } \
+} while (0)
+
+int main(void) {
+    printf("--- CTFB Carry Melee Regression ---\n");
+    local_init_match(12, MODE_CTFB);
+
+    PlayerState *attacker = &local_state.players[0];
+    PlayerState *target = &local_state.players[7];
+    unsigned int now_ms = 1000;
+
+    attacker->state = STATE_ALIVE;
+    attacker->x = 0.0f; attacker->y = 0.0f; attacker->z = 0.0f;
+    attacker->yaw = 0.0f; attacker->pitch = 0.0f;
+    attacker->carried_flag_team_id = TDMB_RED_TEAM;
+    attacker->ctf_melee_cooldown_ms = 0;
+
+    target->state = STATE_ALIVE;
+    target->shield = 0;
+    target->health = 100;
+    target->x = 0.0f; target->y = 0.0f; target->z = -8.0f;
+    target->scene_id = attacker->scene_id;
+    target->team_id = TDMB_RED_TEAM;
+
+    ctf_try_carry_melee(attacker, now_ms);
+    ASSERT_TRUE(target->health == 100 - CTFB_CARRY_MELEE_DAMAGE, "Flag carry melee reuses knife envelope and lands in front arc");
+    ASSERT_TRUE(attacker->ctf_melee_cooldown_ms == now_ms + CTFB_CARRY_MELEE_COOLDOWN_MS, "Flag carry melee applies CTF cooldown source of truth");
+    ASSERT_TRUE(attacker->is_shooting == 3, "Flag carry melee marks melee fire animation state");
+
+    int health_after_first = target->health;
+    ctf_try_carry_melee(attacker, now_ms + 100);
+    ASSERT_TRUE(target->health == health_after_first, "Flag carry melee respects cooldown and does not multi-hit early");
+
+    target->health = 100;
+    target->x = 8.0f; target->z = 0.0f;
+    attacker->ctf_melee_cooldown_ms = 0;
+    ctf_try_carry_melee(attacker, now_ms + 900);
+    ASSERT_TRUE(target->health == 100, "Flag carry melee misses targets outside knife-style trace envelope");
+
+    printf("SUMMARY: %d/%d Tests Passed.\n", tests_passed, tests_run);
+    return (tests_passed == tests_run) ? 0 : 1;
+}

--- a/apps/tests/test_ctfb_respawn.c
+++ b/apps/tests/test_ctfb_respawn.c
@@ -39,7 +39,7 @@ int main(void) {
     enemy_flag->state = FLAG_CARRIED;
     enemy_flag->carrier_id = carrier->id;
 
-    apply_projectile_damage(attacker, carrier, 50, death_ms);
+    apply_projectile_damage(attacker, carrier, 50, death_ms, 0.0f, 0.0f);
 
     ASSERT_TRUE(carrier->state == STATE_DEAD, "Carrier is dead immediately after lethal hit");
     ASSERT_TRUE(carrier->respawn_time == death_ms + CTFB_RESPAWN_DELAY_MS, "Carrier respawn is scheduled 3000ms later");

--- a/packages/common/physics.h
+++ b/packages/common/physics.h
@@ -2234,6 +2234,41 @@ int check_hit_location(float ox, float oy, float oz, float dx, float dy, float d
     return 0;
 }
 
+static inline int phys_try_melee_strike(PlayerState *attacker, PlayerState *targets, int base_damage, int hit_feedback, int allow_headshot_multiplier, unsigned int now_ms, unsigned int respawn_delay_ms) {
+    float r = -attacker->yaw * 0.0174533f;
+    float rp = attacker->pitch * 0.0174533f;
+    float dx = sinf(r) * cosf(rp);
+    float dy = sinf(rp);
+    float dz = -cosf(r) * cosf(rp);
+    int hit_any = 0;
+
+    for (int i = 0; i < MAX_CLIENTS; i++) {
+        if (attacker == &targets[i]) continue;
+        if (!targets[i].active || targets[i].state == STATE_DEAD) continue;
+        if (targets[i].scene_id != attacker->scene_id) continue;
+        if (phys_is_friendly(attacker, &targets[i])) continue;
+
+        float kx = attacker->x - targets[i].x;
+        float ky = attacker->y - targets[i].y;
+        float kz = attacker->z - targets[i].z;
+        if ((kx*kx + ky*ky + kz*kz) > MELEE_RANGE_SQ + 22.0f) continue;
+
+        int hit_type = check_hit_location(attacker->x, attacker->y + EYE_HEIGHT, attacker->z, dx, dy, dz, &targets[i]);
+        if (hit_type <= 0) continue;
+
+        int damage = base_damage;
+        attacker->hit_feedback = hit_feedback;
+        if (allow_headshot_multiplier && hit_type == 2 && targets[i].shield <= 0) {
+            damage *= 3;
+            attacker->hit_feedback = 20;
+        }
+        katana_apply_damage(attacker, &targets[i], damage, attacker->hit_feedback, now_ms, respawn_delay_ms);
+        hit_any = 1;
+    }
+
+    return hit_any;
+}
+
 void apply_friction(PlayerState *p) {
     if (p->dash_timer > 0) return;
     float speed = sqrtf(p->vx*p->vx + p->vz*p->vz);
@@ -2436,6 +2471,10 @@ void update_weapons(PlayerState *p, PlayerState *targets, Projectile *projectile
                 katana_try_slash(p, targets, now_ms, respawn_delay_ms);
                 return;
             }
+            if (w == WPN_KNIFE) {
+                phys_try_melee_strike(p, targets, WPN_STATS[w].dmg, 10, 1, now_ms, respawn_delay_ms);
+                return;
+            }
             
             float r = -p->yaw * 0.0174533f; float rp = p->pitch * 0.0174533f;
             float dx = sinf(r) * cosf(rp); float dy = sinf(rp); float dz = -cosf(r) * cosf(rp);
@@ -2450,11 +2489,6 @@ void update_weapons(PlayerState *p, PlayerState *targets, Projectile *projectile
                 if (!targets[i].active || targets[i].state == STATE_DEAD) continue;
                 if (targets[i].scene_id != p->scene_id) continue;
                 if (phys_is_friendly(p, &targets[i])) continue;
-                if (w == WPN_KNIFE) {
-                    float kx = p->x - targets[i].x;
-                    float ky = p->y - targets[i].y; float kz = p->z - targets[i].z;
-                    if ((kx*kx + ky*ky + kz*kz) > MELEE_RANGE_SQ + 22.0f ) continue;
-                }
                 int hit_type = check_hit_location(p->x, p->y + EYE_HEIGHT, p->z, dx, dy, dz, &targets[i]);
                 if (hit_type > 0) {
                     printf("🔫 HIT! Dmg: %d on Target %d\n", WPN_STATS[w].dmg, i);

--- a/packages/simulation/local_game.h
+++ b/packages/simulation/local_game.h
@@ -423,42 +423,10 @@ static void ctf_try_capture(PlayerState *p, unsigned int now_ms) {
 static void ctf_try_carry_melee(PlayerState *attacker, unsigned int now_ms) {
     if (attacker->carried_flag_team_id < 0) return;
     if (attacker->ctf_melee_cooldown_ms > now_ms) return;
-    float r = -attacker->yaw * 0.0174533f;
-    float fx = sinf(r), fz = -cosf(r);
-    float range_sq = 11.0f * 11.0f;
-    float best_dot = 0.75f;
-    int best = -1;
-    for (int i = 0; i < MAX_CLIENTS; i++) {
-        PlayerState *t = &local_state.players[i];
-        if (t == attacker || !t->active || t->state == STATE_DEAD) continue;
-        if (t->scene_id != attacker->scene_id) continue;
-        if (t->team_id == attacker->team_id) continue;
-        float dx = t->x - attacker->x, dz = t->z - attacker->z;
-        float d2 = dx*dx + dz*dz;
-        if (d2 > range_sq || d2 < 0.001f) continue;
-        float inv = 1.0f / sqrtf(d2);
-        float dot = fx * (dx * inv) + fz * (dz * inv);
-        if (dot > best_dot) { best_dot = dot; best = i; }
-    }
+    /* Reuse knife melee envelope (trace + range gate); CTFB keeps its own damage/cooldown as source of truth. */
     attacker->ctf_melee_cooldown_ms = now_ms + CTFB_CARRY_MELEE_COOLDOWN_MS;
     attacker->is_shooting = 3;
-    if (best >= 0) {
-        PlayerState *t = &local_state.players[best];
-        t->shield_regen_timer = SHIELD_REGEN_DELAY;
-        int damage = CTFB_CARRY_MELEE_DAMAGE;
-        if (t->shield > 0) {
-            if (t->shield >= damage) { t->shield -= damage; damage = 0; }
-            else { damage -= t->shield; t->shield = 0; }
-        }
-        t->health -= damage;
-        attacker->hit_feedback = 16;
-        if (t->health <= 0) {
-            ctf_drop_flag_from_carrier(t->id, now_ms);
-            float incoming_x = t->x - attacker->x;
-            float incoming_z = t->z - attacker->z;
-            ctf_schedule_respawn(attacker, t, now_ms, incoming_x, incoming_z);
-        }
-    }
+    phys_try_melee_strike(attacker, local_state.players, CTFB_CARRY_MELEE_DAMAGE, 16, 0, now_ms, mode_respawn_delay_ms(local_state.game_mode));
 }
 
 // --- BOT AI ---


### PR DESCRIPTION
### Motivation
- Provide a dedicated low‑poly first‑person viewmodel when a player carries the enemy flag in CTFB so the player visibly holds a team‑colored flag instead of a gun. 
- Reuse existing knife/katana melee geometry and timing where possible so carry attacks use the same trace/range envelope while preserving CTFB damage/cooldown constants.

### Description
- Add a dedicated carry viewmodel render path enabled when `local_state.game_mode == MODE_CTFB` and `p->carried_flag_team_id >= 0`, implemented via `player_is_flag_carrying_viewmodel`, `viewmodel_tuning_for_flag_carry`, and `draw_viewmodel_flag_carry`, and selected inside `draw_weapon_p` to override normal weapon rendering.
- Model is immediate‑mode, low‑poly box composition (forearms, gloved hands, pole, cloth) with cloth color driven by `carried_flag_team_id`, slightly slanted up/left, and bob/sway driven from existing viewmodel bob basis.
- Add a carry swing animation (wind‑up, left‑biased drive, recover) in `draw_weapon_p` that is separate from gun recoil and does not produce muzzle flash when active.
- Extract a shared melee helper `phys_try_melee_strike(...)` in `packages/common/physics.h` and route existing knife melee and the CTFB carry melee through it so both use the same trace/range envelope; CTFB still uses `CTFB_CARRY_MELEE_DAMAGE` and `CTFB_CARRY_MELEE_COOLDOWN_MS` as the source of truth (documented in code comments).
- Replace the bespoke CTF carry targeting code in `ctf_try_carry_melee` with a call to `phys_try_melee_strike(...)` so carry attacks reuse knife geometry while keeping CTF damage/cooldown semantics.
- Files changed: `apps/lobby/src/main.c` (viewmodel helpers, carry model, animation, muzzle suppression), `packages/common/physics.h` (new `phys_try_melee_strike` and routing knife through it), `packages/simulation/local_game.h` (CTFB carry melee now calls helper), `apps/tests/test_ctfb_carry_melee.c` (new focused regression test), and a minor test signature fix in `apps/tests/test_ctfb_respawn.c`.

### Testing
- Built and ran the focused carry melee test with: `gcc -O2 -Wall -Ipackages/common -Ipackages/simulation -Ipackages/world apps/tests/test_ctfb_carry_melee.c packages/world/terrain.c -lm -o /tmp/test_ctfb_carry_melee && /tmp/test_ctfb_carry_melee`, and it passed (5/5 assertions).
- Rebuilt and ran the existing respawn/flag drop test with: `gcc -O2 -Wall -Ipackages/common -Ipackages/simulation -Ipackages/world apps/tests/test_ctfb_respawn.c packages/world/terrain.c -lm -o /tmp/test_ctfb_respawn && /tmp/test_ctfb_respawn`, and it passed (11/11 assertions).
- Attempted a lobby client build to sanity‑check viewmodel compile, but environment lacks SDL2 headers so the client build failed with `SDL2/SDL.h` not found; runtime visual verification should be done where SDL/OpenGL dev headers are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4102f8ca0832795f945f5b9dc4f14)