### PR TITLE
Add 120ms visual dead hold before fall-over animation

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -182,8 +182,12 @@ static float smoothstepf(float edge0, float edge1, float x) {
 
 static float death_pose_progress(const PlayerState *p, unsigned int now_ms) {
     if (!p || p->state != STATE_DEAD || p->death_time_ms == 0) return 0.0f;
+    const unsigned int hold_ms = 120;
+    const float fall_ms = 360.0f;
     unsigned int elapsed = (now_ms > p->death_time_ms) ? (now_ms - p->death_time_ms) : 0;
-    float t = (float)elapsed / 360.0f;
+    if (elapsed <= hold_ms) return 0.0f;
+    unsigned int anim_elapsed = elapsed - hold_ms;
+    float t = (float)anim_elapsed / fall_ms;
     if (t < 0.0f) t = 0.0f;
     if (t > 1.0f) t = 1.0f;
     return t * t * (3.0f - 2.0f * t);


### PR DESCRIPTION
### Motivation
- Introduce a short visual pause between the instant a player is marked dead and when the fall-over animation begins to make deaths read clearer visually while keeping gameplay timing identical.
- The change must be strictly render-side so `STATE_DEAD`, `death_time_ms`, respawn timers, kill credit, and flag-drop logic remain driven by the original death timestamp.

### Description
- Updated `death_pose_progress(const PlayerState *p, unsigned int now_ms)` in `apps/lobby/src/main.c` to add a `hold_ms = 120` before the fall starts. 
- Kept the fall duration `fall_ms = 360` and reused the existing smooth easing (`t * t * (3 - 2*t)`) and clamping behavior. 
- Behavior: compute `elapsed = max(0, now_ms - p->death_time_ms)`, return `0.0f` for `elapsed <= hold_ms`, otherwise use `anim_elapsed = elapsed - hold_ms` and `t = anim_elapsed / fall_ms` to drive the same eased curve.

### Testing
- Ran source-level checks with `rg -n "death_pose_progress\(|phys_enter_death_state|death_time_ms" apps/lobby/src/main.c` to confirm the change is localized to the render-side helper and no gameplay death functions were modified. 
- Verified the exact patch via `git diff` of `apps/lobby/src/main.c` to ensure only the stated lines were changed. 
- Note: runtime/manual in-game checks (local death feel, respawn timing, multiplayer snapshots, and CTF flag-drop behavior) were not executable in this headless environment and should be validated in-game following the provided test plan.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4134c672c83279280072f7de3a379)