### PR TITLE
Reset STORY mode to Voxworld ‘Breach Titan’ boss prototype

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -799,7 +799,7 @@ static void lobby_apply_scene_id(const char *scene_id) {
     } else if (strcmp(scene_id, "POO_POO_ISLAND") == 0) {
         scene_load(SCENE_POO_POO_ISLAND);
     } else if (strcmp(scene_id, "STORY_CAVE") == 0) {
-        scene_load(SCENE_STORY_CAVE);
+        scene_load(SCENE_VOXWORLD);
     }
 }
 
@@ -3043,11 +3043,8 @@ void draw_player_3rd(PlayerState *p) {
         /* Buggy is rendered from buggy world entities, not player pose. */
     } else {
         int forced_skin = -1;
-        int story_bear = (local_state.game_mode == MODE_STORY && p->id > 0);
         if (local_state.game_mode == MODE_TDMB || local_state.game_mode == MODE_TDMO || local_state.game_mode == MODE_CTFB) {
             forced_skin = (p->team_id == 1) ? SKIN_NINJA : SKIN_PIRATE;
-        } else if (story_bear) {
-            forced_skin = SKIN_CYBORG;
         }
         int draw_skin = (forced_skin >= 0) ? forced_skin : clamp_skin_id(g_selected_skin);
         switch (draw_skin) {
@@ -3125,6 +3122,90 @@ static void draw_helicopter_model(const HelicopterState *h) {
     draw_box(1.4f, 0.05f, 0.16f);
     glPopMatrix();
     glPopMatrix();
+}
+
+static void draw_story_boss_world(const StoryBossState *boss, unsigned int now_ms) {
+    if (!boss || !boss->active) return;
+    float pulse = 0.5f + 0.5f * sinf((float)now_ms * 0.004f);
+    int hurt_flash = now_ms < boss->hurt_flash_until_ms;
+    glPushMatrix();
+    glTranslatef(boss->x, boss->y, boss->z);
+    glRotatef(180.0f - norm_yaw_deg(boss->yaw), 0, 1, 0);
+    glScalef(8.8f, 11.5f, 8.8f);
+
+    glColor3f(hurt_flash ? 0.56f : 0.23f, hurt_flash ? 0.24f : 0.24f, hurt_flash ? 0.62f : 0.28f);
+    glPushMatrix(); glTranslatef(0.0f, 1.9f, 0.0f); draw_box(1.7f, 2.6f, 1.4f); glPopMatrix();
+    glColor3f(0.18f, 0.20f, 0.23f);
+    glPushMatrix(); glTranslatef(0.46f, 2.55f, -0.20f); draw_box(0.7f, 1.4f, 0.8f); glPopMatrix();
+    glPushMatrix(); glTranslatef(-0.50f, 2.45f, 0.14f); draw_box(0.8f, 1.3f, 0.7f); glPopMatrix();
+    glColor3f(0.22f + pulse * 0.12f, 0.28f, 0.20f + pulse * 0.1f);
+    glPushMatrix(); glTranslatef(0.0f, 3.65f, 0.24f); draw_box(0.92f, 0.74f, 0.90f); glPopMatrix();
+    glColor3f(0.08f, 0.09f, 0.11f);
+    glPushMatrix(); glTranslatef(0.0f, 3.42f, 0.78f); draw_box(0.54f, 0.18f, 0.16f); glPopMatrix();
+
+    glColor3f(0.30f, 0.24f + pulse * 0.06f, 0.34f + pulse * 0.08f);
+    for (int s = 0; s < 5; s++) {
+        float off = -0.8f + 0.4f * (float)s;
+        glPushMatrix(); glTranslatef(off, 2.8f + 0.2f * (float)(s % 2), -0.7f); glRotatef((float)(s * 7), 1, 0, 0); draw_box(0.20f, 0.78f, 0.16f); glPopMatrix();
+    }
+
+    glColor3f(0.26f, 0.30f, 0.35f);
+    glPushMatrix(); glTranslatef(-1.28f, 2.65f, 0.0f); draw_box(0.72f, 0.64f, 0.72f); glPopMatrix();
+    glPushMatrix(); glTranslatef(1.28f, 2.62f, 0.1f); draw_box(0.84f, 0.66f, 0.70f); glPopMatrix();
+    glPushMatrix(); glTranslatef(-1.62f, 1.5f, 0.0f); glRotatef(14.0f, 0, 0, 1); draw_box(0.42f, 1.8f, 0.42f); glPopMatrix();
+    glPushMatrix(); glTranslatef(1.70f, 1.38f, -0.15f); glRotatef(-21.0f, 0, 0, 1); draw_box(0.46f, 2.2f, 0.46f); glPopMatrix();
+    glColor3f(0.11f, 0.12f, 0.13f);
+    glPushMatrix(); glTranslatef(-1.9f, 0.3f, 0.25f); draw_box(0.46f, 0.66f, 0.64f); glPopMatrix();
+    glPushMatrix(); glTranslatef(2.0f, -0.1f, -0.10f); draw_box(0.58f, 0.78f, 0.72f); glPopMatrix();
+
+    glColor3f(0.20f, 0.22f, 0.24f);
+    glPushMatrix(); glTranslatef(-0.44f, 0.34f, 0.0f); draw_box(0.60f, 1.8f, 0.62f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.36f, 0.34f, 0.0f); draw_box(0.62f, 1.7f, 0.64f); glPopMatrix();
+    glPushMatrix(); glTranslatef(-0.46f, -0.56f, 0.18f); draw_box(0.42f, 0.28f, 0.28f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.44f, -0.52f, 0.14f); draw_box(0.40f, 0.24f, 0.28f); glPopMatrix();
+
+    glColor3f(0.34f, 0.28f, 0.42f);
+    glPushMatrix(); glTranslatef(-0.42f, 4.14f, -0.02f); glRotatef(28.0f, 0, 0, 1); draw_box(0.16f, 1.1f, 0.20f); glPopMatrix();
+    glPushMatrix(); glTranslatef(0.44f, 4.18f, -0.02f); glRotatef(-28.0f, 0, 0, 1); draw_box(0.16f, 1.2f, 0.20f); glPopMatrix();
+    glPopMatrix();
+
+    glDisable(GL_CULL_FACE);
+    glColor4f(0.72f, 0.12f + pulse * 0.36f, 0.92f, 0.55f);
+    glBegin(GL_LINE_LOOP);
+    for (int i = 0; i < 36; i++) {
+        float a = ((float)i / 36.0f) * 6.28318f;
+        glVertex3f(boss->x + cosf(a) * 110.0f, boss->y - 35.0f, boss->z + sinf(a) * 110.0f);
+    }
+    glEnd();
+    glEnable(GL_CULL_FACE);
+
+    for (int i = 0; i < 28; i++) {
+        float fi = (float)i;
+        float ox = sinf(fi * 4.1f + now_ms * 0.0013f) * 44.0f;
+        float oy = 10.0f + cosf(fi * 3.1f + now_ms * 0.0017f) * 28.0f;
+        float oz = cosf(fi * 2.7f + now_ms * 0.0019f) * 42.0f;
+        glPushMatrix();
+        glTranslatef(boss->x + ox, boss->y + oy, boss->z + oz);
+        glColor3f((i % 3 == 0) ? 0.62f : 0.28f, (i % 2 == 0) ? 0.86f : 0.34f, 0.78f);
+        draw_box(1.8f, 1.8f, 1.8f);
+        glPopMatrix();
+    }
+}
+
+static void draw_story_boss_hud(const StoryBossState *boss) {
+    if (!boss || (!boss->active && !boss->defeated)) return;
+    float pct = (boss->max_health > 0.0f) ? (boss->health / boss->max_health) : 0.0f;
+    if (pct < 0.0f) pct = 0.0f;
+    if (pct > 1.0f) pct = 1.0f;
+    float x0 = 320.0f, x1 = 960.0f, y0 = 690.0f, y1 = 710.0f;
+    glColor4f(0.06f, 0.04f, 0.08f, 0.78f); glRectf(x0 - 8.0f, y0 - 10.0f, x1 + 8.0f, y1 + 10.0f);
+    glColor3f(0.25f, 0.10f, 0.16f); glRectf(x0, y0, x1, y1);
+    glColor3f(0.84f, 0.20f, 0.34f); glRectf(x0, y0, x0 + (x1 - x0) * pct, y1);
+    glColor3f(0.95f, 0.70f, 0.90f); draw_string("BREACH TITAN", 530, 714, 4);
+    if (boss->defeated) {
+        glColor3f(0.55f, 1.0f, 0.65f);
+        draw_string("DEFEATED", 600, 694, 4);
+    }
 }
 
 // --- NEW HELPER: Wireframe Circle ---
@@ -3320,19 +3401,20 @@ void draw_hud(PlayerState *p) {
     } else if (local_state.game_mode == MODE_STORY) {
         glColor3f(0.85f, 0.92f, 0.95f);
         if (local_state.story_phase == STORY_PHASE_CUTSCENE) {
-            draw_string("STORY: CAVE ENTRY", 500, 682, 6);
+            draw_string("STORY: VOXWORLD BREACH", 452, 682, 6);
             draw_string("INTRO IN PROGRESS...", 500, 658, 4);
         } else if (local_state.story_phase == STORY_PHASE_COMPLETE) {
             glColor3f(0.55f, 1.0f, 0.65f);
-            draw_string("STORY COMPLETE", 510, 682, 8);
+            draw_string("BREACH TITAN DEFEATED", 420, 682, 7);
             glColor3f(0.85f, 0.92f, 0.95f);
             draw_string("PRESS ESC TO RETURN", 500, 650, 4);
         } else if (local_state.story_phase == STORY_PHASE_FAILED) {
             glColor3f(1.0f, 0.45f, 0.35f);
             draw_string("MISSION FAILED", 520, 682, 7);
         } else {
-            draw_string("OBJECTIVE: REACH THE END OF THE CAVE", 410, 682, 4);
+            draw_string("OBJECTIVE: DEFEAT THE BREACH TITAN", 390, 682, 4);
         }
+        draw_story_boss_hud(&local_state.story_boss);
     }
     float x0 = 50.0f, x1 = vs0_art_direction_enabled ? 220.0f : 250.0f;
     float y_health0 = 50.0f, y_health1 = vs0_art_direction_enabled ? 66.0f : 70.0f;
@@ -3941,13 +4023,13 @@ void draw_scene(PlayerState *render_p) {
     }
 
     if (story_cutscene) {
-        float look_x = render_p->x;
-        float look_y = render_p->y + 3.0f;
-        float look_z = render_p->z;
-        float yaw_rad = (180.0f - render_p->yaw) * 0.0174533f;
-        float cam_x = look_x + sinf(yaw_rad) * 18.0f;
-        float cam_y = look_y + 3.0f;
-        float cam_z = look_z + cosf(yaw_rad) * 18.0f;
+        const StoryBossState *boss = &local_state.story_boss;
+        float look_x = boss->x;
+        float look_y = boss->y + 24.0f;
+        float look_z = boss->z;
+        float cam_x = boss->x + 140.0f;
+        float cam_y = boss->y + 70.0f;
+        float cam_z = boss->z + 190.0f;
         gluLookAt(cam_x, cam_y, cam_z, look_x, look_y, look_z, 0.0f, 1.0f, 0.0f);
     } else if (!(render_p->in_vehicle && render_p->vehicle_type == VEH_HELICOPTER)) {
         float draw_cam_pitch = lerpf(cam_pitch, -14.0f, death_cam_blend);
@@ -3991,6 +4073,9 @@ void draw_scene(PlayerState *render_p) {
         HelicopterState *h = &local_state.helicopters[hi];
         if (!h->active || h->scene_id != render_p->scene_id) continue;
         draw_helicopter_model(h);
+    }
+    if (local_state.game_mode == MODE_STORY && render_p->scene_id == SCENE_VOXWORLD) {
+        draw_story_boss_world(&local_state.story_boss, now_ms);
     }
     draw_projectiles();
     if (render_p->in_vehicle && render_p->vehicle_type != VEH_BUGGY) draw_player_3rd(render_p);
@@ -5256,7 +5341,8 @@ int main(int argc, char* argv[]) {
             } else {
                 if (local_state.game_mode == MODE_STORY &&
                     (local_state.story_phase == STORY_PHASE_CUTSCENE ||
-                     local_state.story_phase == STORY_PHASE_COMPLETE)) {
+                     local_state.story_phase == STORY_PHASE_COMPLETE ||
+                     local_state.story_phase == STORY_PHASE_FAILED)) {
                     fwd = 0.0f; str = 0.0f;
                     jump = 0; crouch = 0; shoot = 0; reload = 0; use = 0; ability = 0;
                 }
@@ -5327,13 +5413,6 @@ int main(int argc, char* argv[]) {
                     local_state.story_phase_start_ms = now_ms;
                 }
                 local_update(fwd, str, cam_yaw, cam_pitch, shoot, wpn_req, jump, crouch, reload, ability, NULL, now_ms);
-                if (local_state.game_mode == MODE_STORY && local_state.players[0].state == STATE_DEAD) {
-                    local_state.story_phase = STORY_PHASE_FAILED;
-                    local_init_match(1, MODE_STORY);
-                    local_state.story_phase_start_ms = SDL_GetTicks();
-                    cam_yaw = 0.0f;
-                    cam_pitch = 0.0f;
-                }
             }
             int render_pid = 0;
             if (app_state == STATE_GAME_NET &&

--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -293,6 +293,17 @@ typedef enum { MODE_DEATHMATCH=0, MODE_TDM=1, MODE_SURVIVAL=2, MODE_CTF=3, MODE_
 typedef enum { STORY_PHASE_CUTSCENE=0, STORY_PHASE_PLAYING=1, STORY_PHASE_COMPLETE=2, STORY_PHASE_FAILED=3 } StoryPhase;
 
 typedef struct {
+    int active;
+    int defeated;
+    float x, y, z;
+    float yaw;
+    float health;
+    float max_health;
+    unsigned int last_attack_ms;
+    unsigned int hurt_flash_until_ms;
+} StoryBossState;
+
+typedef struct {
     PlayerState players[MAX_CLIENTS];
     Projectile projectiles[MAX_PROJECTILES];
     HelicopterState helicopters[MAX_HELICOPTERS];
@@ -309,6 +320,7 @@ typedef struct {
     int winning_team;
     int story_phase;
     unsigned int story_phase_start_ms;
+    StoryBossState story_boss;
     CtfMatchState ctf;
     struct sockaddr_in clients[MAX_CLIENTS];
     ClientMeta client_meta[MAX_CLIENTS];

--- a/packages/simulation/local_game.h
+++ b/packages/simulation/local_game.h
@@ -25,29 +25,10 @@ static int tdmb_last_kills[MAX_CLIENTS];
 #define CTFB_CARRY_MELEE_DAMAGE 80
 #define CTFB_CARRY_MELEE_COOLDOWN_MS 450
 #define CTFB_RESPAWN_DEBUG_LOG 0
-#define STORY_BEAR_COUNT 7
-#define STORY_END_TRIGGER_Z 1210.0f
-#define STORY_END_TRIGGER_RADIUS 72.0f
 #define STORY_CUTSCENE_DURATION_MS 5000
-
-typedef enum {
-    STORY_BEAR_IDLE = 0,
-    STORY_BEAR_ALERTED = 1,
-    STORY_BEAR_CHASING = 2,
-    STORY_BEAR_ATTACKING = 3,
-    STORY_BEAR_DEAD = 4
-} StoryBearState;
-
-static const Vec2 story_bear_spawn_points[STORY_BEAR_COUNT] = {
-    { 0.0f, -760.0f },
-    {-38.0f, -340.0f },
-    { 42.0f, -280.0f },
-    { 60.0f, 130.0f },
-    {-36.0f, 420.0f },
-    { 28.0f, 780.0f },
-    {-42.0f, 910.0f }
-};
-static StoryBearState story_bear_states[MAX_CLIENTS];
+#define STORY_BOSS_ATTACK_MIN_MS 2500U
+#define STORY_BOSS_ATTACK_MAX_MS 4000U
+#define STORY_BOSS_ATTACK_RADIUS 125.0f
 
 static int mode_uses_team_scores(int mode) {
     return mode == MODE_TDM || mode == MODE_TDMB || mode == MODE_TDMO || mode == MODE_CTFB;
@@ -561,55 +542,95 @@ static void ctf_try_carry_melee(PlayerState *attacker, unsigned int now_ms) {
     phys_try_melee_strike(attacker, local_state.players, CTFB_CARRY_MELEE_DAMAGE, 16, 0, now_ms, mode_respawn_delay_ms(local_state.game_mode));
 }
 
-static void story_update_bear_state(PlayerState *bear, PlayerState *target, float dist) {
-    StoryBearState state = story_bear_states[bear->id];
-    if (bear->state == STATE_DEAD) {
-        story_bear_states[bear->id] = STORY_BEAR_DEAD;
-        return;
+static float story_boss_weapon_damage(int weapon) {
+    if (weapon >= 0 && weapon < MAX_WEAPONS) return (float)WPN_STATS[weapon].dmg;
+    return 8.0f;
+}
+
+static int story_boss_is_targeted(const PlayerState *hero, const StoryBossState *boss, float max_dist, float cone_dot) {
+    float to_x = boss->x - hero->x;
+    float to_y = (boss->y + 36.0f) - (hero->y + EYE_HEIGHT);
+    float to_z = boss->z - hero->z;
+    float dist = sqrtf(to_x * to_x + to_y * to_y + to_z * to_z);
+    if (dist <= 0.001f || dist > max_dist) return 0;
+    float r = -hero->yaw * 0.0174533f;
+    float rp = hero->pitch * 0.0174533f;
+    float fx = sinf(r) * cosf(rp);
+    float fy = sinf(rp);
+    float fz = -cosf(r) * cosf(rp);
+    float inv = 1.0f / dist;
+    float dot = fx * (to_x * inv) + fy * (to_y * inv) + fz * (to_z * inv);
+    return dot >= cone_dot;
+}
+
+static void story_boss_apply_player_hit(PlayerState *hero, unsigned int now_ms) {
+    StoryBossState *boss = &local_state.story_boss;
+    if (local_state.game_mode != MODE_STORY || local_state.story_phase != STORY_PHASE_PLAYING) return;
+    if (!boss->active || boss->defeated || hero->state == STATE_DEAD) return;
+    int weapon = hero->current_weapon;
+    float max_dist = 560.0f;
+    float cone_dot = 0.93f;
+    if (weapon == WPN_SNIPER) cone_dot = 0.88f;
+    else if (weapon == WPN_SHOTGUN) cone_dot = 0.95f;
+    else if (weapon == WPN_KNIFE || weapon == WPN_KATANA) {
+        max_dist = 24.0f;
+        cone_dot = 0.72f;
     }
-    switch (state) {
-        case STORY_BEAR_IDLE:
-            if (dist < 210.0f) story_bear_states[bear->id] = STORY_BEAR_ALERTED;
-            break;
-        case STORY_BEAR_ALERTED:
-            story_bear_states[bear->id] = (dist < 170.0f) ? STORY_BEAR_CHASING : STORY_BEAR_IDLE;
-            break;
-        case STORY_BEAR_CHASING:
-            if (dist < 9.0f) story_bear_states[bear->id] = STORY_BEAR_ATTACKING;
-            else if (dist > 280.0f) story_bear_states[bear->id] = STORY_BEAR_IDLE;
-            break;
-        case STORY_BEAR_ATTACKING:
-            if (dist > 12.0f) story_bear_states[bear->id] = STORY_BEAR_CHASING;
-            break;
-        case STORY_BEAR_DEAD:
-            break;
+    if (!story_boss_is_targeted(hero, boss, max_dist, cone_dot)) return;
+    float dmg = story_boss_weapon_damage(weapon);
+    boss->health -= dmg;
+    if (boss->health < 0.0f) boss->health = 0.0f;
+    boss->hurt_flash_until_ms = now_ms + 130;
+    static unsigned int next_damage_log_ms = 0;
+    if (now_ms >= next_damage_log_ms) {
+        printf("[STORY] boss damaged %.1f hp=%.1f/%.1f\n", dmg, boss->health, boss->max_health);
+        next_damage_log_ms = now_ms + 350;
     }
-    (void)target;
+    if (boss->health <= 0.0f) {
+        boss->defeated = 1;
+        boss->active = 0;
+        local_state.story_phase = STORY_PHASE_COMPLETE;
+        local_state.story_phase_start_ms = now_ms;
+        local_state.match_over = 1;
+        printf("[STORY] boss defeated\n");
+    }
+}
+
+static void story_boss_tick(PlayerState *hero, unsigned int now_ms) {
+    StoryBossState *boss = &local_state.story_boss;
+    if (local_state.game_mode != MODE_STORY || local_state.story_phase != STORY_PHASE_PLAYING) return;
+    if (!boss->active || boss->defeated || hero->state == STATE_DEAD) return;
+    unsigned int cooldown = STORY_BOSS_ATTACK_MIN_MS + (unsigned int)(((boss->x + boss->z) < 0.0f ? -boss->z : boss->z));
+    cooldown = STORY_BOSS_ATTACK_MIN_MS + (cooldown % (STORY_BOSS_ATTACK_MAX_MS - STORY_BOSS_ATTACK_MIN_MS + 1U));
+    if (now_ms - boss->last_attack_ms < cooldown) return;
+    boss->last_attack_ms = now_ms;
+    boss->hurt_flash_until_ms = now_ms + 180;
+    float dx = hero->x - boss->x;
+    float dz = hero->z - boss->z;
+    float dist = sqrtf(dx * dx + dz * dz);
+    if (dist <= STORY_BOSS_ATTACK_RADIUS) {
+        int damage = 26;
+        hero->shield_regen_timer = SHIELD_REGEN_DELAY;
+        if (hero->shield > 0) {
+            if (hero->shield >= damage) { hero->shield -= damage; damage = 0; }
+            else { damage -= hero->shield; hero->shield = 0; }
+        }
+        hero->health -= damage;
+        if (hero->health <= 0) {
+            hero->health = 0;
+            phys_enter_death_state(NULL, hero, now_ms, mode_respawn_delay_ms(local_state.game_mode), 0.0f, 0.0f);
+            local_state.story_phase = STORY_PHASE_FAILED;
+            local_state.story_phase_start_ms = now_ms;
+            local_state.match_over = 1;
+        }
+    }
 }
 
 // --- BOT AI ---
 void bot_think(int bot_idx, PlayerState *players, float *out_fwd, float *out_yaw, int *out_buttons) {
     PlayerState *me = &players[bot_idx];
     if (me->state == STATE_DEAD || local_state.match_over) { *out_buttons = 0; return; }
-    if (local_state.game_mode == MODE_STORY) {
-        PlayerState *hero = &players[0];
-        float dx = hero->x - me->x;
-        float dz = hero->z - me->z;
-        float dist = sqrtf(dx*dx + dz*dz);
-        float target_yaw = atan2f(dx, dz) * (180.0f / 3.14159f);
-        float diff = angle_diff(target_yaw, me->yaw);
-        if (diff > 7.0f) diff = 7.0f;
-        if (diff < -7.0f) diff = -7.0f;
-        *out_yaw = me->yaw + diff;
-        story_update_bear_state(me, hero, dist);
-        StoryBearState state = story_bear_states[bot_idx];
-        if (state == STORY_BEAR_ALERTED || state == STORY_BEAR_CHASING) *out_fwd = 0.9f;
-        if (state == STORY_BEAR_ATTACKING) {
-            me->current_weapon = WPN_KNIFE;
-            *out_buttons |= BTN_ATTACK;
-        }
-        return;
-    }
+    if (local_state.game_mode == MODE_STORY) { *out_buttons = 0; *out_fwd = 0.0f; *out_yaw = me->yaw; return; }
     if (local_state.game_mode == MODE_CTFB && local_state.ctf.active && team_id_is_valid(me->team_id)) {
         CtfBotObservation obs;
         build_ctf_bot_observation(bot_idx, &obs);
@@ -855,6 +876,10 @@ void local_update(float fwd, float str, float yaw, float pitch, int shoot, int w
                 local_state.story_phase = STORY_PHASE_PLAYING;
                 local_state.story_phase_start_ms = cmd_time;
             }
+            float dx = local_state.story_boss.x - p0->x;
+            float dz = local_state.story_boss.z - p0->z;
+            yaw = atan2f(dx, dz) * (180.0f / 3.14159f);
+            pitch = -5.0f;
         } else if (local_state.story_phase == STORY_PHASE_COMPLETE || local_state.story_phase == STORY_PHASE_FAILED) {
             fwd = 0.0f; str = 0.0f; shoot = 0; jump = 0; crouch = 0; reload = 0; ability = 0;
         }
@@ -1010,13 +1035,10 @@ void local_update(float fwd, float str, float yaw, float pitch, int shoot, int w
     buggy_tick_all();
     update_projectiles(cmd_time);
     if (local_state.game_mode == MODE_STORY && local_state.story_phase == STORY_PHASE_PLAYING) {
-        float ex = p0->x - 0.0f;
-        float ez = p0->z - STORY_END_TRIGGER_Z;
-        if (ex * ex + ez * ez <= STORY_END_TRIGGER_RADIUS * STORY_END_TRIGGER_RADIUS) {
-            local_state.story_phase = STORY_PHASE_COMPLETE;
-            local_state.story_phase_start_ms = cmd_time;
-            local_state.match_over = 1;
+        if (p0->is_shooting >= 5 || (p0->current_weapon == WPN_KNIFE && p0->in_shoot) || (p0->current_weapon == WPN_KATANA && p0->in_shoot)) {
+            story_boss_apply_player_hit(p0, cmd_time);
         }
+        story_boss_tick(p0, cmd_time);
     }
     if (local_state.game_mode == MODE_CTFB) {
         ctf_tick_flags(cmd_time);
@@ -1050,7 +1072,6 @@ void local_init_match(int num_players, int mode) {
     local_state.score_limit = (mode == MODE_TDMB || mode == MODE_TDMO) ? TDMB_SCORE_LIMIT : (mode == MODE_CTFB ? CTFB_SCORE_LIMIT : 0);
     local_state.story_phase = (mode == MODE_STORY) ? STORY_PHASE_CUTSCENE : STORY_PHASE_PLAYING;
     local_state.story_phase_start_ms = 0;
-    memset(story_bear_states, 0, sizeof(story_bear_states));
 
     if (mode == MODE_TDMB) {
         num_players = 1 + TDMB_BLUE_BOTS + TDMB_RED_BOTS;
@@ -1060,8 +1081,9 @@ void local_init_match(int num_players, int mode) {
         num_players = 1 + TDMB_BLUE_BOTS + TDMB_RED_BOTS;
         local_state.scene_id = SCENE_OIL_TANKER;
     } else if (mode == MODE_STORY) {
-        num_players = 1 + STORY_BEAR_COUNT;
-        local_state.scene_id = SCENE_STORY_CAVE;
+        num_players = 1;
+        local_state.scene_id = SCENE_VOXWORLD;
+        printf("[STORY] starting Voxworld boss encounter\n");
     } else {
         local_state.scene_id = SCENE_GARAGE_OSAKA;
     }
@@ -1093,21 +1115,22 @@ void local_init_match(int num_players, int mode) {
         local_state.players[i].carried_flag_team_id = -1;
         phys_respawn(&local_state.players[i], i*100);
         init_genome(&local_state.players[i].brain);
-        if (mode == MODE_STORY) {
-            int bear_slot = i - 1;
-            if (bear_slot >= 0 && bear_slot < STORY_BEAR_COUNT) {
-                local_state.players[i].x = story_bear_spawn_points[bear_slot].x;
-                local_state.players[i].z = story_bear_spawn_points[bear_slot].y;
-                local_state.players[i].y = 6.0f;
-                local_state.players[i].yaw = 180.0f;
-                local_state.players[i].current_weapon = WPN_KNIFE;
-                local_state.players[i].health = (bear_slot >= STORY_BEAR_COUNT - 2) ? 100 : 80;
-                local_state.players[i].shield = 0;
-                story_bear_states[i] = STORY_BEAR_IDLE;
-            }
-        }
     }
     scene_load(local_state.scene_id);
+    if (mode == MODE_STORY) {
+        StoryBossState *boss = &local_state.story_boss;
+        boss->active = 1;
+        boss->defeated = 0;
+        boss->x = 0.0f;
+        boss->z = -420.0f;
+        boss->y = voxworld_height_at(boss->x, boss->z) + 42.0f;
+        boss->yaw = 180.0f;
+        boss->max_health = 1000.0f;
+        boss->health = boss->max_health;
+        boss->last_attack_ms = 0;
+        boss->hurt_flash_until_ms = 0;
+        printf("[STORY] boss spawned at %.1f/%.1f/%.1f hp=%.1f\n", boss->x, boss->y, boss->z, boss->max_health);
+    }
     if (mode == MODE_CTFB) {
         ctf_init_match_state(local_state.scene_id);
         ctf_training_on_episode_begin();


### PR DESCRIPTION
### Motivation
- Replace the broken cave/bear based STORY flow with a fresh Voxworld boss prototype so STORY mode is playable and deterministic. 
- Provide a clean simulation-driven boss state and simple encounter loop that is safe to iterate on without preserving the old cave endpoint/bear wave logic.

### Description
- Add a `StoryBossState` to `ServerState` in `packages/common/protocol.h` to hold boss transform, HP, timers and flags and expose it to simulation and rendering. 
- Replace STORY routing/initialization in `packages/simulation/local_game.h` so `MODE_STORY` sets `local_state.scene_id = SCENE_VOXWORLD`, spawns a single player (`num_players = 1`), and initializes the boss at a canyon location with `max_health = 1000.0f`. 
- Remove the old cave completion trigger and bear-wave dependency by deleting usage of `STORY_END_TRIGGER_*`, `STORY_BEAR_COUNT`, bear spawn points and the bear AI progression path; bot AI now no-ops for `MODE_STORY`. 
- Implement simulation-side boss logic in `packages/simulation/local_game.h`: simple hit acceptance from player weapons, HP reduction, defeat handling that sets `STORY_PHASE_COMPLETE`, periodic boss AoE shockwave attack that damages the player, and small hurt/attack timing logs. 
- Add immediate-mode boss rendering and boss HUD in `apps/lobby/src/main.c`: large jagged low-poly titan composed with `draw_box` primitives, floating glitch cubes, telegraph ring, cutscene camera that frames the boss, and a top-center `BREACH TITAN` health bar; update HUD strings to `STORY: VOXWORLD BREACH`, `OBJECTIVE: DEFEAT THE BREACH TITAN`, and `BREACH TITAN DEFEATED`. 
- Ensure UI/scene plumbing maps any `STORY_CAVE` selection to `SCENE_VOXWORLD` so the old cave path is not used at runtime. 
- Add light logging: `[STORY] starting Voxworld boss encounter`, boss spawn log, damage logs and defeated log for developer visibility.

### Testing
- Ran a local build with `make -j2`; the lobby client build failed in this environment due to missing system SDL2 headers (`SDL2/SDL.h`, `SDL2/SDL_opengl.h`), not due to the story logic changes. 
- The server/logic portions were compiled as far as the toolchain allowed and produced only an unrelated unused-function warning, indicating the simulation changes are syntactically valid in this tree. 
- Manual code inspection and targeted `rg`/`sed` checks were used to verify old cave/bear flow was bypassed and the new boss spawn, HUD, rendering and hit logic are wired into the story update and render paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2a8f58a483278c5d18431285b7a7)