### PR TITLE
lobby: shrink and move magnum front sight forward

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -1900,7 +1900,7 @@ static void draw_viewmodel_magnum(const ViewmodelPalette *p) {
     glPushMatrix(); glTranslatef(0.00f, -0.14f, -0.24f); glRotatef(-15.0f, 1, 0, 0); draw_viewmodel_box_tone(p, 0.46f, 0.70f, 0.66f, 1); glPopMatrix();
     glPushMatrix(); glTranslatef(0.00f, 0.03f, 0.94f); draw_viewmodel_box_tone(p, 0.62f, 0.18f, 0.46f, 1); glPopMatrix();
     glPushMatrix(); glTranslatef(0.00f, 0.28f, 0.16f); draw_viewmodel_box_tone(p, 0.74f, 0.08f, 0.90f, 1); glPopMatrix();
-    glPushMatrix(); glTranslatef(0.00f, 0.19f, 1.20f); draw_viewmodel_box_tone(p, 0.18f, 0.10f, 0.14f, 1); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.00f, 0.19f, 1.34f); draw_viewmodel_box_tone(p, 0.036f, 0.020f, 0.028f, 1); glPopMatrix();
 }
 
 static void draw_viewmodel_ar(const ViewmodelPalette *p) {


### PR DESCRIPTION
### Motivation
- Reduce the magnum iron/front sight size and move it slightly toward the muzzle to improve the first-person silhouette while keeping all other weapon geometry, tuning, and materials unchanged.

### Description
- Replaced the final magnum sight block in `apps/lobby/src/main.c` by changing the line from `glPushMatrix(); glTranslatef(0.00f, 0.19f, 1.20f); draw_viewmodel_box_tone(p, 0.18f, 0.10f, 0.14f, 1); glPopMatrix();` to `glPushMatrix(); glTranslatef(0.00f, 0.19f, 1.34f); draw_viewmodel_box_tone(p, 0.036f, 0.020f, 0.028f, 1); glPopMatrix();` which shrinks the sight dimensions by 80% and moves it forward along local +Z without touching any other viewmodel pieces or parameters.

### Testing
- Verified the edit via `rg` to locate the original pattern, inspected the `git diff` to confirm only the targeted line changed, and printed the file region with `nl` to validate the before/after; all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e42a76ad3c83279cb0c02056a1e9fd)