### PR TITLE
Reset STORY mode to Voxworld Breach Titan boss prototype

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -3043,11 +3043,8 @@ void draw_player_3rd(PlayerState *p) {
         /* Buggy is rendered from buggy world entities, not player pose. */
     } else {
         int forced_skin = -1;
-        int story_bear = (local_state.game_mode == MODE_STORY && p->id > 0);
         if (local_state.game_mode == MODE_TDMB || local_state.game_mode == MODE_TDMO || local_state.game_mode == MODE_CTFB) {
             forced_skin = (p->team_id == 1) ? SKIN_NINJA : SKIN_PIRATE;
-        } else if (story_bear) {
-            forced_skin = SKIN_CYBORG;
         }
         int draw_skin = (forced_skin >= 0) ? forced_skin : clamp_skin_id(g_selected_skin);
         switch (draw_skin) {
@@ -3137,6 +3134,75 @@ void draw_circle(float x, float y, float r, int segments) {
         glVertex2f(x + cx, y + cy);
     }
     glEnd();
+}
+
+static void draw_story_boss_world(unsigned int now_ms) {
+    if (local_state.game_mode != MODE_STORY) return;
+    StoryBossState *boss = &local_state.story_boss;
+    if (!boss->active && !boss->defeated) return;
+    if (local_state.scene_id != SCENE_VOXWORLD) return;
+
+    float t = now_ms * 0.001f;
+    float pulse = 0.5f + 0.5f * sinf(t * 2.2f + boss->x * 0.03f);
+    float fissure = (now_ms < boss->hurt_flash_until_ms) ? 1.0f : pulse * 0.35f;
+
+    glPushMatrix();
+    glTranslatef(boss->x, boss->y, boss->z);
+    glRotatef(boss->yaw, 0, 1, 0);
+    glScalef(3.0f, 3.0f, 3.0f);
+
+    glColor3f(0.20f, 0.22f, 0.25f); draw_box(8.5f, 10.5f, 5.8f);
+    glPushMatrix(); glTranslatef(0.6f, 4.8f, 0.8f); glColor3f(0.28f, 0.24f, 0.34f); draw_box(6.0f, 6.0f, 4.6f); glPopMatrix();
+    glPushMatrix(); glTranslatef(-0.8f, 10.5f, 0.7f); glColor3f(0.20f + 0.12f * pulse, 0.16f + 0.20f * pulse, 0.26f + 0.22f * pulse); draw_box(3.8f, 2.8f, 3.1f); glPopMatrix();
+    glPushMatrix(); glTranslatef(-4.8f, 5.8f, 0.4f); glColor3f(0.18f, 0.20f, 0.23f); draw_box(2.8f, 7.8f, 2.6f); glPopMatrix();
+    glPushMatrix(); glTranslatef(5.3f, 5.2f, -0.6f); glColor3f(0.25f, 0.21f, 0.27f); draw_box(2.3f, 8.8f, 2.2f); glPopMatrix();
+    glPushMatrix(); glTranslatef(-4.5f, 9.4f, 0.1f); glColor3f(0.25f, 0.30f, 0.25f); draw_box(3.8f, 1.8f, 2.6f); glPopMatrix();
+    glPushMatrix(); glTranslatef(4.8f, 9.2f, -0.3f); glColor3f(0.30f, 0.23f, 0.32f); draw_box(4.4f, 2.2f, 2.7f); glPopMatrix();
+
+    for (int i = 0; i < 6; i++) {
+        float off = (float)i * 1.2f;
+        glPushMatrix();
+        glTranslatef(((i % 2) ? 2.0f : -2.3f), 6.5f + off, -2.2f - off * 0.55f);
+        glRotatef((i % 2) ? 22.0f : -20.0f, 1, 0, 0);
+        glColor3f(0.21f + 0.08f * pulse, 0.18f + 0.12f * pulse, 0.30f + 0.10f * pulse);
+        draw_box(0.8f - off * 0.05f, 1.0f - off * 0.06f, 1.9f);
+        glPopMatrix();
+    }
+
+    glColor3f(0.05f + 0.45f * fissure, 0.03f + 0.30f * fissure, 0.08f + 0.50f * fissure);
+    glBegin(GL_QUADS);
+    glVertex3f(-0.5f, 1.0f, 3.0f); glVertex3f(0.3f, 1.0f, 3.0f); glVertex3f(0.2f, 8.8f, 2.9f); glVertex3f(-0.6f, 8.8f, 2.9f);
+    glVertex3f(-2.2f, 2.2f, 2.9f); glVertex3f(-1.5f, 2.2f, 2.9f); glVertex3f(-1.9f, 9.0f, 2.7f); glVertex3f(-2.5f, 9.0f, 2.7f);
+    glVertex3f(1.5f, 2.3f, 2.8f); glVertex3f(2.1f, 2.3f, 2.8f); glVertex3f(2.0f, 9.5f, 2.5f); glVertex3f(1.4f, 9.5f, 2.5f);
+    glEnd();
+
+    for (int i = 0; i < 22; i++) {
+        float fi = (float)i;
+        float px = sinf(t * 1.5f + fi * 0.8f) * (7.0f + (fi * 0.23f));
+        float py = 2.0f + fmodf(fi * 2.4f + t * 6.0f, 16.0f);
+        float pz = cosf(t * 1.2f + fi * 0.6f) * (4.0f + (fi * 0.12f));
+        float c = 0.35f + 0.65f * sinf(fi * 1.7f + t * 3.2f);
+        glPushMatrix();
+        glTranslatef(px, py, pz);
+        glColor3f(0.22f + 0.4f * c, 0.15f + 0.5f * (1.0f - c), 0.28f + 0.45f * c);
+        draw_box(0.22f, 0.22f, 0.22f);
+        glPopMatrix();
+    }
+    glPopMatrix();
+
+    if (!boss->defeated && local_state.story_phase == STORY_PHASE_PLAYING) {
+        float shock_t = (now_ms - boss->last_attack_ms);
+        if (shock_t < 420.0f) {
+            float ring_r = 30.0f + shock_t * 0.22f;
+            glColor4f(0.65f, 0.15f, 0.82f, 0.55f);
+            glBegin(GL_LINE_LOOP);
+            for (int i = 0; i < 48; i++) {
+                float a = (float)i / 48.0f * 6.28318f;
+                glVertex3f(boss->x + cosf(a) * ring_r, boss->y - 24.5f, boss->z + sinf(a) * ring_r);
+            }
+            glEnd();
+        }
+    }
 }
 
 static void draw_ammo_bars(const PlayerState *p) {
@@ -3320,18 +3386,40 @@ void draw_hud(PlayerState *p) {
     } else if (local_state.game_mode == MODE_STORY) {
         glColor3f(0.85f, 0.92f, 0.95f);
         if (local_state.story_phase == STORY_PHASE_CUTSCENE) {
-            draw_string("STORY: CAVE ENTRY", 500, 682, 6);
+            draw_string("STORY: VOXWORLD BREACH", 452, 682, 6);
             draw_string("INTRO IN PROGRESS...", 500, 658, 4);
         } else if (local_state.story_phase == STORY_PHASE_COMPLETE) {
             glColor3f(0.55f, 1.0f, 0.65f);
-            draw_string("STORY COMPLETE", 510, 682, 8);
+            draw_string("BREACH TITAN DEFEATED", 430, 682, 7);
             glColor3f(0.85f, 0.92f, 0.95f);
             draw_string("PRESS ESC TO RETURN", 500, 650, 4);
         } else if (local_state.story_phase == STORY_PHASE_FAILED) {
             glColor3f(1.0f, 0.45f, 0.35f);
             draw_string("MISSION FAILED", 520, 682, 7);
         } else {
-            draw_string("OBJECTIVE: REACH THE END OF THE CAVE", 410, 682, 4);
+            draw_string("OBJECTIVE: DEFEAT THE BREACH TITAN", 420, 682, 4);
+        }
+
+        if (local_state.story_boss.active || local_state.story_boss.defeated) {
+            float max_hp = local_state.story_boss.max_health > 1.0f ? local_state.story_boss.max_health : 1.0f;
+            float hp = local_state.story_boss.health;
+            if (hp < 0.0f) hp = 0.0f;
+            float pct = hp / max_hp;
+            if (pct < 0.0f) pct = 0.0f;
+            if (pct > 1.0f) pct = 1.0f;
+            float bx0 = 320.0f, bx1 = 960.0f, by0 = 628.0f, by1 = 646.0f;
+            glColor4f(0.06f, 0.03f, 0.09f, 0.85f);
+            glRectf(bx0 - 2.0f, by0 - 2.0f, bx1 + 2.0f, by1 + 2.0f);
+            glColor3f(0.35f, 0.09f, 0.19f);
+            glRectf(bx0, by0, bx1, by1);
+            glColor3f(0.82f, 0.10f, 0.44f);
+            glRectf(bx0, by0, bx0 + (bx1 - bx0) * pct, by1);
+            glColor3f(0.94f, 0.88f, 0.98f);
+            draw_string("BREACH TITAN", 548, 650, 4);
+            if (local_state.story_boss.defeated) {
+                glColor3f(0.55f, 1.0f, 0.65f);
+                draw_string("DEFEATED", 600, 632, 4);
+            }
         }
     }
     float x0 = 50.0f, x1 = vs0_art_direction_enabled ? 220.0f : 250.0f;
@@ -3941,13 +4029,12 @@ void draw_scene(PlayerState *render_p) {
     }
 
     if (story_cutscene) {
-        float look_x = render_p->x;
-        float look_y = render_p->y + 3.0f;
-        float look_z = render_p->z;
-        float yaw_rad = (180.0f - render_p->yaw) * 0.0174533f;
-        float cam_x = look_x + sinf(yaw_rad) * 18.0f;
-        float cam_y = look_y + 3.0f;
-        float cam_z = look_z + cosf(yaw_rad) * 18.0f;
+        float look_x = local_state.story_boss.x;
+        float look_y = local_state.story_boss.y + 5.0f;
+        float look_z = local_state.story_boss.z;
+        float cam_x = look_x + 90.0f;
+        float cam_y = look_y + 40.0f;
+        float cam_z = look_z + 120.0f;
         gluLookAt(cam_x, cam_y, cam_z, look_x, look_y, look_z, 0.0f, 1.0f, 0.0f);
     } else if (!(render_p->in_vehicle && render_p->vehicle_type == VEH_HELICOPTER)) {
         float draw_cam_pitch = lerpf(cam_pitch, -14.0f, death_cam_blend);
@@ -3979,6 +4066,7 @@ void draw_scene(PlayerState *render_p) {
     draw_voxworld_grass_overlay(&world_lighting, render_p);
     draw_voxworld_bushes();
     draw_map(&world_lighting);
+    draw_story_boss_world(now_ms);
     draw_team_map_markers(local_state.scene_id, local_state.game_mode);
     draw_garage_vehicle_pads();
     draw_garage_portal_frame();

--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -293,6 +293,17 @@ typedef enum { MODE_DEATHMATCH=0, MODE_TDM=1, MODE_SURVIVAL=2, MODE_CTF=3, MODE_
 typedef enum { STORY_PHASE_CUTSCENE=0, STORY_PHASE_PLAYING=1, STORY_PHASE_COMPLETE=2, STORY_PHASE_FAILED=3 } StoryPhase;
 
 typedef struct {
+    int active;
+    int defeated;
+    float x, y, z;
+    float yaw;
+    float health;
+    float max_health;
+    unsigned int last_attack_ms;
+    unsigned int hurt_flash_until_ms;
+} StoryBossState;
+
+typedef struct {
     PlayerState players[MAX_CLIENTS];
     Projectile projectiles[MAX_PROJECTILES];
     HelicopterState helicopters[MAX_HELICOPTERS];
@@ -309,6 +320,7 @@ typedef struct {
     int winning_team;
     int story_phase;
     unsigned int story_phase_start_ms;
+    StoryBossState story_boss;
     CtfMatchState ctf;
     struct sockaddr_in clients[MAX_CLIENTS];
     ClientMeta client_meta[MAX_CLIENTS];

--- a/packages/simulation/local_game.h
+++ b/packages/simulation/local_game.h
@@ -25,29 +25,10 @@ static int tdmb_last_kills[MAX_CLIENTS];
 #define CTFB_CARRY_MELEE_DAMAGE 80
 #define CTFB_CARRY_MELEE_COOLDOWN_MS 450
 #define CTFB_RESPAWN_DEBUG_LOG 0
-#define STORY_BEAR_COUNT 7
-#define STORY_END_TRIGGER_Z 1210.0f
-#define STORY_END_TRIGGER_RADIUS 72.0f
 #define STORY_CUTSCENE_DURATION_MS 5000
-
-typedef enum {
-    STORY_BEAR_IDLE = 0,
-    STORY_BEAR_ALERTED = 1,
-    STORY_BEAR_CHASING = 2,
-    STORY_BEAR_ATTACKING = 3,
-    STORY_BEAR_DEAD = 4
-} StoryBearState;
-
-static const Vec2 story_bear_spawn_points[STORY_BEAR_COUNT] = {
-    { 0.0f, -760.0f },
-    {-38.0f, -340.0f },
-    { 42.0f, -280.0f },
-    { 60.0f, 130.0f },
-    {-36.0f, 420.0f },
-    { 28.0f, 780.0f },
-    {-42.0f, 910.0f }
-};
-static StoryBearState story_bear_states[MAX_CLIENTS];
+#define STORY_BOSS_MAX_HEALTH 1000.0f
+#define STORY_BOSS_ATTACK_INTERVAL_MIN_MS 2500
+#define STORY_BOSS_ATTACK_INTERVAL_MAX_MS 4000
 
 static int mode_uses_team_scores(int mode) {
     return mode == MODE_TDM || mode == MODE_TDMB || mode == MODE_TDMO || mode == MODE_CTFB;
@@ -561,55 +542,10 @@ static void ctf_try_carry_melee(PlayerState *attacker, unsigned int now_ms) {
     phys_try_melee_strike(attacker, local_state.players, CTFB_CARRY_MELEE_DAMAGE, 16, 0, now_ms, mode_respawn_delay_ms(local_state.game_mode));
 }
 
-static void story_update_bear_state(PlayerState *bear, PlayerState *target, float dist) {
-    StoryBearState state = story_bear_states[bear->id];
-    if (bear->state == STATE_DEAD) {
-        story_bear_states[bear->id] = STORY_BEAR_DEAD;
-        return;
-    }
-    switch (state) {
-        case STORY_BEAR_IDLE:
-            if (dist < 210.0f) story_bear_states[bear->id] = STORY_BEAR_ALERTED;
-            break;
-        case STORY_BEAR_ALERTED:
-            story_bear_states[bear->id] = (dist < 170.0f) ? STORY_BEAR_CHASING : STORY_BEAR_IDLE;
-            break;
-        case STORY_BEAR_CHASING:
-            if (dist < 9.0f) story_bear_states[bear->id] = STORY_BEAR_ATTACKING;
-            else if (dist > 280.0f) story_bear_states[bear->id] = STORY_BEAR_IDLE;
-            break;
-        case STORY_BEAR_ATTACKING:
-            if (dist > 12.0f) story_bear_states[bear->id] = STORY_BEAR_CHASING;
-            break;
-        case STORY_BEAR_DEAD:
-            break;
-    }
-    (void)target;
-}
-
 // --- BOT AI ---
 void bot_think(int bot_idx, PlayerState *players, float *out_fwd, float *out_yaw, int *out_buttons) {
     PlayerState *me = &players[bot_idx];
     if (me->state == STATE_DEAD || local_state.match_over) { *out_buttons = 0; return; }
-    if (local_state.game_mode == MODE_STORY) {
-        PlayerState *hero = &players[0];
-        float dx = hero->x - me->x;
-        float dz = hero->z - me->z;
-        float dist = sqrtf(dx*dx + dz*dz);
-        float target_yaw = atan2f(dx, dz) * (180.0f / 3.14159f);
-        float diff = angle_diff(target_yaw, me->yaw);
-        if (diff > 7.0f) diff = 7.0f;
-        if (diff < -7.0f) diff = -7.0f;
-        *out_yaw = me->yaw + diff;
-        story_update_bear_state(me, hero, dist);
-        StoryBearState state = story_bear_states[bot_idx];
-        if (state == STORY_BEAR_ALERTED || state == STORY_BEAR_CHASING) *out_fwd = 0.9f;
-        if (state == STORY_BEAR_ATTACKING) {
-            me->current_weapon = WPN_KNIFE;
-            *out_buttons |= BTN_ATTACK;
-        }
-        return;
-    }
     if (local_state.game_mode == MODE_CTFB && local_state.ctf.active && team_id_is_valid(me->team_id)) {
         CtfBotObservation obs;
         build_ctf_bot_observation(bot_idx, &obs);
@@ -846,6 +782,97 @@ static void update_projectiles(unsigned int now_ms) {
     }
 }
 
+static float story_weapon_damage_value(int weapon_id) {
+    switch (weapon_id) {
+        case WPN_MAGNUM: return 35.0f;
+        case WPN_SNIPER: return 80.0f;
+        case WPN_KNIFE:
+        case WPN_KATANA: return 25.0f;
+        case WPN_AR:
+        default: return 8.0f;
+    }
+}
+
+static void story_try_damage_boss(PlayerState *attacker, unsigned int now_ms) {
+    if (!attacker || !local_state.story_boss.active || local_state.story_boss.defeated) return;
+    static unsigned int story_last_damage_ms = 0;
+    if (now_ms - story_last_damage_ms < 90) return;
+
+    float dx = local_state.story_boss.x - attacker->x;
+    float dz = local_state.story_boss.z - attacker->z;
+    float dist = sqrtf(dx * dx + dz * dz);
+    if (dist > 620.0f) return;
+
+    float yaw_rad = attacker->yaw * (3.14159f / 180.0f);
+    float dir_x = sinf(yaw_rad);
+    float dir_z = cosf(yaw_rad);
+    float inv_dist = (dist > 0.001f) ? (1.0f / dist) : 1.0f;
+    float to_boss_x = dx * inv_dist;
+    float to_boss_z = dz * inv_dist;
+    float facing_dot = dir_x * to_boss_x + dir_z * to_boss_z;
+    int melee_weapon = (attacker->current_weapon == WPN_KNIFE || attacker->current_weapon == WPN_KATANA);
+    float required_dot = melee_weapon ? 0.68f : 0.80f;
+    if (facing_dot < required_dot) return;
+    if (melee_weapon && dist > 65.0f) return;
+
+    float dmg = story_weapon_damage_value(attacker->current_weapon);
+    local_state.story_boss.health -= dmg;
+    if (local_state.story_boss.health < 0.0f) local_state.story_boss.health = 0.0f;
+    local_state.story_boss.hurt_flash_until_ms = now_ms + 140;
+    story_last_damage_ms = now_ms;
+
+    static unsigned int story_last_damage_log_ms = 0;
+    if (now_ms - story_last_damage_log_ms > 250) {
+        printf("[STORY] boss damaged %.1f hp=%.1f/%.1f\n",
+               dmg, local_state.story_boss.health, local_state.story_boss.max_health);
+        story_last_damage_log_ms = now_ms;
+    }
+
+    if (local_state.story_boss.health <= 0.0f) {
+        local_state.story_boss.defeated = 1;
+        local_state.story_boss.active = 0;
+        local_state.story_phase = STORY_PHASE_COMPLETE;
+        local_state.story_phase_start_ms = now_ms;
+        local_state.match_over = 1;
+        printf("[STORY] boss defeated\n");
+    }
+}
+
+static void story_tick_boss(PlayerState *hero, unsigned int now_ms) {
+    if (local_state.game_mode != MODE_STORY) return;
+    if (!hero || hero->state == STATE_DEAD) return;
+    if (!local_state.story_boss.active || local_state.story_boss.defeated) return;
+    if (local_state.story_phase != STORY_PHASE_PLAYING) return;
+
+    if (hero->is_shooting > 0 || hero->in_shoot > 0) story_try_damage_boss(hero, now_ms);
+
+    float dx = hero->x - local_state.story_boss.x;
+    float dz = hero->z - local_state.story_boss.z;
+    float dist = sqrtf(dx * dx + dz * dz);
+    unsigned int interval_span = STORY_BOSS_ATTACK_INTERVAL_MAX_MS - STORY_BOSS_ATTACK_INTERVAL_MIN_MS;
+    unsigned int interval = STORY_BOSS_ATTACK_INTERVAL_MIN_MS;
+    if (interval_span > 0) {
+        unsigned int t = now_ms / 137;
+        interval += (t % (interval_span + 1));
+    }
+    if (now_ms - local_state.story_boss.last_attack_ms >= interval && dist < 300.0f) {
+        local_state.story_boss.last_attack_ms = now_ms;
+        local_state.story_boss.hurt_flash_until_ms = now_ms + 200;
+        if (dist < 120.0f) {
+            int shock_dmg = 28;
+            hero->shield_regen_timer = SHIELD_REGEN_DELAY;
+            if (hero->shield > 0) {
+                if (hero->shield >= shock_dmg) { hero->shield -= shock_dmg; shock_dmg = 0; }
+                else { shock_dmg -= hero->shield; hero->shield = 0; }
+            }
+            hero->health -= shock_dmg;
+            if (hero->health <= 0) {
+                phys_enter_death_state(NULL, hero, now_ms, mode_respawn_delay_ms(local_state.game_mode), 0.0f, 0.0f);
+            }
+        }
+    }
+}
+
 void local_update(float fwd, float str, float yaw, float pitch, int shoot, int weapon_req, int jump, int crouch, int reload, int ability, void *server_context, unsigned int cmd_time) {
     PlayerState *p0 = &local_state.players[0];
     if (local_state.game_mode == MODE_STORY) {
@@ -1009,15 +1036,7 @@ void local_update(float fwd, float str, float yaw, float pitch, int shoot, int w
     }
     buggy_tick_all();
     update_projectiles(cmd_time);
-    if (local_state.game_mode == MODE_STORY && local_state.story_phase == STORY_PHASE_PLAYING) {
-        float ex = p0->x - 0.0f;
-        float ez = p0->z - STORY_END_TRIGGER_Z;
-        if (ex * ex + ez * ez <= STORY_END_TRIGGER_RADIUS * STORY_END_TRIGGER_RADIUS) {
-            local_state.story_phase = STORY_PHASE_COMPLETE;
-            local_state.story_phase_start_ms = cmd_time;
-            local_state.match_over = 1;
-        }
-    }
+    story_tick_boss(p0, cmd_time);
     if (local_state.game_mode == MODE_CTFB) {
         ctf_tick_flags(cmd_time);
         ctf_training_on_step(cmd_time);
@@ -1050,7 +1069,6 @@ void local_init_match(int num_players, int mode) {
     local_state.score_limit = (mode == MODE_TDMB || mode == MODE_TDMO) ? TDMB_SCORE_LIMIT : (mode == MODE_CTFB ? CTFB_SCORE_LIMIT : 0);
     local_state.story_phase = (mode == MODE_STORY) ? STORY_PHASE_CUTSCENE : STORY_PHASE_PLAYING;
     local_state.story_phase_start_ms = 0;
-    memset(story_bear_states, 0, sizeof(story_bear_states));
 
     if (mode == MODE_TDMB) {
         num_players = 1 + TDMB_BLUE_BOTS + TDMB_RED_BOTS;
@@ -1060,8 +1078,25 @@ void local_init_match(int num_players, int mode) {
         num_players = 1 + TDMB_BLUE_BOTS + TDMB_RED_BOTS;
         local_state.scene_id = SCENE_OIL_TANKER;
     } else if (mode == MODE_STORY) {
-        num_players = 1 + STORY_BEAR_COUNT;
-        local_state.scene_id = SCENE_STORY_CAVE;
+        num_players = 1;
+        local_state.scene_id = SCENE_VOXWORLD;
+        local_state.story_boss.active = 1;
+        local_state.story_boss.defeated = 0;
+        local_state.story_boss.x = 0.0f;
+        local_state.story_boss.z = -420.0f;
+        {
+            float gy = terrain_sample_height(&g_scene_terrain, local_state.story_boss.x, local_state.story_boss.z);
+            if (gy < 0.0f) gy = 0.0f;
+            local_state.story_boss.y = gy + 26.0f;
+        }
+        local_state.story_boss.yaw = 180.0f;
+        local_state.story_boss.max_health = STORY_BOSS_MAX_HEALTH;
+        local_state.story_boss.health = local_state.story_boss.max_health;
+        local_state.story_boss.last_attack_ms = 0;
+        local_state.story_boss.hurt_flash_until_ms = 0;
+        printf("[STORY] starting Voxworld boss encounter\n");
+        printf("[STORY] boss spawned at %.1f/%.1f/%.1f hp=%.1f\n",
+               local_state.story_boss.x, local_state.story_boss.y, local_state.story_boss.z, local_state.story_boss.health);
     } else {
         local_state.scene_id = SCENE_GARAGE_OSAKA;
     }
@@ -1093,19 +1128,6 @@ void local_init_match(int num_players, int mode) {
         local_state.players[i].carried_flag_team_id = -1;
         phys_respawn(&local_state.players[i], i*100);
         init_genome(&local_state.players[i].brain);
-        if (mode == MODE_STORY) {
-            int bear_slot = i - 1;
-            if (bear_slot >= 0 && bear_slot < STORY_BEAR_COUNT) {
-                local_state.players[i].x = story_bear_spawn_points[bear_slot].x;
-                local_state.players[i].z = story_bear_spawn_points[bear_slot].y;
-                local_state.players[i].y = 6.0f;
-                local_state.players[i].yaw = 180.0f;
-                local_state.players[i].current_weapon = WPN_KNIFE;
-                local_state.players[i].health = (bear_slot >= STORY_BEAR_COUNT - 2) ? 100 : 80;
-                local_state.players[i].shield = 0;
-                story_bear_states[i] = STORY_BEAR_IDLE;
-            }
-        }
     }
     scene_load(local_state.scene_id);
     if (mode == MODE_CTFB) {


### PR DESCRIPTION
### Motivation
- STORY mode was relying on a broken cave/bear flow and an end-of-cave trigger, so replace it with a focused prototype boss encounter in Voxworld.
- Provide a simple, simulation-driven boss state and rendering so STORY is a clear playable prototype (spawn, HUD, damage, defeat).

### Description
- Added a dedicated `StoryBossState` to `ServerState` in `packages/common/protocol.h` to hold boss runtime state (`active`, `defeated`, `x,y,z`, `yaw`, `health`, `max_health`, timers).
- Replaced old cave/bear story flow in `packages/simulation/local_game.h`: removed cave end trigger constants and bear spawn/AI hooks, routed `MODE_STORY` to `SCENE_VOXWORLD`, set `num_players = 1`, and initialize `local_state.story_boss` (position, grounded Y, health, timers, and logs).
- Implemented boss simulation logic in `packages/simulation/local_game.h`: `story_try_damage_boss` (aim/range-gated damage using weapon-damage mapping), `story_tick_boss` (periodic boss shockwave attack), and removed the old `STORY_END_TRIGGER` completion path in favor of boss-defeat completion (sets `STORY_PHASE_COMPLETE` and `match_over`).
- Added immediate-mode boss rendering and cinematic support in `apps/lobby/src/main.c`: `draw_story_boss_world`, repointed the story cutscene camera to frame the boss, and added HUD updates including cutscene title `STORY: VOXWORLD BREACH`, playing objective `OBJECTIVE: DEFEAT THE BREACH TITAN`, complete text `BREACH TITAN DEFEATED`, and a top-center boss health bar labeled `BREACH TITAN`.
- Removed story-mode bear-specific rendering/special-case (`forced_skin`/bear skin) so bears are no longer used in STORY.
- Added light log lines: `[STORY] starting Voxworld boss encounter`, boss spawn, boss damaged, and boss defeated.
- Files changed: `packages/common/protocol.h`, `packages/simulation/local_game.h`, `apps/lobby/src/main.c`.

### Testing
- Ran a local build with `make -j4`; the build could not complete in this environment because the lobby client compilation failed due to missing system SDL2 headers (`SDL2/SDL.h`, `SDL2/SDL_opengl.h`), so full binary validation could not be completed.
- Static inspection and local compile attempts show server-side compilation started, and the new simulation logic and HUD/draw code are wired into the existing rendering/update paths; runtime verification is recommended on a machine with SDL2 available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2a8f58a483278c5d18431285b7a7)