### PR TITLE
Tune live weapon stats: Magnum ammo 8, Sniper ROF 60

### DIFF
--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -82,10 +82,10 @@ typedef struct {
 
 static const WeaponStats WPN_STATS[MAX_WEAPONS] = {
     {WPN_KNIFE,   200, 20, 1, 0.0f,  0},   
-    {WPN_MAGNUM,  45, 25, 1, 0.0f,  6},   
+    {WPN_MAGNUM,  45, 25, 1, 0.0f,  8},   
     {WPN_AR,      20, 6,  1, 0.04f, 30},  
     {WPN_SHOTGUN, 128, 17, 8, 0.15f, 8},   
-    {WPN_SNIPER,  101, 70, 1, 0.0f,  5},   
+    {WPN_SNIPER,  101, 60, 1, 0.0f,  5},   
     {WPN_KATANA,   40, 28, 1, 0.0f,  0}    
 };
 


### PR DESCRIPTION
### Motivation
- Make the sniper modestly faster and increase the magnum magazine capacity with a minimal, surgical stat-table patch. 
- Keep this as a pure data tuning change on the live gameplay path without refactoring weapon systems or changing IDs/packet structs. 

### Description
- Updated the canonical live `WPN_STATS` table in `packages/common/protocol.h` to change `WPN_MAGNUM` ammo from `6` → `8`. 
- Updated the same table to change `WPN_SNIPER` `rof` from `70` → `60` so the sniper fires slightly faster via the normal cooldown. 
- Only one source file was modified: `packages/common/protocol.h`, and no other weapon systems, IDs, packet structs, UI flow, or reload architecture were changed. 

### Testing
- Verified code references and behavior by running repository searches (`rg`) for `WPN_STATS`, `WPN_MAGNUM`, `WPN_SNIPER`, `ammo_max`, and `rof`, and confirmed the live table in `packages/common/protocol.h` was the authoritative one (succeeded). 
- Inspected weapon use sites in `packages/common/physics.h` and `services/game-server/src/server.c` to confirm reloads/respawns use `WPN_STATS[w].ammo_max` and firing cadence uses `WPN_STATS[w].rof`, so the magnum capacity and sniper cooldown inherit automatically (succeeded). 
- Created and reviewed the diff (`git diff`), staged, and committed the change to `packages/common/protocol.h` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e964fc427083278997547ace323fd4)