### PR TITLE
Add STORY mode with cave scene, 5s intro cutscene, and cyborg-bear encounters

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -672,6 +672,7 @@ void draw_string(const char* str, float x, float y, float size) {
 typedef enum {
     LOBBY_JOIN = 0,
     LOBBY_TDMO,
+    LOBBY_STORY,
     LOBBY_SOLO,
     LOBBY_BATTLE,
     LOBBY_TDMB,
@@ -684,6 +685,7 @@ char lobby_labels_mutable[LOBBY_COUNT][64];
 static const char *LOBBY_LABELS[LOBBY_COUNT] = {
     "JOIN",
     "TDMO",
+    "STORY",
     "SOLO",
     "TRAIN",
     "TDMB",
@@ -796,6 +798,8 @@ static void lobby_apply_scene_id(const char *scene_id) {
         scene_load(SCENE_OIL_TANKER);
     } else if (strcmp(scene_id, "POO_POO_ISLAND") == 0) {
         scene_load(SCENE_POO_POO_ISLAND);
+    } else if (strcmp(scene_id, "STORY_CAVE") == 0) {
+        scene_load(SCENE_STORY_CAVE);
     }
 }
 
@@ -822,6 +826,9 @@ static void lobby_apply_ui_state() {
     } else if (strcmp(ui_state.active_mode_id, "mode.battle") == 0) {
         app_state = STATE_GAME_LOCAL;
         local_init_match(12, MODE_DEATHMATCH);
+    } else if (strcmp(ui_state.active_mode_id, "mode.story") == 0) {
+        app_state = STATE_GAME_LOCAL;
+        local_init_match(1, MODE_STORY);
     } else if (strcmp(ui_state.active_mode_id, "mode.tdmb") == 0) {
         app_state = STATE_GAME_LOCAL;
         local_init_match(12, MODE_TDMB);
@@ -886,6 +893,9 @@ static void lobby_start_action(int action) {
     } else {
         app_state = STATE_GAME_LOCAL;
         switch (action) {
+            case LOBBY_STORY:
+                local_init_match(1, MODE_STORY);
+                break;
             case LOBBY_SOLO:
                 local_init_match(1, MODE_DEATHMATCH);
                 break;
@@ -3033,6 +3043,8 @@ void draw_player_3rd(PlayerState *p) {
         int forced_skin = -1;
         if (local_state.game_mode == MODE_TDMB || local_state.game_mode == MODE_TDMO || local_state.game_mode == MODE_CTFB) {
             forced_skin = (p->team_id == 1) ? SKIN_NINJA : SKIN_PIRATE;
+        } else if (local_state.game_mode == MODE_STORY && p->is_bot) {
+            forced_skin = SKIN_CYBORG;
         }
         int draw_skin = (forced_skin >= 0) ? forced_skin : clamp_skin_id(g_selected_skin);
         switch (draw_skin) {
@@ -3292,6 +3304,7 @@ static const char *scene_name_ui(int scene_id) {
         case SCENE_DUST_COMPOUND: return "DUST_COMPOUND";
         case SCENE_OIL_TANKER: return "OIL_TANKER";
         case SCENE_POO_POO_ISLAND: return "POO_POO_ISLAND";
+        case SCENE_STORY_CAVE: return "STORY_CAVE";
         default: return "UNKNOWN";
     }
 }
@@ -3791,6 +3804,26 @@ static void draw_tdmb_match_over_overlay(void) {
     glMatrixMode(GL_MODELVIEW); glPopMatrix();
 }
 
+static void draw_story_overlay(void) {
+    if (local_state.game_mode != MODE_STORY) return;
+    if (local_state.story_phase != STORY_PHASE_COMPLETE) return;
+    glDisable(GL_DEPTH_TEST);
+    glMatrixMode(GL_PROJECTION); glPushMatrix(); glLoadIdentity(); gluOrtho2D(0, 1280, 0, 720);
+    glMatrixMode(GL_MODELVIEW); glPushMatrix(); glLoadIdentity();
+    glColor4f(0.0f, 0.0f, 0.0f, 0.50f);
+    glBegin(GL_QUADS);
+    glVertex2f(280, 250); glVertex2f(1000, 250); glVertex2f(1000, 470); glVertex2f(280, 470);
+    glEnd();
+    glColor3f(0.92f, 1.0f, 0.45f);
+    draw_string("CAVE CLEARED", 485, 390, 10);
+    glColor3f(0.95f, 0.95f, 0.95f);
+    draw_string("STORY COMPLETE", 478, 340, 7);
+    draw_string("ESC: BACK TO MENU", 474, 300, 6);
+    glEnable(GL_DEPTH_TEST);
+    glMatrixMode(GL_PROJECTION); glPopMatrix();
+    glMatrixMode(GL_MODELVIEW); glPopMatrix();
+}
+
 void draw_scene(PlayerState *render_p) {
     if (vs0_art_direction_enabled) glClearColor(0.18f, 0.25f, 0.36f, 1.0f);
     else glClearColor(0.02f, 0.02f, 0.05f, 1.0f);
@@ -3816,6 +3849,7 @@ void draw_scene(PlayerState *render_p) {
         }
     }
     static float heli_cam_x = 0.0f, heli_cam_y = 0.0f, heli_cam_z = 0.0f;
+    int story_cutscene = (local_state.game_mode == MODE_STORY && local_state.story_phase == STORY_PHASE_CUTSCENE);
     if (render_p->in_vehicle && render_p->vehicle_type == VEH_HELICOPTER) {
         HelicopterState *hh = NULL;
         for (int i = 0; i < MAX_HELICOPTERS; i++) {
@@ -3860,7 +3894,22 @@ void draw_scene(PlayerState *render_p) {
         reconcile_z = reconcile_corr_z;
     }
 
-    if (!(render_p->in_vehicle && render_p->vehicle_type == VEH_HELICOPTER)) {
+    if (story_cutscene) {
+        float rr = -render_p->yaw * 0.01745f;
+        float fx = sinf(rr);
+        float fz = -cosf(rr);
+        float cam_x = render_p->x + fx * 18.0f;
+        float cam_y_cut = render_p->y + 5.0f;
+        float cam_z = render_p->z + fz * 18.0f;
+        float look_dx = render_p->x - cam_x;
+        float look_dy = (render_p->y + 3.0f) - cam_y_cut;
+        float look_dz = render_p->z - cam_z;
+        float look_yaw = atan2f(look_dx, -look_dz) * 57.29578f;
+        float look_pitch = atan2f(look_dy, sqrtf(look_dx * look_dx + look_dz * look_dz)) * 57.29578f;
+        glRotatef(-look_pitch, 1, 0, 0);
+        glRotatef(-look_yaw, 0, 1, 0);
+        glTranslatef(-cam_x, -cam_y_cut, -cam_z);
+    } else if (!(render_p->in_vehicle && render_p->vehicle_type == VEH_HELICOPTER)) {
         float draw_cam_pitch = lerpf(cam_pitch, -14.0f, death_cam_blend);
         glRotatef(-draw_cam_pitch, 1, 0, 0); glRotatef(-cam_yaw, 0, 1, 0);
         glTranslatef(-((render_p->x + reconcile_x) - cx), -((render_p->y + reconcile_y) + cam_y), -((render_p->z + reconcile_z) - cz));
@@ -3870,6 +3919,14 @@ void draw_scene(PlayerState *render_p) {
         float sky_cam_x = (render_p->x + reconcile_x) - cx;
         float sky_cam_y = (render_p->y + reconcile_y) + cam_y;
         float sky_cam_z = (render_p->z + reconcile_z) - cz;
+        if (story_cutscene) {
+            float rr = -render_p->yaw * 0.01745f;
+            float fx = sinf(rr);
+            float fz = -cosf(rr);
+            sky_cam_x = render_p->x + fx * 18.0f;
+            sky_cam_y = render_p->y + 5.0f;
+            sky_cam_z = render_p->z + fz * 18.0f;
+        }
         if (render_p->in_vehicle && render_p->vehicle_type == VEH_HELICOPTER) {
             sky_cam_x = heli_cam_x;
             sky_cam_y = heli_cam_y;
@@ -3904,16 +3961,21 @@ void draw_scene(PlayerState *render_p) {
         draw_helicopter_model(h);
     }
     draw_projectiles();
-    if (render_p->in_vehicle && render_p->vehicle_type != VEH_BUGGY) draw_player_3rd(render_p);
+    if (story_cutscene || (render_p->in_vehicle && render_p->vehicle_type != VEH_BUGGY)) draw_player_3rd(render_p);
     for(int i=0; i<MAX_CLIENTS; i++) {
         PlayerState *p = &local_state.players[i];
         if (!p->active || p->scene_id != render_p->scene_id) continue;
         if (p == render_p) continue;
         draw_player_3rd(p);
     }
-    draw_weapon_p(render_p); draw_hud(render_p); draw_garage_overlay(render_p); draw_tab_scoreboard(render_p);
+    if (!story_cutscene) {
+        draw_weapon_p(render_p);
+        draw_hud(render_p);
+    }
+    draw_garage_overlay(render_p); draw_tab_scoreboard(render_p);
     draw_travel_overlay();
     draw_tdmb_match_over_overlay();
+    draw_story_overlay();
 }
 
 typedef struct {
@@ -5064,6 +5126,7 @@ int main(int argc, char* argv[]) {
                     }
                 }
                 if(e.type == SDL_MOUSEMOTION) {
+                    if (local_state.game_mode == MODE_STORY && local_state.story_phase == STORY_PHASE_CUTSCENE) continue;
                     if (app_state == STATE_GAME_NET && net_spawn_protect_cmds > 0) continue;
                     float sens = (current_fov < 50.0f) ? 0.05f : 0.15f; 
                     cam_yaw -= e.motion.xrel * sens;

--- a/packages/common/physics.h
+++ b/packages/common/physics.h
@@ -151,6 +151,24 @@ static const Box map_geo_garage[] = {
     {10.00, 5.00, -20.00, 12.00, 4.00, 12.00}
 };
 
+static const Box map_geo_story_cave[] = {
+    {0.0f, -8.0f, 0.0f, 140.0f, 8.0f, 1520.0f},
+    {0.0f, 18.0f, 0.0f, 138.0f, 8.0f, 1520.0f},
+    {-70.0f, 5.0f, 0.0f, 8.0f, 30.0f, 1520.0f},
+    {70.0f, 5.0f, 0.0f, 8.0f, 30.0f, 1520.0f},
+    {-12.0f, 2.0f, -480.0f, 42.0f, 14.0f, 80.0f},
+    {24.0f, 2.0f, -160.0f, 52.0f, 16.0f, 90.0f},
+    {-20.0f, 2.0f, 170.0f, 48.0f, 15.0f, 92.0f},
+    {12.0f, 2.0f, 500.0f, 60.0f, 17.0f, 100.0f},
+    {-18.0f, 2.0f, 780.0f, 58.0f, 15.0f, 94.0f},
+    {0.0f, 2.0f, 1020.0f, 62.0f, 18.0f, 110.0f},
+    {34.0f, 9.0f, -620.0f, 12.0f, 18.0f, 140.0f},
+    {-28.0f, 9.0f, -280.0f, 10.0f, 16.0f, 120.0f},
+    {30.0f, 9.0f, 80.0f, 12.0f, 16.0f, 130.0f},
+    {-34.0f, 9.0f, 420.0f, 10.0f, 17.0f, 128.0f},
+    {26.0f, 9.0f, 700.0f, 12.0f, 16.0f, 116.0f}
+};
+
 
 #define CITY_MAX_BOXES 2048
 static Box map_geo_voxworld[CITY_MAX_BOXES];
@@ -236,6 +254,9 @@ static int map_count = 0;
 #define POO_POO_ISLAND_ORIGIN_Z (-(POO_POO_ISLAND_TERRAIN_H * POO_POO_ISLAND_CELL * 0.5f))
 #define POO_POO_ISLAND_BOUNDS_X 1240.0f
 #define POO_POO_ISLAND_BOUNDS_Z 1240.0f
+#define STORY_CAVE_KILL_Y -80.0f
+#define STORY_CAVE_BOUNDS_X 110.0f
+#define STORY_CAVE_BOUNDS_Z 820.0f
 
 #define GARAGE_PORTAL_X 0.0f
 #define GARAGE_PORTAL_Y 6.0f
@@ -1121,6 +1142,10 @@ static inline void phys_set_scene(int scene_id) {
         map_geo = map_geo_stadium;
         map_count = (int)(sizeof(map_geo_stadium) / sizeof(Box));
         g_scene_terrain.active = (g_scene_terrain.heights != NULL);
+    } else if (scene_id == SCENE_STORY_CAVE) {
+        map_geo = map_geo_story_cave;
+        map_count = (int)(sizeof(map_geo_story_cave) / sizeof(Box));
+        g_scene_terrain.active = 0;
     } else {
         map_geo = map_geo_stadium;
         map_count = (int)(sizeof(map_geo_stadium) / sizeof(Box));
@@ -1525,6 +1550,12 @@ static inline void scene_spawn_point(int scene_id, int slot, float *out_x, float
         *out_y = stadium_height_at(*out_x, *out_z) + 6.0f;
         return;
     }
+    if (scene_id == SCENE_STORY_CAVE) {
+        *out_x = 0.0f;
+        *out_y = 4.0f;
+        *out_z = -720.0f;
+        return;
+    }
     if (slot % 2 == 0) {
         *out_x = 0.0f; *out_z = 0.0f; *out_y = 80.0f;
     } else {
@@ -1538,6 +1569,7 @@ static inline void scene_spawn_point(int scene_id, int slot, float *out_x, float
 static inline void scene_spawn_for_player(PlayerState *p, float *out_x, float *out_y, float *out_z) {
     if (p->scene_id != SCENE_VOXWORLD && p->scene_id != SCENE_DUST_COMPOUND &&
         p->scene_id != SCENE_OIL_TANKER && p->scene_id != SCENE_STADIUM &&
+        p->scene_id != SCENE_STORY_CAVE &&
         p->scene_id != SCENE_POO_POO_ISLAND) {
         scene_spawn_point(p->scene_id, p->id, out_x, out_y, out_z);
         return;
@@ -1681,6 +1713,14 @@ static inline void scene_safety_check(PlayerState *p) {
         if (p->y < POO_POO_ISLAND_KILL_Y ||
             p->x < -POO_POO_ISLAND_BOUNDS_X || p->x > POO_POO_ISLAND_BOUNDS_X ||
             p->z < -POO_POO_ISLAND_BOUNDS_Z || p->z > POO_POO_ISLAND_BOUNDS_Z) {
+            scene_force_spawn(p);
+        }
+        return;
+    }
+    if (p->scene_id == SCENE_STORY_CAVE) {
+        if (p->y < STORY_CAVE_KILL_Y ||
+            p->x < -STORY_CAVE_BOUNDS_X || p->x > STORY_CAVE_BOUNDS_X ||
+            p->z < -STORY_CAVE_BOUNDS_Z || p->z > STORY_CAVE_BOUNDS_Z) {
             scene_force_spawn(p);
         }
     }

--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -15,6 +15,7 @@
 #define SCENE_CITY 4
 #define SCENE_OIL_TANKER 5
 #define SCENE_POO_POO_ISLAND 6
+#define SCENE_STORY_CAVE 7
 
 #define PACKET_CONNECT 0
 #define PACKET_USERCMD 1
@@ -288,7 +289,14 @@ typedef struct {
     unsigned int event_counter;
 } CtfMatchState;
 
-typedef enum { MODE_DEATHMATCH=0, MODE_TDM=1, MODE_SURVIVAL=2, MODE_CTF=3, MODE_ODDBALL=4, MODE_LOCAL=98, MODE_NET=99, MODE_EVOLUTION=100, MODE_TDMB=101, MODE_TDMO=102, MODE_CTFB=103, MODE_CTFO=104 } GameMode;
+typedef enum { MODE_DEATHMATCH=0, MODE_TDM=1, MODE_SURVIVAL=2, MODE_CTF=3, MODE_ODDBALL=4, MODE_LOCAL=98, MODE_NET=99, MODE_EVOLUTION=100, MODE_TDMB=101, MODE_TDMO=102, MODE_CTFB=103, MODE_CTFO=104, MODE_STORY=105 } GameMode;
+
+typedef enum {
+    STORY_PHASE_CUTSCENE = 0,
+    STORY_PHASE_PLAYING = 1,
+    STORY_PHASE_COMPLETE = 2,
+    STORY_PHASE_FAILED = 3
+} StoryPhase;
 
 typedef struct {
     PlayerState players[MAX_CLIENTS];
@@ -305,6 +313,14 @@ typedef struct {
     int score_limit;
     int match_over;
     int winning_team;
+    int story_phase;
+    unsigned int story_cutscene_start_ms;
+    float story_intro_yaw;
+    float story_intro_pitch;
+    float story_end_x;
+    float story_end_y;
+    float story_end_z;
+    float story_end_radius;
     CtfMatchState ctf;
     struct sockaddr_in clients[MAX_CLIENTS];
     ClientMeta client_meta[MAX_CLIENTS];

--- a/packages/simulation/local_game.h
+++ b/packages/simulation/local_game.h
@@ -25,6 +25,8 @@ static int tdmb_last_kills[MAX_CLIENTS];
 #define CTFB_CARRY_MELEE_DAMAGE 80
 #define CTFB_CARRY_MELEE_COOLDOWN_MS 450
 #define CTFB_RESPAWN_DEBUG_LOG 0
+#define STORY_CUTSCENE_MS 5000
+#define STORY_BEAR_COUNT 6
 
 static int mode_uses_team_scores(int mode) {
     return mode == MODE_TDM || mode == MODE_TDMB || mode == MODE_TDMO || mode == MODE_CTFB;
@@ -60,12 +62,69 @@ static const char *scene_name_debug(int scene_id) {
         case SCENE_STADIUM: return "STADIUM";
         case SCENE_VOXWORLD: return "VOXWORLD";
         case SCENE_POO_POO_ISLAND: return "POO_POO_ISLAND";
+        case SCENE_STORY_CAVE: return "STORY_CAVE";
         default: return "UNKNOWN";
     }
 }
 
 static int team_id_is_valid(int team_id) {
     return team_id == TDMB_BLUE_TEAM || team_id == TDMB_RED_TEAM;
+}
+
+typedef struct {
+    float x, y, z;
+} StorySpawn;
+
+static const StorySpawn story_bear_spawns[STORY_BEAR_COUNT] = {
+    {8.0f, 4.0f, -540.0f},   /* Early isolated threat. */
+    {-18.0f, 4.0f, -260.0f},
+    {24.0f, 4.0f, -180.0f},  /* Mid double encounter. */
+    {-26.0f, 4.0f, 120.0f},  /* Around-bend surprise. */
+    {14.0f, 4.0f, 490.0f},
+    {-16.0f, 4.0f, 560.0f}   /* Stronger final stretch pair. */
+};
+
+static void story_bear_think(PlayerState *bear, PlayerState *hero, unsigned int now_ms) {
+    if (!bear || !hero || !bear->active || bear->state == STATE_DEAD) return;
+    float dx = hero->x - bear->x;
+    float dz = hero->z - bear->z;
+    float dist_sq = dx * dx + dz * dz;
+    float dist = sqrtf(dist_sq);
+
+    int phase = bear->ctf_bot_intent;
+    if (phase <= 0 && dist < 120.0f) phase = 1; /* alerted */
+    if (phase > 0) phase = (dist > 18.0f) ? 2 : 3; /* chasing vs attacking */
+    bear->ctf_bot_intent = phase;
+
+    bear->in_fwd = 0.0f;
+    bear->in_strafe = 0.0f;
+    bear->in_jump = 0;
+    bear->in_reload = 0;
+    bear->in_ability = 0;
+    bear->crouching = 0;
+    bear->in_use = 0;
+    bear->current_weapon = WPN_KNIFE;
+
+    if (phase > 0) {
+        float target_yaw = atan2f(dx, -dz) * 57.29578f;
+        bear->yaw = target_yaw;
+        if (phase == 2) {
+            MoveIntent move_intent = {
+                .forward = 1.0f,
+                .strafe = 0.0f,
+                .control_yaw_deg = bear->yaw,
+                .wants_jump = 0,
+                .wants_sprint = 0
+            };
+            MoveWish move_wish = shankpit_move_wish_from_intent(move_intent);
+            accelerate(bear, move_wish.dir_x, move_wish.dir_z, MAX_SPEED * 0.82f, ACCEL);
+        }
+    }
+
+    bear->in_shoot = (phase == 3 && dist < 24.0f) ? 1 : 0;
+    if (phase == 2 && dist < 48.0f && (now_ms % 91u) == 0u && bear->on_ground) {
+        bear->in_jump = 1;
+    }
 }
 
 typedef enum {
@@ -779,6 +838,21 @@ static void update_projectiles(unsigned int now_ms) {
 
 void local_update(float fwd, float str, float yaw, float pitch, int shoot, int weapon_req, int jump, int crouch, int reload, int ability, void *server_context, unsigned int cmd_time) {
     PlayerState *p0 = &local_state.players[0];
+    if (local_state.game_mode == MODE_STORY) {
+        if (local_state.story_cutscene_start_ms == 0) local_state.story_cutscene_start_ms = cmd_time;
+        if (local_state.story_phase == STORY_PHASE_CUTSCENE) {
+            unsigned int elapsed = cmd_time - local_state.story_cutscene_start_ms;
+            if (elapsed < STORY_CUTSCENE_MS) {
+                fwd = 0.0f; str = 0.0f; shoot = 0; jump = 0; crouch = 0; reload = 0; ability = 0;
+                yaw = local_state.story_intro_yaw;
+                pitch = local_state.story_intro_pitch;
+            } else {
+                local_state.story_phase = STORY_PHASE_PLAYING;
+            }
+        } else if (local_state.story_phase == STORY_PHASE_COMPLETE || local_state.story_phase == STORY_PHASE_FAILED) {
+            fwd = 0.0f; str = 0.0f; shoot = 0; jump = 0; crouch = 0; reload = 0; ability = 0;
+        }
+    }
     if (local_state.match_over && (local_state.game_mode == MODE_TDMB || local_state.game_mode == MODE_CTFB)) {
         fwd = 0.0f; str = 0.0f; shoot = 0; jump = 0; crouch = 0; reload = 0; ability = 0;
     }
@@ -858,6 +932,19 @@ void local_update(float fwd, float str, float yaw, float pitch, int shoot, int w
         PlayerState *p = &local_state.players[i];
         if (!p->active) continue;
         if (p->state == STATE_DEAD) {
+            if (local_state.game_mode == MODE_STORY && i > 0) {
+                p->in_shoot = 0;
+                p->in_reload = 0;
+                p->in_use = 0;
+                p->in_jump = 0;
+                p->in_ability = 0;
+                p->is_shooting = 0;
+                p->attack_cooldown = 0;
+                p->reload_timer = 0;
+                p->respawn_time = 0;
+                p->use_was_down = p->in_use;
+                continue;
+            }
             if (p->in_vehicle && p->vehicle_type == VEH_BUGGY) {
                 for (int bi = 0; bi < MAX_BUGGIES; bi++) {
                     if (local_state.buggies[bi].active && local_state.buggies[bi].occupant_player_id == i) {
@@ -891,6 +978,9 @@ void local_update(float fwd, float str, float yaw, float pitch, int shoot, int w
             continue;
         }
         if (i > 0 && p->active && p->state != STATE_DEAD) {
+            if (local_state.game_mode == MODE_STORY) {
+                story_bear_think(p, p0, cmd_time);
+            } else {
             float b_fwd=0, b_yaw=p->yaw;
             int b_btns=0;
             bot_think(i, local_state.players, &b_fwd, &b_yaw, &b_btns);
@@ -908,6 +998,7 @@ void local_update(float fwd, float str, float yaw, float pitch, int shoot, int w
             p->in_use = ((b_btns & BTN_USE) != 0);
             p->in_ability = 0;
             if ((b_btns & BTN_JUMP) && p->on_ground) { p->y += 0.1f; p->vy += JUMP_FORCE; }
+            }
         }
         if (local_state.game_mode == MODE_CTFB) {
             ctf_handle_use_interactions(p, cmd_time);
@@ -942,6 +1033,23 @@ void local_update(float fwd, float str, float yaw, float pitch, int shoot, int w
             tdmb_last_kills[i] = pp->kills;
         }
     }
+    if (local_state.game_mode == MODE_STORY) {
+        if (p0->state == STATE_DEAD) {
+            local_state.story_phase = STORY_PHASE_FAILED;
+            local_init_match(1, MODE_STORY);
+            return;
+        }
+        if (local_state.story_phase == STORY_PHASE_PLAYING) {
+            float dx = p0->x - local_state.story_end_x;
+            float dy = p0->y - local_state.story_end_y;
+            float dz = p0->z - local_state.story_end_z;
+            float rr = local_state.story_end_radius * local_state.story_end_radius;
+            if (dx*dx + dy*dy + dz*dz <= rr) {
+                local_state.story_phase = STORY_PHASE_COMPLETE;
+                local_state.match_over = 1;
+            }
+        }
+    }
 }
 
 void local_init_match(int num_players, int mode) {
@@ -953,6 +1061,14 @@ void local_init_match(int num_players, int mode) {
     local_state.transition_timer = 0;
     local_state.winning_team = -1;
     local_state.score_limit = (mode == MODE_TDMB || mode == MODE_TDMO) ? TDMB_SCORE_LIMIT : (mode == MODE_CTFB ? CTFB_SCORE_LIMIT : 0);
+    local_state.story_phase = STORY_PHASE_PLAYING;
+    local_state.story_cutscene_start_ms = 0;
+    local_state.story_intro_yaw = 180.0f;
+    local_state.story_intro_pitch = 0.0f;
+    local_state.story_end_x = 0.0f;
+    local_state.story_end_y = 4.0f;
+    local_state.story_end_z = 730.0f;
+    local_state.story_end_radius = 28.0f;
 
     if (mode == MODE_TDMB) {
         num_players = 1 + TDMB_BLUE_BOTS + TDMB_RED_BOTS;
@@ -961,6 +1077,10 @@ void local_init_match(int num_players, int mode) {
     } else if (mode == MODE_CTFB) {
         num_players = 1 + TDMB_BLUE_BOTS + TDMB_RED_BOTS;
         local_state.scene_id = SCENE_OIL_TANKER;
+    } else if (mode == MODE_STORY) {
+        num_players = 1 + STORY_BEAR_COUNT;
+        local_state.scene_id = SCENE_STORY_CAVE;
+        local_state.story_phase = STORY_PHASE_CUTSCENE;
     } else {
         local_state.scene_id = SCENE_GARAGE_OSAKA;
     }
@@ -976,11 +1096,14 @@ void local_init_match(int num_players, int mode) {
     local_state.players[0].scene_id = local_state.scene_id;
     local_state.players[0].carried_flag_team_id = -1;
     phys_respawn(&local_state.players[0], 0);
+    local_state.story_intro_yaw = local_state.players[0].yaw;
 
     for(int i=1; i<num_players; i++) {
         local_state.players[i].active = 1;
         local_state.players[i].is_bot = 1;
-        if (mode == MODE_TDMB || mode == MODE_CTFB) {
+        if (mode == MODE_STORY) {
+            local_state.players[i].team_id = 1;
+        } else if (mode == MODE_TDMB || mode == MODE_CTFB) {
             local_state.players[i].team_id = (i <= TDMB_BLUE_BOTS) ? TDMB_BLUE_TEAM : TDMB_RED_TEAM;
         } else {
             local_state.players[i].team_id = (mode == MODE_TDM || mode == MODE_CTF || mode == MODE_TDMO) ? (i % 2) : -1;
@@ -989,6 +1112,18 @@ void local_init_match(int num_players, int mode) {
         local_state.players[i].carried_flag_team_id = -1;
         phys_respawn(&local_state.players[i], i*100);
         init_genome(&local_state.players[i].brain);
+        if (mode == MODE_STORY && i - 1 < STORY_BEAR_COUNT) {
+            local_state.players[i].x = story_bear_spawns[i - 1].x;
+            local_state.players[i].y = story_bear_spawns[i - 1].y;
+            local_state.players[i].z = story_bear_spawns[i - 1].z;
+            local_state.players[i].vx = local_state.players[i].vy = local_state.players[i].vz = 0.0f;
+            local_state.players[i].yaw = 180.0f;
+            local_state.players[i].pitch = 0.0f;
+            local_state.players[i].health = (i >= 5) ? 180 : 140;
+            local_state.players[i].shield = 0;
+            local_state.players[i].current_weapon = WPN_KNIFE;
+            local_state.players[i].ctf_bot_intent = 0;
+        }
     }
     scene_load(local_state.scene_id);
     if (mode == MODE_CTFB) {


### PR DESCRIPTION
### Motivation
- Provide a first vertical slice of solo STORY play while preserving the existing shared local simulation and physics path.
- Integrate STORY as a mode/ruleset (not a simulation fork) so future co-op can reuse the same systems.
- Give a minimal playable experience: intro cutscene, authored cave scene, simple enemies, and an end trigger that uses existing match/scene plumbing.

### Description
- Introduces `MODE_STORY` and `SCENE_STORY_CAVE`, plus a small `StoryPhase` enum and story runtime fields on `ServerState` to track cutscene timing and end-trigger data (`packages/common/protocol.h`).
- Adds a simple authored cave collision layout, spawn point, bounds/kill checks and `phys_set_scene` wiring so the cave is a first-class scene (`packages/common/physics.h`).
- Extends `local_init_match` and `local_update` to initialize STORY correctly and run the 5s intro cutscene before handing control to the player, while reusing the existing local simulation path; implements story-specific bear spawns, a small bear AI (`story_bear_think`), completion trigger and death restart behavior (`packages/simulation/local_game.h`).
- Adds a `STORY` lobby option and UI binding so STORY launches through the existing menu flow, forces cyborg skin for story bots, and adds a simple on-screen completion overlay (`apps/lobby/src/main.c`).
- Implements a minimal STORY cutscene camera that looks at the standing player for 5s, suppresses look/move/fire input during the cutscene, and resumes normal first-person rendering after the cutscene (`apps/lobby/src/main.c`).

### Testing
- Ran `make server` in the environment and the game server build completed successfully.
- Attempted `make lobby` but it failed in this container due to missing SDL2 development headers/libs (`SDL2/SDL.h` not found), which is an environment issue rather than a code problem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e79b9effc883278f3756f4849768a8)