### PR TITLE
Add small yellow 'MADE IN AMERICA' tagline to lobby title

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -5068,7 +5068,7 @@ int main(int argc, char* argv[]) {
              glColor3f(0, 1, 1); // CYAN TEXT
              draw_string("SHANKPIT", LOBBY_LAYOUT.title_x, LOBBY_LAYOUT.title_y, 12);
              glColor3f(1.0f, 1.0f, 0.0f);
-             draw_string("MADE IN AMERICA", LOBBY_LAYOUT.title_x + 10, LOBBY_LAYOUT.title_y - 28, 3);
+             draw_string("MADE IN AMERICA", LOBBY_LAYOUT.title_x + 10, LOBBY_LAYOUT.title_y - 52, 3);
              glColor3f(0, 1, 1);
              int menu_count = lobby_menu_count();
              draw_lobby_buttons(menu_count, &LOBBY_LAYOUT);

--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -5067,6 +5067,9 @@ int main(int argc, char* argv[]) {
              setup_lobby_2d();
              glColor3f(0, 1, 1); // CYAN TEXT
              draw_string("SHANKPIT", LOBBY_LAYOUT.title_x, LOBBY_LAYOUT.title_y, 12);
+             glColor3f(1.0f, 1.0f, 0.0f);
+             draw_string("MADE IN AMERICA", LOBBY_LAYOUT.title_x + 10, LOBBY_LAYOUT.title_y - 28, 3);
+             glColor3f(0, 1, 1);
              int menu_count = lobby_menu_count();
              draw_lobby_buttons(menu_count, &LOBBY_LAYOUT);
              if (skin_menu_open) {


### PR DESCRIPTION
### Motivation
- Add a small, secondary yellow tagline near the lobby title so the main menu shows the text `MADE IN AMERICA` visually associated with the `SHANKPIT` title without refactoring the menu system.

### Description
- Inserted a yellow draw call in `apps/lobby/src/main.c` inside the `STATE_LOBBY` render block immediately after `draw_string("SHANKPIT", LOBBY_LAYOUT.title_x, LOBBY_LAYOUT.title_y, 12);` using `glColor3f(1.0f,1.0f,0.0f); draw_string("MADE IN AMERICA", LOBBY_LAYOUT.title_x + 10, LOBBY_LAYOUT.title_y - 28, 3);` and restored the cyan color afterward to avoid color bleed.

### Testing
- No automated tests were run; repository checks `git diff -- apps/lobby/src/main.c` and `git show --stat --oneline HEAD` were executed and show the expected one-file change (the UI change is visual only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e540e8775c83279470c8af300a4e1a)