### PR TITLE
Remove in-game bottom debug HUD strings

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -3276,14 +3276,8 @@ void draw_hud(PlayerState *p) {
         glColor3f(0.95f, 0.55f, 0.1f);
         draw_string(style_buf, 50, 98, vs0_art_direction_enabled ? 4 : 6);
     }
-    glColor3f(0.58f, 0.75f, 0.76f);
-    draw_string(terrain_wireframe_debug ? "F6 TERRAIN WIRE:ON" : "F6 TERRAIN WIRE:OFF", 50, 24, vs0_art_direction_enabled ? 3 : 5);
-    glColor3f(0.68f, 0.56f, 0.76f);
-    draw_string(terrain_normals_debug ? "F7 TERRAIN NORMALS:ON" : "F7 TERRAIN NORMALS:OFF", 220, 24, vs0_art_direction_enabled ? 3 : 5);
-    glColor3f(0.78f, 0.69f, 0.48f);
-    draw_string(voxworld_points_debug ? "F11 SCENE DEBUG:ON" : "F11 SCENE DEBUG:OFF", 430, 24, vs0_art_direction_enabled ? 3 : 5);
-    glColor3f(0.72f, 0.74f, 0.80f);
-    draw_string(vs0_art_direction_enabled ? "F12 VS0 ART:ON" : "F12 VS0 ART:OFF", 650, 24, 3);
+    /* Removed bottom-of-screen debug toggle readouts from player HUD.
+       Debug toggles and key handling remain active for internal use. */
 
     if (p->current_weapon == WPN_KATANA) {
         char katana_buf[64];
@@ -3306,10 +3300,6 @@ void draw_hud(PlayerState *p) {
         draw_string("E: STORM ARROWS READY", 50, 132, vs0_art_direction_enabled ? 3 : 4);
     }
     
-    float raw_speed = sqrtf(p->vx*p->vx + p->vz*p->vz);
-    char vel_buf[32]; sprintf(vel_buf, "VEL: %.2f", raw_speed);
-    glColor3f(vs0_art_direction_enabled ? 0.80f : 1.0f, vs0_art_direction_enabled ? 0.78f : 1.0f, vs0_art_direction_enabled ? 0.44f : 0.0f);
-    draw_string(vel_buf, 1120, 50, vs0_art_direction_enabled ? 5 : 8); 
     draw_ammo_bars(p);
 
     glEnable(GL_DEPTH_TEST); glMatrixMode(GL_PROJECTION); glPopMatrix(); glMatrixMode(GL_MODELVIEW); glPopMatrix();


### PR DESCRIPTION
### Motivation
- The bottom of the gameplay HUD displays developer/debug cheat-sheet strings and a velocity readout that should not be visible to players during normal play.
- Make a surgical UI-only cleanup to remove those on-screen debug readouts while preserving all gameplay HUD and debug toggle behavior.

### Description
- Removed the on-screen draw calls for the bottom debug toggle strings (`F6 TERRAIN WIRE`, `F7 TERRAIN NORMALS`, `F11 SCENE DEBUG`, `F12 VS0 ART`) in `draw_hud` by replacing them with a short explanatory comment in `apps/lobby/src/main.c`.
- Removed the on-screen velocity readout block (`raw_speed`, `vel_buf`, and the `draw_string("VEL: ...")` call) from the HUD draw path.
- Preserved all underlying debug variables and key handling, and left vehicle status and all gameplay HUD elements (health/shield, ammo bars, abilities, CTFB/story overlays, vehicle HUD) untouched.
- Change is intentionally small and UI-focused so no debug system logic or bindings were removed.

### Testing
- Ran `rg`/searches to confirm the debug strings and velocity draw were removed from `apps/lobby/src/main.c` and the file was updated as expected (verification succeeded).
- Attempted a full build with `make -C /workspace/SHANKPIT`, which failed in this environment due to missing SDL2 development headers (`SDL2/SDL.h` and `SDL2/SDL_opengl.h`) so a complete binary build could not be produced (build failed).
- Confirmed the edited region no longer contains the removed draw calls so the change should not introduce new unused-local warnings in that area when built in a properly provisioned environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed228483848327aab26991eebfb6a1)