### PR TITLE
Fix merge-conflict breakage in lobby skin rendering code

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -2292,6 +2292,8 @@ static void draw_skin_glow_end(void) {
     else glDisable(GL_LIGHTING);
     if (g_skin_glow_tex2d_was_enabled) glEnable(GL_TEXTURE_2D);
     else glDisable(GL_TEXTURE_2D);
+}
+
 static void draw_player_limb_segment(float w, float h, float d) {
     glPushMatrix();
     glTranslatef(0.0f, -h * 0.5f, 0.0f);
@@ -3068,8 +3070,8 @@ static void draw_player_skin_emiree(PlayerState *p, float draw_pitch, float draw
 
     /* Arms/gloves material zones. */
     float shoulder_y = 1.18f + pose.torso_bob;
-    float left_pitch = -6.0f + pose.left_arm_swing;
-    float right_pitch = 28.0f + pose.right_arm_swing;
+    float left_pitch = pose.left_upper_arm_pitch;
+    float right_pitch = pose.right_upper_arm_pitch;
     float left_elbow = pose.left_elbow;
     float right_elbow = pose.right_elbow;
     for (int right = 0; right <= 1; ++right) {


### PR DESCRIPTION
### Motivation
- A bad merge resolution removed a closing brace in `draw_skin_glow_end`, which caused many subsequent top-level functions to be parsed as nested declarations and produced numerous `invalid storage class for function` compiler errors. 
- The Emiree skin code referenced non-existent `PlayerAnimPose` fields (`left_arm_swing` / `right_arm_swing`) that needed to be mapped to the current pose fields.

### Description
- Restored the missing closing brace to properly terminate `draw_skin_glow_end` in `apps/lobby/src/main.c` so subsequent functions are defined at top level. 
- Replaced stale Emiree animation references `pose.left_arm_swing` / `pose.right_arm_swing` with the existing `pose.left_upper_arm_pitch` / `pose.right_upper_arm_pitch` in `draw_player_skin_emiree`. 
- Verified the file no longer contains the old field names and that `draw_skin_glow_end` is properly closed.

### Testing
- Ran a targeted search with `rg -n "left_arm_swing|right_arm_swing|draw_skin_glow_end\("` to confirm the stale fields were removed and the function exists, which succeeded. 
- Attempted a full build with `make -j4`, which no longer fails with the previous parser/storage-class errors but stops with missing SDL2 headers (`SDL2/SDL.h`, `SDL2/SDL_opengl.h`) in this environment, indicating the compile errors seen now are due to environment setup rather than the earlier merge damage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed349e68608327b29a66243f647177)