### PR TITLE
Add subtle dead-hold twist and shorten death fall to 300ms

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -183,7 +183,7 @@ static float smoothstepf(float edge0, float edge1, float x) {
 static float death_pose_progress(const PlayerState *p, unsigned int now_ms) {
     if (!p || p->state != STATE_DEAD || p->death_time_ms == 0) return 0.0f;
     const unsigned int hold_ms = 120;
-    const float fall_ms = 360.0f;
+    const float fall_ms = 300.0f;
     unsigned int elapsed = (now_ms > p->death_time_ms) ? (now_ms - p->death_time_ms) : 0;
     if (elapsed <= hold_ms) return 0.0f;
     unsigned int anim_elapsed = elapsed - hold_ms;
@@ -191,6 +191,16 @@ static float death_pose_progress(const PlayerState *p, unsigned int now_ms) {
     if (t < 0.0f) t = 0.0f;
     if (t > 1.0f) t = 1.0f;
     return t * t * (3.0f - 2.0f * t);
+}
+
+static float death_pose_twist_degrees(const PlayerState *p, unsigned int now_ms) {
+    if (!p || p->state != STATE_DEAD || p->death_time_ms == 0) return 0.0f;
+    const unsigned int hold_ms = 120;
+    const float max_twist_deg = 6.5f;
+    unsigned int elapsed = (now_ms > p->death_time_ms) ? (now_ms - p->death_time_ms) : 0;
+    float hold_t = clamp01f((float)elapsed / (float)hold_ms);
+    float eased = hold_t * hold_t * (3.0f - 2.0f * hold_t);
+    return max_twist_deg * eased;
 }
 
 /*
@@ -2718,7 +2728,11 @@ void draw_player_3rd(PlayerState *p) {
             axis_x /= axis_len;
             axis_z /= axis_len;
         }
-        float fall = death_pose_progress(p, SDL_GetTicks());
+        unsigned int now_ms = SDL_GetTicks();
+        float fall = death_pose_progress(p, now_ms);
+        float twist = death_pose_twist_degrees(p, now_ms);
+        float twist_sign = (local_right >= 0.0f) ? 1.0f : -1.0f;
+        glRotatef(twist * twist_sign, 0.0f, 1.0f, 0.0f);
         glTranslatef(0.0f, 1.1f, 0.0f);
         glRotatef(88.0f * fall, axis_x, 0.0f, axis_z);
         glRotatef(8.0f * fall * local_right, 0.0f, 0.0f, 1.0f);


### PR DESCRIPTION
### Motivation
- Improve the visual read of lethal deaths by retaining the 120 ms visual hold while adding a subtle long-axis twist during that hold so the body reads more natural and corkscrew-like before the topple.
- Speed up the existing death topple so the fall completes faster and feels snappier while leaving all gameplay death semantics unchanged.

### Description
- Reduced the fall duration in `death_pose_progress(...)` from `360.0f` to `300.0f` and kept the existing `hold_ms = 120` gate so topple still starts after the 120 ms hold (file: `apps/lobby/src/main.c`).
- Added a render-only helper `death_pose_twist_degrees(const PlayerState *p, unsigned int now_ms)` that ramps a small twist (max ~6.5°) from death start through the 120 ms hold using the same smoothstep easing used elsewhere (file: `apps/lobby/src/main.c`).
- Composed the motion in `draw_player_3rd(...)` by sampling `now_ms = SDL_GetTicks()`, applying the twist rotation (signed by `local_right`) before the existing topple rotations so the original fall-away direction logic driven by `death_pose_progress(...)` is preserved (file: `apps/lobby/src/main.c`).

### Testing
- Attempted to run project tests via `./run_tests` but received permission denied, and `bash run_tests` was not executable in this environment, so automated test harness could not be executed here.
- Ran `make -j2` to build; compilation started but failed due to missing system SDL2 headers (`SDL2/SDL.h`, `SDL2/SDL_opengl.h`) in this environment, so a full binary test could not be completed.
- Changes were compiled locally up to preprocessing in the test environment and committed as a focused change (`apps/lobby/src/main.c`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41916c3b48327a1da7eae84b25314)