### PR TITLE
Upgrade Ability 1 HUD to square cooldown tile

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -3182,6 +3182,91 @@ static void draw_ammo_bars(const PlayerState *p) {
     glEnd();
 }
 
+static void draw_ability_one_tile(const PlayerState *p) {
+    if (!p) return;
+
+    const float tile_size = 72.0f;
+    const float tile_border = 2.0f;
+    const float tile_x = 50.0f;
+    const float tile_y = 122.0f;
+    const float icon_inset = 12.0f;
+    const float cooldown_text_size = 14.0f;
+    const float keybind_size = 4.0f;
+
+    float cooldown_remaining = ((float)p->ability_cooldown) / 60.0f;
+    int on_cooldown = cooldown_remaining > 0.0f;
+    int cooldown_display = (int)ceilf(cooldown_remaining);
+    if (on_cooldown && cooldown_display < 1) cooldown_display = 1;
+
+    float bg_r = on_cooldown ? 0.42f : 0.08f;
+    float bg_g = on_cooldown ? 0.08f : 0.10f;
+    float bg_b = on_cooldown ? 0.10f : 0.14f;
+    float border_r = on_cooldown ? 1.0f : 0.62f;
+    float border_g = on_cooldown ? 0.18f : 0.78f;
+    float border_b = on_cooldown ? 0.18f : 0.95f;
+
+    glColor4f(bg_r, bg_g, bg_b, 0.78f);
+    glRectf(tile_x, tile_y, tile_x + tile_size, tile_y + tile_size);
+
+    glColor4f(border_r, border_g, border_b, 0.95f);
+    glLineWidth(tile_border);
+    glBegin(GL_LINE_LOOP);
+    glVertex2f(tile_x, tile_y);
+    glVertex2f(tile_x + tile_size, tile_y);
+    glVertex2f(tile_x + tile_size, tile_y + tile_size);
+    glVertex2f(tile_x, tile_y + tile_size);
+    glEnd();
+    glLineWidth(1.0f);
+
+    const float icon_left = tile_x + icon_inset;
+    const float icon_right = tile_x + tile_size - icon_inset;
+    const float icon_bottom = tile_y + icon_inset;
+    const float icon_top = tile_y + tile_size - icon_inset;
+    float icon_r = on_cooldown ? 0.92f : 0.46f;
+    float icon_g = on_cooldown ? 0.52f : 0.92f;
+    float icon_b = on_cooldown ? 0.52f : 1.00f;
+
+    glColor4f(icon_r, icon_g, icon_b, on_cooldown ? 0.72f : 0.95f);
+    glBegin(GL_QUADS);
+    glVertex2f(icon_left + 6.0f, icon_bottom + 4.0f);
+    glVertex2f(icon_left + 13.0f, icon_bottom + 4.0f);
+    glVertex2f(icon_right - 2.0f, icon_top - 4.0f);
+    glVertex2f(icon_right - 9.0f, icon_top - 4.0f);
+    glVertex2f(icon_left + 2.0f, icon_bottom + 8.0f);
+    glVertex2f(icon_left + 9.0f, icon_bottom + 8.0f);
+    glVertex2f(icon_right - 6.0f, icon_top - 14.0f);
+    glVertex2f(icon_right - 13.0f, icon_top - 14.0f);
+    glEnd();
+    glColor4f(icon_r, icon_g, icon_b, on_cooldown ? 0.55f : 0.85f);
+    glBegin(GL_TRIANGLES);
+    glVertex2f(icon_left + 8.0f, icon_top - 2.0f);
+    glVertex2f(icon_left + 14.0f, icon_top - 12.0f);
+    glVertex2f(icon_left + 4.0f, icon_top - 12.0f);
+    glVertex2f(icon_right - 7.0f, icon_bottom + 2.0f);
+    glVertex2f(icon_right - 13.0f, icon_bottom + 12.0f);
+    glVertex2f(icon_right - 3.0f, icon_bottom + 12.0f);
+    glEnd();
+
+    if (on_cooldown) {
+        char cooldown_buf[8];
+        snprintf(cooldown_buf, sizeof(cooldown_buf), "%d", cooldown_display);
+        int digit_count = (int)strlen(cooldown_buf);
+        float approx_text_w = digit_count * cooldown_text_size * 3.8f;
+        float text_x = tile_x + (tile_size - approx_text_w) * 0.5f;
+        float text_y = tile_y + tile_size * 0.32f;
+
+        glColor4f(0.55f, 0.02f, 0.06f, 0.42f);
+        glRectf(tile_x, tile_y, tile_x + tile_size, tile_y + tile_size);
+        glColor3f(1.0f, 0.95f, 0.95f);
+        draw_string(cooldown_buf, text_x, text_y, cooldown_text_size);
+    }
+
+    glColor3f(0.80f, 0.88f, 0.95f);
+    draw_string("ABILITY 1", tile_x + 2.0f, tile_y - 14.0f, keybind_size);
+    glColor3f(0.92f, 0.96f, 1.0f);
+    draw_string("E", tile_x + tile_size - 10.0f, tile_y - 14.0f, keybind_size);
+}
+
 void draw_hud(PlayerState *p) {
     glDisable(GL_DEPTH_TEST);
     glMatrixMode(GL_PROJECTION); glPushMatrix(); glLoadIdentity(); gluOrtho2D(0, 1280, 0, 720);
@@ -3279,25 +3364,29 @@ void draw_hud(PlayerState *p) {
     /* Removed bottom-of-screen debug toggle readouts from player HUD.
        Debug toggles and key handling remain active for internal use. */
 
+    draw_ability_one_tile(p);
+
     if (p->current_weapon == WPN_KATANA) {
         char katana_buf[64];
         if (p->dash_timer > 0) {
             snprintf(katana_buf, sizeof(katana_buf), "KATANA DASHING");
         } else if (p->ability_cooldown == 0) {
-            snprintf(katana_buf, sizeof(katana_buf), "E: BLADE DASH READY");
+            snprintf(katana_buf, sizeof(katana_buf), "BLADE DASH READY");
         } else {
-            snprintf(katana_buf, sizeof(katana_buf), "BLADE DASH CD: %.1f", p->ability_cooldown / 60.0f);
+            int cooldown_seconds = (int)ceilf(((float)p->ability_cooldown) / 60.0f);
+            if (cooldown_seconds < 1) cooldown_seconds = 1;
+            snprintf(katana_buf, sizeof(katana_buf), "BLADE DASH CD: %ds", cooldown_seconds);
         }
         glColor3f(0.0f, 0.85f, 1.0f);
-        draw_string(katana_buf, 50, 132, vs0_art_direction_enabled ? 6 : 8);
+        draw_string(katana_buf, 132, 154, vs0_art_direction_enabled ? 5 : 6);
     } else if (p->storm_charges > 0) {
         char storm_buf[32];
         sprintf(storm_buf, "STORM ARROWS: %d", p->storm_charges);
         glColor3f(1.0f, 0.2f, 0.2f);
-        draw_string(storm_buf, 50, 132, vs0_art_direction_enabled ? 6 : 8);
+        draw_string(storm_buf, 132, 154, vs0_art_direction_enabled ? 5 : 6);
     } else if (p->ability_cooldown == 0) {
         glColor3f(0.0f, 0.8f, 1.0f);
-        draw_string("E: STORM ARROWS READY", 50, 132, vs0_art_direction_enabled ? 3 : 4);
+        draw_string("STORM ARROWS READY", 132, 154, vs0_art_direction_enabled ? 3 : 4);
     }
     
     draw_ammo_bars(p);

--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -3190,7 +3190,7 @@ static void draw_ability_one_tile(const PlayerState *p) {
     const float tile_x = 50.0f;
     const float tile_y = 122.0f;
     const float icon_inset = 12.0f;
-    const float cooldown_text_size = 14.0f;
+    const float cooldown_text_size = 3.5f;
     const float keybind_size = 4.0f;
 
     float cooldown_remaining = ((float)p->ability_cooldown) / 60.0f;
@@ -3222,11 +3222,11 @@ static void draw_ability_one_tile(const PlayerState *p) {
     const float icon_right = tile_x + tile_size - icon_inset;
     const float icon_bottom = tile_y + icon_inset;
     const float icon_top = tile_y + tile_size - icon_inset;
-    float icon_r = on_cooldown ? 0.92f : 0.46f;
-    float icon_g = on_cooldown ? 0.52f : 0.92f;
-    float icon_b = on_cooldown ? 0.52f : 1.00f;
+    float icon_r = on_cooldown ? 1.00f : 0.46f;
+    float icon_g = on_cooldown ? 0.42f : 0.92f;
+    float icon_b = on_cooldown ? 0.78f : 1.00f;
 
-    glColor4f(icon_r, icon_g, icon_b, on_cooldown ? 0.72f : 0.95f);
+    glColor4f(icon_r, icon_g, icon_b, on_cooldown ? 0.95f : 0.95f);
     glBegin(GL_QUADS);
     glVertex2f(icon_left + 6.0f, icon_bottom + 4.0f);
     glVertex2f(icon_left + 13.0f, icon_bottom + 4.0f);
@@ -3237,7 +3237,7 @@ static void draw_ability_one_tile(const PlayerState *p) {
     glVertex2f(icon_right - 6.0f, icon_top - 14.0f);
     glVertex2f(icon_right - 13.0f, icon_top - 14.0f);
     glEnd();
-    glColor4f(icon_r, icon_g, icon_b, on_cooldown ? 0.55f : 0.85f);
+    glColor4f(icon_r, icon_g, icon_b, on_cooldown ? 0.85f : 0.85f);
     glBegin(GL_TRIANGLES);
     glVertex2f(icon_left + 8.0f, icon_top - 2.0f);
     glVertex2f(icon_left + 14.0f, icon_top - 12.0f);
@@ -3255,14 +3255,10 @@ static void draw_ability_one_tile(const PlayerState *p) {
         float text_x = tile_x + (tile_size - approx_text_w) * 0.5f;
         float text_y = tile_y + tile_size * 0.32f;
 
-        glColor4f(0.55f, 0.02f, 0.06f, 0.42f);
-        glRectf(tile_x, tile_y, tile_x + tile_size, tile_y + tile_size);
         glColor3f(1.0f, 0.95f, 0.95f);
         draw_string(cooldown_buf, text_x, text_y, cooldown_text_size);
     }
 
-    glColor3f(0.80f, 0.88f, 0.95f);
-    draw_string("ABILITY 1", tile_x + 2.0f, tile_y - 14.0f, keybind_size);
     glColor3f(0.92f, 0.96f, 1.0f);
     draw_string("E", tile_x + tile_size - 10.0f, tile_y - 14.0f, keybind_size);
 }


### PR DESCRIPTION
### Motivation
- Improve readability and visual clarity of the Ability 1 indicator so it reads like a hero-shooter ability tile with clear ready vs cooldown states.
- Replace the old text-only readout with a framed square tile that fits into the existing HUD and is easy to extend for future abilities.

### Description
- Added a new helper `draw_ability_one_tile(const PlayerState *p)` in `apps/lobby/src/main.c` to render a named-constant square tile, border, procedural icon, and integer cooldown display. 
- The tile is wired to the real `p->ability_cooldown` value (converted to seconds) and uses `ceilf()` to compute the displayed whole-second cooldown, ensuring `3.9 -> 4`, `0.2 -> 1`, and hiding the number at `<= 0`. 
- Cooldown styling applies a strong red tint and a prominent centered integer when unavailable, while the ready state shows a neutral/dark tile with a bright border and visible icon. 
- Integrated the tile into the existing `draw_hud` flow and adjusted nearby ability status strings so the new tile does not overlap existing HUD elements, preserving health/shield/ammo/score/CTF/vehicle UI.

### Testing
- Ran a local build attempt with `make -j4`; compilation failed in this environment due to missing SDL2 development headers (`SDL2/SDL.h` and `SDL2/SDL_opengl.h`), so full runtime validation could not be executed here. 
- No automated unit tests were added; change is localized to `apps/lobby/src/main.c` and the new drawing helper is intended to be visually validated during gameplay.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed23d955908327b05295a354918e72)