### PR TITLE
Decouple buggy camera yaw from body; improve third-person camera and steering

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -4222,14 +4222,13 @@ void draw_scene(PlayerState *render_p) {
             glTranslatef(-heli_cam_x, -heli_cam_y, -heli_cam_z);
         }
     } else {
-        float follow_yaw = cam_buggy ? cam_buggy->yaw : cam_yaw;
-        float cam_z_off = cam_buggy ? 16.5f : (render_p->in_vehicle ? 10.0f : lerpf(0.0f, 8.5f, death_cam_blend));
+        float follow_yaw = cam_yaw;
+        float cam_z_off = cam_buggy ? 26.0f : (render_p->in_vehicle ? 10.0f : lerpf(0.0f, 8.5f, death_cam_blend));
         float rad = -follow_yaw * 0.01745f;
         cx = sinf(rad) * cam_z_off;
         cz = cosf(rad) * cam_z_off;
         if (cam_buggy) {
-            cam_y = 5.2f;
-            cam_yaw = follow_yaw;
+            cam_y = 7.8f;
         }
     }
     
@@ -5131,7 +5130,6 @@ void net_process_snapshot(char *buffer, int len) {
                 occ->in_vehicle = 1;
                 occ->vehicle_type = VEH_BUGGY;
                 occ->x = b->x; occ->y = b->y; occ->z = b->z;
-                occ->yaw = b->yaw;
             }
         }
     }

--- a/packages/simulation/local_game.h
+++ b/packages/simulation/local_game.h
@@ -315,11 +315,16 @@ static inline void buggy_tick_all(void) {
         if (b->occupant_player_id >= 0 && b->occupant_player_id < MAX_CLIENTS) {
             PlayerState *occ = &local_state.players[b->occupant_player_id];
             b->scene_id = occ->scene_id;
+            /* While driving a buggy:
+               - occ->yaw is the driver's desired look/steer yaw (camera yaw target)
+               - b->yaw is the buggy body yaw */
             throttle = occ->in_fwd;
             float yaw_err = norm_yaw_deg(occ->yaw - b->yaw);
             if (yaw_err > 180.0f) yaw_err -= 360.0f;
             if (yaw_err < -180.0f) yaw_err += 360.0f;
-            steer_intent = yaw_err / 75.0f;
+            steer_intent = yaw_err / 50.0f;
+            float throttle_abs = fabsf(throttle);
+            if (throttle_abs < 0.05f) steer_intent = 0.0f;
             if (steer_intent > 1.0f) steer_intent = 1.0f;
             if (steer_intent < -1.0f) steer_intent = -1.0f;
         } else {
@@ -330,7 +335,6 @@ static inline void buggy_tick_all(void) {
         if (b->occupant_player_id >= 0 && b->occupant_player_id < MAX_CLIENTS) {
             PlayerState *occ = &local_state.players[b->occupant_player_id];
             occ->x = b->x; occ->y = b->y; occ->z = b->z;
-            occ->yaw = b->yaw;
             occ->vx = occ->vy = occ->vz = 0.0f;
             occ->on_ground = b->grounded;
         }


### PR DESCRIPTION
### Motivation
- The buggy camera was locked to the buggy body (`BuggyState.yaw`) so the mouse could not orbit independently, making camera and vehicle feel welded together.
- The steering logic overwrote the occupant view yaw with the buggy body yaw and used the occupant yaw as both camera and body source, destroying the independent desired steer target.
- The goal is to let `cam_yaw` (and the occupant desired yaw) remain independent, orbit the camera behind the buggy, and make the buggy steer toward that desired yaw with physical catch-up and near-idle damping.

### Description
- In `apps/lobby/src/main.c` the third-person buggy camera now orbits using `cam_yaw` instead of `cam_buggy->yaw`, increases the chase distance to `26.0f`, and raises camera height to `7.8f` so the whole buggy is visible, and removed forcing `cam_yaw = cam_buggy->yaw`.
- In `packages/simulation/local_game.h` steering now uses the occupant's desired yaw as the steering target and computes `steer_intent = yaw_err / 50.0f` (faster catch-up), with a near-idle guard that zeroes steering when `fabsf(throttle) < 0.05f` to prevent parked buggies spinning in place.
- The code stops overwriting the occupant view yaw with the buggy body yaw after simulation and during snapshot ingest so `occ->yaw` remains the camera/desired yaw while `b->yaw` remains the vehicle body yaw.
- Small clarifying comment added to explain the separation: `occ->yaw` = desired look/steer yaw, `b->yaw` = buggy body yaw.

### Testing
- Attempted a full build with `make` in this environment and it failed due to missing SDL2 development headers (`SDL2/SDL.h` and `SDL2/SDL_opengl.h`), so runtime/manual validation was not possible here (build failed).
- No other automated tests were available or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed394ea9108327bad70ddcf49dedc3)