### PR TITLE
Camera-led buggy steering: add steer_target and refine yaw/traction model

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -3785,6 +3785,9 @@ void draw_scene(PlayerState *render_p) {
     float base_cam_y = (render_p->crouching ? 2.5f : EYE_HEIGHT);
     float cam_y = lerpf(base_cam_y, 4.5f, death_cam_blend);
     float cx = 0.0f, cz = 0.0f;
+    float cam_focus_x = render_p->x;
+    float cam_focus_y = render_p->y;
+    float cam_focus_z = render_p->z;
     BuggyState *cam_buggy = NULL;
     if (render_p->in_vehicle && render_p->vehicle_type == VEH_BUGGY) {
         for (int bi = 0; bi < MAX_BUGGIES; bi++) {
@@ -3820,12 +3823,16 @@ void draw_scene(PlayerState *render_p) {
         }
     } else {
         float follow_yaw = cam_buggy ? cam_buggy->yaw : cam_yaw;
-        float cam_z_off = cam_buggy ? 16.5f : (render_p->in_vehicle ? 10.0f : lerpf(0.0f, 8.5f, death_cam_blend));
+        float cam_z_off = cam_buggy ? BUGGY_CAMERA_BACKUP : (render_p->in_vehicle ? 10.0f : lerpf(0.0f, 8.5f, death_cam_blend));
         float rad = -follow_yaw * 0.01745f;
         cx = sinf(rad) * cam_z_off;
         cz = cosf(rad) * cam_z_off;
         if (cam_buggy) {
-            cam_y = 5.2f;
+            float fwd_x = sinf(rad);
+            float fwd_z = -cosf(rad);
+            cam_focus_x += fwd_x * BUGGY_CAMERA_LOOKAHEAD;
+            cam_focus_z += fwd_z * BUGGY_CAMERA_LOOKAHEAD;
+            cam_y = BUGGY_CAMERA_HEIGHT;
             cam_yaw = follow_yaw;
         }
     }
@@ -3838,17 +3845,20 @@ void draw_scene(PlayerState *render_p) {
         reconcile_y = reconcile_corr_y;
         reconcile_z = reconcile_corr_z;
     }
+    cam_focus_x += reconcile_x;
+    cam_focus_y += reconcile_y;
+    cam_focus_z += reconcile_z;
 
     if (!(render_p->in_vehicle && render_p->vehicle_type == VEH_HELICOPTER)) {
         float draw_cam_pitch = lerpf(cam_pitch, -14.0f, death_cam_blend);
         glRotatef(-draw_cam_pitch, 1, 0, 0); glRotatef(-cam_yaw, 0, 1, 0);
-        glTranslatef(-((render_p->x + reconcile_x) - cx), -((render_p->y + reconcile_y) + cam_y), -((render_p->z + reconcile_z) - cz));
+        glTranslatef(-(cam_focus_x - cx), -(cam_focus_y + cam_y), -(cam_focus_z - cz));
     }
 
     {
-        float sky_cam_x = (render_p->x + reconcile_x) - cx;
-        float sky_cam_y = (render_p->y + reconcile_y) + cam_y;
-        float sky_cam_z = (render_p->z + reconcile_z) - cz;
+        float sky_cam_x = cam_focus_x - cx;
+        float sky_cam_y = cam_focus_y + cam_y;
+        float sky_cam_z = cam_focus_z - cz;
         if (render_p->in_vehicle && render_p->vehicle_type == VEH_HELICOPTER) {
             sky_cam_x = heli_cam_x;
             sky_cam_y = heli_cam_y;

--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -3793,6 +3793,9 @@ void draw_scene(PlayerState *render_p) {
         for (int bi = 0; bi < MAX_BUGGIES; bi++) {
             if (local_state.buggies[bi].active && local_state.buggies[bi].occupant_player_id == render_p->id) {
                 cam_buggy = &local_state.buggies[bi];
+                cam_focus_x = cam_buggy->x;
+                cam_focus_y = cam_buggy->y;
+                cam_focus_z = cam_buggy->z;
                 break;
             }
         }
@@ -3845,9 +3848,11 @@ void draw_scene(PlayerState *render_p) {
         reconcile_y = reconcile_corr_y;
         reconcile_z = reconcile_corr_z;
     }
-    cam_focus_x += reconcile_x;
-    cam_focus_y += reconcile_y;
-    cam_focus_z += reconcile_z;
+    if (!cam_buggy) {
+        cam_focus_x += reconcile_x;
+        cam_focus_y += reconcile_y;
+        cam_focus_z += reconcile_z;
+    }
 
     if (!(render_p->in_vehicle && render_p->vehicle_type == VEH_HELICOPTER)) {
         float draw_cam_pitch = lerpf(cam_pitch, -14.0f, death_cam_blend);

--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -3822,18 +3822,18 @@ void draw_scene(PlayerState *render_p) {
             glTranslatef(-heli_cam_x, -heli_cam_y, -heli_cam_z);
         }
     } else {
-        float follow_yaw = cam_buggy ? cam_buggy->yaw : cam_yaw;
+        float follow_yaw = cam_yaw;
         float cam_z_off = cam_buggy ? BUGGY_CAMERA_BACKUP : (render_p->in_vehicle ? 10.0f : lerpf(0.0f, 8.5f, death_cam_blend));
         float rad = -follow_yaw * 0.01745f;
         cx = sinf(rad) * cam_z_off;
         cz = cosf(rad) * cam_z_off;
         if (cam_buggy) {
-            float fwd_x = sinf(rad);
-            float fwd_z = -cosf(rad);
+            float buggy_rad = -cam_buggy->yaw * 0.01745f;
+            float fwd_x = sinf(buggy_rad);
+            float fwd_z = -cosf(buggy_rad);
             cam_focus_x += fwd_x * BUGGY_CAMERA_LOOKAHEAD;
             cam_focus_z += fwd_z * BUGGY_CAMERA_LOOKAHEAD;
             cam_y = BUGGY_CAMERA_HEIGHT;
-            cam_yaw = follow_yaw;
         }
     }
     
@@ -4729,7 +4729,6 @@ void net_process_snapshot(char *buffer, int len) {
                 occ->in_vehicle = 1;
                 occ->vehicle_type = VEH_BUGGY;
                 occ->x = b->x; occ->y = b->y; occ->z = b->z;
-                occ->yaw = b->yaw;
             }
         }
     }

--- a/packages/common/physics.h
+++ b/packages/common/physics.h
@@ -25,9 +25,6 @@
 #define BUGGY_BASE_DRIVE_FORCE 0.0364f
 #define BUGGY_COAST_FRICTION 0.0048f
 #define BUGGY_BRAKE_FRICTION 0.022f
-#define BUGGY_TURN_RATE_LOW 3.1f
-#define BUGGY_TURN_RATE_HIGH 0.9f
-#define BUGGY_LATERAL_GRIP 0.12f
 #define BUGGY_TRANSMISSION_BAND1_END 0.22f
 #define BUGGY_TRANSMISSION_BAND2_END 0.52f
 #define BUGGY_TRANSMISSION_BAND3_END 0.78f
@@ -36,6 +33,29 @@
 #define BUGGY_TRACK_WIDTH 3.8f
 #define BUGGY_WHEEL_RADIUS 1.05f
 #define BUGGY_CHASSIS_CLEARANCE 0.95f
+
+// Camera-led steering + yaw/slip tuning.
+#define BUGGY_STEER_DEADZONE_DEG 2.0f
+#define BUGGY_STEER_YAW_FOR_FULL_LOCK 68.0f
+#define BUGGY_STEER_RESPONSE_IN 0.16f
+#define BUGGY_STEER_RESPONSE_OUT 0.28f
+#define BUGGY_STEER_SPEED_FADE_START 2.6f
+#define BUGGY_STEER_SPEED_FADE_END 6.2f
+#define BUGGY_YAW_RATE_LOW_SPEED 1.0f
+#define BUGGY_YAW_RATE_HIGH_SPEED 4.35f
+#define BUGGY_YAW_DAMPING 0.095f
+#define BUGGY_STEER_BITE 0.24f
+#define BUGGY_LATERAL_GRIP_LOW 0.20f
+#define BUGGY_LATERAL_GRIP_HIGH 0.08f
+#define BUGGY_LATERAL_DRIFT_FACTOR 0.58f
+#define BUGGY_AIR_STEER_FACTOR 0.16f
+#define BUGGY_AIR_LATERAL_DAMP 0.035f
+#define BUGGY_GROUND_REACQUIRE_TOLERANCE 0.02f
+
+// Third-person buggy chase camera tuning.
+#define BUGGY_CAMERA_BACKUP 19.0f
+#define BUGGY_CAMERA_HEIGHT 5.8f
+#define BUGGY_CAMERA_LOOKAHEAD 2.25f
 
 #define EYE_HEIGHT 2.59f    
 #define PLAYER_WIDTH 0.97f  
@@ -2427,18 +2447,35 @@ static inline void simulate_buggy_state(BuggyState *b, float throttle, float ste
     float abs_norm = fabsf(forward_speed) / BUGGY_TOP_SPEED;
     if (abs_norm > 1.0f) abs_norm = 1.0f;
 
-    float steer_rate = BUGGY_TURN_RATE_LOW + (BUGGY_TURN_RATE_HIGH - BUGGY_TURN_RATE_LOW) * abs_norm;
-    float steer_authority = 0.38f + 0.62f * abs_norm;
     float steer_sign = (forward_speed < -0.03f) ? -1.0f : 1.0f;
-    float steer_response = apply_input ? 0.22f : 0.10f;
-    b->steer += (steer - b->steer) * steer_response * dt_scale;
+    float steer_delta = steer - b->steer;
+    float steer_response = BUGGY_STEER_RESPONSE_IN;
+    if ((steer_delta > 0.0f && b->steer > 0.0f && steer > 0.0f && fabsf(steer) < fabsf(b->steer)) ||
+        (steer_delta < 0.0f && b->steer < 0.0f && steer < 0.0f && fabsf(steer) < fabsf(b->steer)) ||
+        (steer > 0.0f && b->steer < 0.0f) || (steer < 0.0f && b->steer > 0.0f)) {
+        steer_response = BUGGY_STEER_RESPONSE_OUT;
+    }
+    if (!apply_input) steer_response *= 0.65f;
+    b->steer += steer_delta * steer_response * dt_scale;
     if (b->steer > 1.0f) b->steer = 1.0f;
     if (b->steer < -1.0f) b->steer = -1.0f;
-    b->yaw = norm_yaw_deg(b->yaw + b->steer * steer_rate * steer_authority * steer_sign * dt_scale);
 
-    float grip = BUGGY_LATERAL_GRIP * (0.62f + 0.68f * abs_norm) * dt_scale;
-    if (grip > 1.0f) grip = 1.0f;
-    lateral_speed *= (1.0f - grip);
+    float yaw_rate = BUGGY_YAW_RATE_LOW_SPEED + (BUGGY_YAW_RATE_HIGH_SPEED - BUGGY_YAW_RATE_LOW_SPEED) * abs_norm;
+    yaw_rate *= (1.0f - 0.33f * abs_norm * abs_norm);
+    float steer_bite = 1.0f - fminf(0.42f, fabsf(lateral_speed) * BUGGY_YAW_DAMPING);
+    if (steer_bite < 0.58f) steer_bite = 0.58f;
+    float grounded_factor = b->grounded ? 1.0f : BUGGY_AIR_STEER_FACTOR;
+    b->yaw = norm_yaw_deg(b->yaw + b->steer * yaw_rate * steer_sign * steer_bite * grounded_factor * dt_scale);
+
+    float desired_lateral = b->steer * forward_speed * BUGGY_LATERAL_DRIFT_FACTOR;
+    float grip = BUGGY_LATERAL_GRIP_LOW + (BUGGY_LATERAL_GRIP_HIGH - BUGGY_LATERAL_GRIP_LOW) * abs_norm;
+    if (!b->grounded) grip = BUGGY_AIR_LATERAL_DAMP;
+    lateral_speed += (desired_lateral - lateral_speed) * BUGGY_STEER_BITE * grounded_factor * dt_scale;
+    float lateral_rel = lateral_speed - desired_lateral;
+    float lateral_damp = grip * dt_scale;
+    if (lateral_damp > 1.0f) lateral_damp = 1.0f;
+    lateral_rel *= (1.0f - lateral_damp);
+    lateral_speed = desired_lateral + lateral_rel;
 
     float r2 = -b->yaw * (3.14159265358979323846f / 180.0f);
     float new_fwd_x = sinf(r2);
@@ -2468,9 +2505,10 @@ static inline void simulate_buggy_state(BuggyState *b, float throttle, float ste
     float support_max = heights[0];
     for (int i = 1; i < 4; i++) if (heights[i] > support_max) support_max = heights[i];
     float support_y = support_max + BUGGY_WHEEL_RADIUS + BUGGY_CHASSIS_CLEARANCE;
-    if (b->y <= support_y + 0.05f) {
+    int allow_reacquire = (b->vy <= 0.0f) || (b->y <= support_y);
+    if (allow_reacquire && b->y <= support_y + BUGGY_GROUND_REACQUIRE_TOLERANCE) {
         b->y = support_y;
-        b->vy = 0.0f;
+        if (b->vy < 0.0f) b->vy = 0.0f;
         b->grounded = 1;
         b->pitch += (target_pitch - b->pitch) * 0.35f;
         b->roll += (target_roll - b->roll) * 0.35f;

--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -255,6 +255,7 @@ typedef struct {
     float yaw;
     float pitch;
     float roll;
+    float steer_target;
     float steer;
     float throttle;
     int health;

--- a/packages/simulation/local_game.h
+++ b/packages/simulation/local_game.h
@@ -287,7 +287,7 @@ static inline void buggy_tick_all(void) {
         BuggyState *b = &local_state.buggies[i];
         if (!b->active) continue;
         float throttle = 0.0f;
-        float steer_intent = 0.0f;
+        float desired_steer = 0.0f;
         if (b->occupant_player_id >= 0 && b->occupant_player_id < MAX_CLIENTS) {
             PlayerState *occ = &local_state.players[b->occupant_player_id];
             b->scene_id = occ->scene_id;
@@ -295,18 +295,32 @@ static inline void buggy_tick_all(void) {
             float yaw_err = norm_yaw_deg(occ->yaw - b->yaw);
             if (yaw_err > 180.0f) yaw_err -= 360.0f;
             if (yaw_err < -180.0f) yaw_err += 360.0f;
-            steer_intent = yaw_err / 75.0f;
-            if (steer_intent > 1.0f) steer_intent = 1.0f;
-            if (steer_intent < -1.0f) steer_intent = -1.0f;
+            float abs_err = fabsf(yaw_err);
+            if (abs_err > BUGGY_STEER_DEADZONE_DEG) {
+                float signed_mag = (yaw_err < 0.0f) ? -1.0f : 1.0f;
+                float mapped = (abs_err - BUGGY_STEER_DEADZONE_DEG) /
+                               (BUGGY_STEER_YAW_FOR_FULL_LOCK - BUGGY_STEER_DEADZONE_DEG);
+                if (mapped < 0.0f) mapped = 0.0f;
+                if (mapped > 1.0f) mapped = 1.0f;
+                mapped = mapped * mapped * (3.0f - 2.0f * mapped); // smoothstep mids
+                float speed = sqrtf(b->vx * b->vx + b->vz * b->vz);
+                float fade_t = (speed - BUGGY_STEER_SPEED_FADE_START) /
+                               (BUGGY_STEER_SPEED_FADE_END - BUGGY_STEER_SPEED_FADE_START);
+                if (fade_t < 0.0f) fade_t = 0.0f;
+                if (fade_t > 1.0f) fade_t = 1.0f;
+                float speed_scale = 1.0f - 0.25f * fade_t;
+                desired_steer = signed_mag * mapped * speed_scale;
+            }
+            b->steer_target = desired_steer;
         } else {
             b->occupant_player_id = -1;
+            b->steer_target = 0.0f;
         }
         phys_set_scene(b->scene_id);
-        simulate_buggy_state(b, throttle, steer_intent, SHANKPIT_NET_FIXED_DT, b->occupant_player_id >= 0);
+        simulate_buggy_state(b, throttle, b->steer_target, SHANKPIT_NET_FIXED_DT, b->occupant_player_id >= 0);
         if (b->occupant_player_id >= 0 && b->occupant_player_id < MAX_CLIENTS) {
             PlayerState *occ = &local_state.players[b->occupant_player_id];
             occ->x = b->x; occ->y = b->y; occ->z = b->z;
-            occ->yaw = b->yaw;
             occ->vx = occ->vy = occ->vz = 0.0f;
             occ->on_ground = b->grounded;
         }


### PR DESCRIPTION
### Motivation
- Diagnosis: steering felt weak after the accel/transmission work because occupant camera yaw was mapped through a thin linear path (`yaw_err / 75.0f`) and the occupant yaw was being snapped to the buggy each tick, collapsing camera-leading behavior; the chassis therefore never had a proper two-stage (camera → wheel → chassis) loop to follow.
- Goal: make camera immediately drive a desired heading while the steering wheel and chassis respond naturally, preserve the non-linear acceleration/transmission model, and avoid sticky ground re-acquire that prevents crest launches.

### Description
- Added persistent steering target state to the vehicle model by introducing `steer_target` on `BuggyState` (in `packages/common/protocol.h`) and grouped new tuning constants in `packages/common/physics.h` (e.g. `BUGGY_STEER_YAW_FOR_FULL_LOCK`, `BUGGY_STEER_RESPONSE_IN/OUT`, `BUGGY_LATERAL_GRIP_LOW/HIGH`, `BUGGY_AIR_STEER_FACTOR`, camera constants). 
- Reworked input → desired-heading path in `buggy_tick_all()` (`packages/simulation/local_game.h`) so camera/player yaw produces a `steer_target` using a small deadzone, a smoothstep saturation curve to full lock, and a speed fade, instead of the previous `yaw_err / 75.0f` immediate mapping.
- Implemented two-stage steering and traction in `simulate_buggy_state()` (`packages/common/physics.h`): wheel state now evolves toward the `steer_target` with separate wind-in / unwind response rates, chassis yaw authority is speed-shaped, a slip-aware `steer_bite` is applied, lateral velocity is driven toward an intentional `desired_lateral` (controllable drift), and airborne steering/lateral correction are reduced via air factors.
- Relaxed ground reacquire so the buggy can launch cleanly off crests: reacquire only when downward or sufficiently close and use a tighter `BUGGY_GROUND_REACQUIRE_TOLERANCE` rather than always snapping immediately.
- Improved third-person buggy camera framing in `apps/lobby/src/main.c` to use a focus point with `BUGGY_CAMERA_LOOKAHEAD`, `BUGGY_CAMERA_BACKUP`, and `BUGGY_CAMERA_HEIGHT` so the camera better reads vehicle attitude while remaining purely a heading input source.
- Preserved existing non-linear drive/transmission code paths (drive force bands / `buggy_drive_force_for_speed`) and persistent entity behavior (player exit leaves vehicle velocity intact).

### Testing
- Built server: ran `make clean && make server` — server build succeeded (no runtime render deps required). ✅
- Built client/lobby: ran `make lobby` — client build failed due to missing SDL2/OpenGL headers in the container environment, which is an environment issue unrelated to the change (same failure before/after). ⚠️
- Verified code compiles for server and no changes were made to the drivetrain force curve or buggy persistence logic; runtime QA checklist provided for manual validation (low-speed turn-in, medium sweeper, camera flick correction, crest launch, exit-at-speed persistence, no-input coast).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e435f50d0083279d52d77c03300f96)