### PR TITLE
Remove persistent garage scene/portal overlay text from gameplay HUD

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -3673,36 +3673,8 @@ static void draw_garage_overlay(PlayerState *p) {
     glOrtho(0, 1280, 0, 720, -1, 1);
     glMatrixMode(GL_MODELVIEW); glPushMatrix(); glLoadIdentity();
 
-    glColor3f(0.2f, 1.0f, 1.0f);
-    draw_string("OSAKA GARAGE", 40, 670, 10);
-    glColor3f(0.9f, 0.9f, 0.9f);
-    draw_string("PORTAL -> STADIUM", 40, 640, 6);
-    draw_string("PORTAL -> VOXWORLD TERRAIN", 40, 620, 6);
-    draw_string("PORTAL -> OIL TANKER", 40, 600, 6);
-    draw_string("PORTAL -> DUST COMPOUND", 40, 580, 6);
-    draw_string("PORTAL -> POO POO ISLAND", 40, 560, 6);
-
     int pad_count = 0;
     const VehiclePad *pads = scene_vehicle_pads(local_state.scene_id, &pad_count);
-    float list_y = 600.0f;
-    for (int i = 0; i < pad_count; i++) {
-        int occupied = 0;
-        for (int bi = 0; bi < MAX_BUGGIES; bi++) {
-            BuggyState *b = &local_state.buggies[bi];
-            if (!b->active || b->scene_id != local_state.scene_id) continue;
-            float dx = b->x - pads[i].x;
-            float dz = b->z - pads[i].z;
-            if ((dx * dx + dz * dz) < 16.0f) {
-                occupied = 1;
-                break;
-            }
-        }
-        char line[128];
-        snprintf(line, sizeof(line), "%s [%s]", pads[i].label, occupied ? "OCCUPIED" : "IDLE");
-        glColor3f(occupied ? 1.0f : 0.5f, occupied ? 0.6f : 0.9f, 0.6f);
-        draw_string(line, 40, list_y, 6);
-        list_y -= 20.0f;
-    }
 
     float portal_x = 0.0f, portal_y = 0.0f, portal_z = 0.0f, portal_r = 0.0f;
     scene_portal_info(local_state.scene_id, &portal_x, &portal_y, &portal_z, &portal_r);


### PR DESCRIPTION
### Motivation
- The Osaka Garage scene rendered permanent top-left title and a static portal destination list which visually clutter normal gameplay and are no longer needed.
- The same overlay code also drew an always-on vehicle pad occupancy list in the same screen region, adding extra non-interactive noise.

### Description
- Removed the hardcoded scene title and portal list `draw_string(...)` calls from `draw_garage_overlay` in `apps/lobby/src/main.c` so the permanent top-left text is no longer rendered.
- Removed the vehicle pad occupancy listing loop from `draw_garage_overlay` to avoid leaving static status text in the overlay area.
- Kept `draw_garage_overlay` in the render path and preserved contextual center-screen interaction prompts (e.g. `TRAVEL`, `PRESS F TO ENTER HELICOPTER`, `ENTER VEHICLE/EXIT VEHICLE`) so interactive feedback remains.

### Testing
- Searched the source with `rg` to confirm removal of the hardcoded strings and found no remaining matches for the removed labels (result: no matches found).
- Attempted to build the lobby with `make lobby`; build attempt failed in this environment due to missing SDL2 development headers (`SDL2/SDL.h` and `SDL2/SDL_opengl.h`), so full compilation validation could not be completed here.
- Verified by inspection that `draw_garage_overlay` still performs interaction checks and draws the contextual prompts, so runtime interaction UI should be preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed24cfb78883279ce7b02effa9eb38)