### PR TITLE
Add lightweight cutscene runtime and Boss-Breach cutscene with puppet actors

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -3494,6 +3494,108 @@ static void draw_story_boss_world(const StoryBossState *boss, unsigned int now_m
     }
 }
 
+static void draw_story_cutscene_portal(const StoryPortalFx *portal, unsigned int now_ms) {
+    if (!portal || !portal->active) return;
+    float pulse = portal->pulse;
+    float ring_r = portal->radius;
+    glDisable(GL_CULL_FACE);
+    glPushMatrix();
+    glTranslatef(portal->x, portal->y, portal->z);
+    glRotatef(portal->spin_deg, 0, 1, 0);
+    glColor4f(0.95f, 0.12f + 0.25f * pulse, 0.78f, 0.35f + 0.4f * portal->open_alpha);
+    for (int ring = 0; ring < 3; ring++) {
+        float r = ring_r * (0.68f + (float)ring * 0.26f);
+        glBegin(GL_LINE_LOOP);
+        for (int i = 0; i < 48; i++) {
+            float a = ((float)i / 48.0f) * 6.28318f;
+            glVertex3f(cosf(a) * r, sinf(a * 2.0f + ring * 0.7f) * (3.0f + ring * 1.4f), sinf(a) * r);
+        }
+        glEnd();
+    }
+    glColor4f(0.75f, 0.08f + pulse * 0.40f, 0.95f, 0.22f + 0.28f * portal->open_alpha);
+    glBegin(GL_QUADS);
+    for (int i = 0; i < 16; i++) {
+        float a0 = ((float)i / 16.0f) * 6.28318f;
+        float a1 = ((float)(i + 1) / 16.0f) * 6.28318f;
+        float r0 = ring_r * 0.35f;
+        float r1 = ring_r * 0.95f;
+        glVertex3f(cosf(a0) * r0, -2.0f, sinf(a0) * r0);
+        glVertex3f(cosf(a0) * r1, 2.0f, sinf(a0) * r1);
+        glVertex3f(cosf(a1) * r1, 2.0f, sinf(a1) * r1);
+        glVertex3f(cosf(a1) * r0, -2.0f, sinf(a1) * r0);
+    }
+    glEnd();
+    for (int i = 0; i < 20; i++) {
+        float fi = (float)i;
+        float ang = fi * 0.93f + (float)now_ms * 0.0018f;
+        float rr = ring_r * (0.45f + 0.50f * (sinf(fi * 1.7f + (float)now_ms * 0.002f) * 0.5f + 0.5f));
+        glPushMatrix();
+        glTranslatef(cosf(ang) * rr, sinf(ang * 2.0f) * 6.5f, sinf(ang) * rr);
+        glColor3f((i % 3 == 0) ? 0.96f : 0.64f, 0.16f + 0.32f * pulse, 0.88f);
+        draw_box(2.2f, 2.2f, 2.2f);
+        glPopMatrix();
+    }
+    glPopMatrix();
+    glEnable(GL_CULL_FACE);
+}
+
+static void draw_story_cutscene_puppet(const StoryPuppetActor *p, unsigned int now_ms) {
+    if (!p || !p->active) return;
+    float pulse = 0.5f + 0.5f * sinf((float)now_ms * 0.008f + p->x * 0.03f);
+    glPushMatrix();
+    glTranslatef(p->x, p->y, p->z);
+    glRotatef(180.0f - norm_yaw_deg(p->yaw), 0, 1, 0);
+    glScalef(p->scale_x, p->scale_y, p->scale_z);
+    glColor3f(0.10f, 0.10f, 0.11f);
+    if (p->type == STORY_PUPPET_RIFT_HOUND) {
+        glPushMatrix(); glTranslatef(0.0f, 2.3f, 0.0f); draw_box(3.6f, 1.4f, 2.8f); glPopMatrix();
+        glPushMatrix(); glTranslatef(0.0f, 2.2f, 2.1f); draw_box(2.0f, 1.0f, 2.2f); glPopMatrix();
+        glColor3f(0.85f, 0.15f + pulse * 0.5f, 0.24f);
+        glPushMatrix(); glTranslatef(0.0f, 2.0f, 3.0f); draw_box(1.1f, 0.3f, 0.6f); glPopMatrix();
+        glColor3f(0.12f, 0.12f, 0.14f);
+        glPushMatrix(); glTranslatef(1.0f, 1.2f, 1.6f); draw_box(0.6f, 1.8f, 0.6f); glPopMatrix();
+        glPushMatrix(); glTranslatef(-1.0f, 1.2f, 1.6f); draw_box(0.6f, 1.8f, 0.6f); glPopMatrix();
+        glPushMatrix(); glTranslatef(1.3f, 1.1f, -1.5f); draw_box(0.5f, 1.7f, 0.5f); glPopMatrix();
+        glPushMatrix(); glTranslatef(-1.3f, 1.1f, -1.5f); draw_box(0.5f, 1.7f, 0.5f); glPopMatrix();
+    } else if (p->type == STORY_PUPPET_SHAMBLER_TROOPER) {
+        glPushMatrix(); glTranslatef(0.0f, 3.2f, 0.0f); draw_box(2.2f, 3.6f, 1.4f); glPopMatrix();
+        glPushMatrix(); glTranslatef(0.0f, 5.4f, 0.0f); draw_box(1.4f, 1.3f, 1.2f); glPopMatrix();
+        glPushMatrix(); glTranslatef(-1.6f, 3.4f, 0.0f); draw_box(0.8f, 2.4f, 0.8f); glPopMatrix();
+        glPushMatrix(); glTranslatef(1.9f, 2.9f, 0.0f); draw_box(1.2f, 3.1f, 1.0f); glPopMatrix();
+        glPushMatrix(); glTranslatef(-0.6f, 1.0f, 0.0f); draw_box(0.8f, 2.0f, 0.8f); glPopMatrix();
+        glPushMatrix(); glTranslatef(0.8f, 1.0f, 0.0f); draw_box(0.8f, 2.0f, 0.8f); glPopMatrix();
+    } else if (p->type == STORY_PUPPET_SHRIEKER) {
+        glPushMatrix(); glTranslatef(0.0f, 3.5f, 0.0f); draw_box(2.0f, 2.6f, 1.5f); glPopMatrix();
+        glColor3f(0.86f, 0.12f + pulse * 0.45f, 0.30f);
+        glPushMatrix(); glTranslatef(0.0f, 3.2f, 1.0f); draw_box(1.4f, 0.9f, 0.2f); glPopMatrix();
+        glColor3f(0.14f, 0.14f, 0.18f);
+        glPushMatrix(); glTranslatef(0.0f, 1.8f, 0.0f); draw_box(0.9f, 0.9f, 0.9f); glPopMatrix();
+    } else if (p->type == STORY_PUPPET_GORE_BRUTE) {
+        glPushMatrix(); glTranslatef(0.0f, 4.2f, 0.0f); draw_box(4.4f, 4.8f, 3.4f); glPopMatrix();
+        glPushMatrix(); glTranslatef(0.0f, 7.2f, 0.3f); draw_box(2.4f, 1.8f, 1.8f); glPopMatrix();
+        glPushMatrix(); glTranslatef(-2.7f, 4.0f, 0.0f); draw_box(1.1f, 3.4f, 1.1f); glPopMatrix();
+        glPushMatrix(); glTranslatef(3.1f, 3.5f, 0.0f); draw_box(1.8f, 4.6f, 1.6f); glPopMatrix();
+        glPushMatrix(); glTranslatef(-1.3f, 1.2f, 0.3f); draw_box(1.3f, 2.4f, 1.3f); glPopMatrix();
+        glPushMatrix(); glTranslatef(1.2f, 1.2f, 0.3f); draw_box(1.3f, 2.4f, 1.3f); glPopMatrix();
+    } else if (p->type == STORY_PUPPET_PORTAL_SHEPHERD) {
+        glPushMatrix(); glTranslatef(0.0f, 5.2f, 0.0f); draw_box(1.7f, 6.2f, 1.3f); glPopMatrix();
+        glColor3f(0.72f, 0.18f + pulse * 0.35f, 0.88f);
+        glPushMatrix(); glTranslatef(0.0f, 8.6f, 0.2f); draw_box(1.0f, 1.0f, 1.0f); glPopMatrix();
+        glColor3f(0.11f, 0.11f, 0.12f);
+        glPushMatrix(); glTranslatef(-1.2f, 5.0f, 0.0f); draw_box(0.4f, 3.5f, 0.4f); glPopMatrix();
+        glPushMatrix(); glTranslatef(1.2f, 5.0f, 0.0f); draw_box(0.4f, 3.5f, 0.4f); glPopMatrix();
+    }
+    glPopMatrix();
+}
+
+static void draw_story_cutscene_world(const StoryCutsceneState *cs, unsigned int now_ms) {
+    if (!cs) return;
+    draw_story_cutscene_portal(&cs->portal, now_ms);
+    for (int i = 0; i < STORY_CUTSCENE_MAX_PUPPETS; i++) {
+        draw_story_cutscene_puppet(&cs->puppets[i], now_ms);
+    }
+}
+
 static void draw_story_boss_hud(const StoryBossState *boss) {
     if (!boss || (!boss->active && !boss->defeated)) return;
     float pct = (boss->max_health > 0.0f) ? (boss->health / boss->max_health) : 0.0f;
@@ -3702,9 +3804,12 @@ void draw_hud(PlayerState *p) {
         }
     } else if (local_state.game_mode == MODE_STORY) {
         glColor3f(0.85f, 0.92f, 0.95f);
-        if (local_state.story_phase == STORY_PHASE_CUTSCENE) {
+        if (local_state.story_phase == STORY_PHASE_INTRO_CUTSCENE) {
             draw_string("STORY: VOXWORLD BREACH", 452, 682, 6);
             draw_string("INTRO IN PROGRESS...", 500, 658, 4);
+        } else if (local_state.story_phase == STORY_PHASE_POST_BOSS_BREACH_CUTSCENE) {
+            draw_string("STORY: MASSIVE PORTAL BREACH", 400, 682, 6);
+            draw_string("RIFT-BORN SPEW EVENT IN PROGRESS...", 380, 658, 4);
         } else if (local_state.story_phase == STORY_PHASE_COMPLETE) {
             glColor3f(0.55f, 1.0f, 0.65f);
             draw_string("BREACH TITAN DEFEATED", 420, 682, 7);
@@ -4261,7 +4366,9 @@ void draw_scene(PlayerState *render_p) {
     local_state.scene_id = render_p->scene_id;
     phys_set_scene(render_p->scene_id);
     unsigned int now_ms = SDL_GetTicks();
-    int story_cutscene = (local_state.game_mode == MODE_STORY && local_state.story_phase == STORY_PHASE_CUTSCENE);
+    int story_cutscene = (local_state.game_mode == MODE_STORY &&
+                          (local_state.story_phase == STORY_PHASE_INTRO_CUTSCENE ||
+                           local_state.story_phase == STORY_PHASE_POST_BOSS_BREACH_CUTSCENE));
     int local_dead = (render_p->state == STATE_DEAD);
     float death_target = (local_state.game_mode == MODE_STORY) ? 0.0f : (local_dead ? 1.0f : 0.0f);
     death_cam_blend += (death_target - death_cam_blend) * 0.18f;
@@ -4323,15 +4430,23 @@ void draw_scene(PlayerState *render_p) {
         reconcile_z = reconcile_corr_z;
     }
 
-    if (story_cutscene) {
-        const StoryBossState *boss = &local_state.story_boss;
-        float look_x = boss->x;
-        float look_y = boss->y + 24.0f;
-        float look_z = boss->z;
-        float cam_x = boss->x + 140.0f;
-        float cam_y = boss->y + 70.0f;
-        float cam_z = boss->z + 190.0f;
-        gluLookAt(cam_x, cam_y, cam_z, look_x, look_y, look_z, 0.0f, 1.0f, 0.0f);
+    if (story_cutscene && local_state.story_cutscene.camera.active) {
+        float shake_x = 0.0f;
+        float shake_y = 0.0f;
+        float shake_z = 0.0f;
+        if (local_state.story_cutscene.shake_amp > 0.01f) {
+            float amp = local_state.story_cutscene.shake_amp;
+            shake_x = sinf((float)now_ms * 0.048f) * amp;
+            shake_y = cosf((float)now_ms * 0.041f) * amp * 0.5f;
+            shake_z = sinf((float)now_ms * 0.053f) * amp;
+        }
+        gluLookAt(local_state.story_cutscene.camera.pos[0] + shake_x,
+                  local_state.story_cutscene.camera.pos[1] + shake_y,
+                  local_state.story_cutscene.camera.pos[2] + shake_z,
+                  local_state.story_cutscene.camera.look[0],
+                  local_state.story_cutscene.camera.look[1],
+                  local_state.story_cutscene.camera.look[2],
+                  0.0f, 1.0f, 0.0f);
     } else if (!(render_p->in_vehicle && render_p->vehicle_type == VEH_HELICOPTER)) {
         float draw_cam_pitch = lerpf(cam_pitch, -14.0f, death_cam_blend);
         glRotatef(-draw_cam_pitch, 1, 0, 0); glRotatef(-cam_yaw, 0, 1, 0);
@@ -4377,6 +4492,7 @@ void draw_scene(PlayerState *render_p) {
     }
     if (local_state.game_mode == MODE_STORY && render_p->scene_id == SCENE_VOXWORLD) {
         draw_story_boss_world(&local_state.story_boss, now_ms);
+        draw_story_cutscene_world(&local_state.story_cutscene, now_ms);
     }
     draw_projectiles();
     if (render_p->in_vehicle && render_p->vehicle_type != VEH_BUGGY) draw_player_3rd(render_p);
@@ -5541,7 +5657,8 @@ int main(int argc, char* argv[]) {
                     if (app_state == STATE_GAME_NET && net_spawn_protect_cmds > 0) continue;
                     if (app_state == STATE_GAME_LOCAL &&
                         local_state.game_mode == MODE_STORY &&
-                        local_state.story_phase == STORY_PHASE_CUTSCENE) {
+                        (local_state.story_phase == STORY_PHASE_INTRO_CUTSCENE ||
+                         local_state.story_phase == STORY_PHASE_POST_BOSS_BREACH_CUTSCENE)) {
                         continue;
                     }
                     float sens = (current_fov < 50.0f) ? 0.05f : 0.15f; 
@@ -5640,7 +5757,8 @@ int main(int argc, char* argv[]) {
                 net_emit_client_summaries(now_ms);
             } else {
                 if (local_state.game_mode == MODE_STORY &&
-                    (local_state.story_phase == STORY_PHASE_CUTSCENE ||
+                    (local_state.story_phase == STORY_PHASE_INTRO_CUTSCENE ||
+                     local_state.story_phase == STORY_PHASE_POST_BOSS_BREACH_CUTSCENE ||
                      local_state.story_phase == STORY_PHASE_COMPLETE ||
                      local_state.story_phase == STORY_PHASE_FAILED)) {
                     fwd = 0.0f; str = 0.0f;
@@ -5708,7 +5826,8 @@ int main(int argc, char* argv[]) {
                 if(local_state.players[0].vehicle_cooldown > 0) local_state.players[0].vehicle_cooldown--;
                 unsigned int now_ms = SDL_GetTicks();
                 if (local_state.game_mode == MODE_STORY &&
-                    local_state.story_phase == STORY_PHASE_CUTSCENE &&
+                    (local_state.story_phase == STORY_PHASE_INTRO_CUTSCENE ||
+                     local_state.story_phase == STORY_PHASE_POST_BOSS_BREACH_CUTSCENE) &&
                     local_state.story_phase_start_ms == 0) {
                     local_state.story_phase_start_ms = now_ms;
                 }

--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -290,7 +290,98 @@ typedef struct {
 } CtfMatchState;
 
 typedef enum { MODE_DEATHMATCH=0, MODE_TDM=1, MODE_SURVIVAL=2, MODE_CTF=3, MODE_ODDBALL=4, MODE_LOCAL=98, MODE_NET=99, MODE_EVOLUTION=100, MODE_TDMB=101, MODE_TDMO=102, MODE_CTFB=103, MODE_CTFO=104, MODE_STORY=105 } GameMode;
-typedef enum { STORY_PHASE_CUTSCENE=0, STORY_PHASE_PLAYING=1, STORY_PHASE_COMPLETE=2, STORY_PHASE_FAILED=3 } StoryPhase;
+typedef enum {
+    STORY_PHASE_INTRO_CUTSCENE = 0,
+    STORY_PHASE_BOSS_PLAYING = 1,
+    STORY_PHASE_POST_BOSS_BREACH_CUTSCENE = 2,
+    STORY_PHASE_COMPLETE = 3,
+    STORY_PHASE_FAILED = 4
+} StoryPhase;
+
+#define STORY_CUTSCENE_MAX_SHOTS 12
+#define STORY_CUTSCENE_MAX_PUPPETS 48
+
+typedef enum {
+    STORY_CUTSCENE_NONE = 0,
+    STORY_CUTSCENE_INTRO = 1,
+    STORY_CUTSCENE_BOSS_DEFEAT_BREACH = 2
+} StoryCutsceneId;
+
+typedef enum {
+    STORY_PUPPET_NONE = 0,
+    STORY_PUPPET_RIFT_HOUND = 1,
+    STORY_PUPPET_SHAMBLER_TROOPER = 2,
+    STORY_PUPPET_SHRIEKER = 3,
+    STORY_PUPPET_GORE_BRUTE = 4,
+    STORY_PUPPET_PORTAL_SHEPHERD = 5
+} StoryPuppetType;
+
+typedef enum {
+    STORY_PUPPET_MOVE_BURST = 0,
+    STORY_PUPPET_MOVE_HEAVY_WALK = 1,
+    STORY_PUPPET_MOVE_HOVER = 2,
+    STORY_PUPPET_MOVE_STOMP = 3,
+    STORY_PUPPET_MOVE_PRESENCE = 4
+} StoryPuppetMoveMode;
+
+typedef struct {
+    unsigned int start_ms;
+    unsigned int end_ms;
+    float start_pos[3];
+    float end_pos[3];
+    float start_look[3];
+    float end_look[3];
+    int lerp_mode;
+} StoryCutsceneShot;
+
+typedef struct {
+    int active;
+    int shot_index;
+    float pos[3];
+    float look[3];
+} StoryCutsceneCamera;
+
+typedef struct {
+    int active;
+    int type;
+    int move_mode;
+    float x, y, z;
+    float yaw;
+    float scale_x, scale_y, scale_z;
+    float base_y;
+    float vel_x, vel_y, vel_z;
+    float jitter_amp;
+    unsigned int spawn_time_ms;
+    unsigned int lifetime_ms;
+} StoryPuppetActor;
+
+typedef struct {
+    int active;
+    float x, y, z;
+    float radius;
+    float open_alpha;
+    float pulse;
+    float spin_deg;
+    float rupture_alpha;
+} StoryPortalFx;
+
+typedef struct {
+    int active;
+    int id;
+    unsigned int start_ms;
+    unsigned int elapsed_ms;
+    int finished;
+    int completion_marked;
+    int shot_count;
+    StoryCutsceneShot shots[STORY_CUTSCENE_MAX_SHOTS];
+    StoryCutsceneCamera camera;
+    StoryPortalFx portal;
+    int puppet_count;
+    StoryPuppetActor puppets[STORY_CUTSCENE_MAX_PUPPETS];
+    int event_flags;
+    float shake_amp;
+    float glow_pulse;
+} StoryCutsceneState;
 
 typedef struct {
     int active;
@@ -321,6 +412,7 @@ typedef struct {
     int story_phase;
     unsigned int story_phase_start_ms;
     StoryBossState story_boss;
+    StoryCutsceneState story_cutscene;
     CtfMatchState ctf;
     struct sockaddr_in clients[MAX_CLIENTS];
     ClientMeta client_meta[MAX_CLIENTS];

--- a/packages/simulation/local_game.h
+++ b/packages/simulation/local_game.h
@@ -25,7 +25,8 @@ static int tdmb_last_kills[MAX_CLIENTS];
 #define CTFB_CARRY_MELEE_DAMAGE 80
 #define CTFB_CARRY_MELEE_COOLDOWN_MS 450
 #define CTFB_RESPAWN_DEBUG_LOG 0
-#define STORY_CUTSCENE_DURATION_MS 5000
+#define STORY_INTRO_CUTSCENE_DURATION_MS 5000
+#define STORY_BREACH_CUTSCENE_DURATION_MS 20000
 #define STORY_BOSS_ATTACK_MIN_MS 2500U
 #define STORY_BOSS_ATTACK_MAX_MS 4000U
 #define STORY_BOSS_ATTACK_RADIUS 125.0f
@@ -546,6 +547,295 @@ static void ctf_try_carry_melee(PlayerState *attacker, unsigned int now_ms) {
     phys_try_melee_strike(attacker, local_state.players, CTFB_CARRY_MELEE_DAMAGE, 16, 0, now_ms, mode_respawn_delay_ms(local_state.game_mode));
 }
 
+static float story_cutscene_lerp(float a, float b, float t) {
+    return a + (b - a) * t;
+}
+
+static void story_cutscene_clear_runtime(StoryCutsceneState *cs) {
+    memset(cs, 0, sizeof(*cs));
+    cs->id = STORY_CUTSCENE_NONE;
+}
+
+static const char *story_cutscene_name(int id) {
+    switch (id) {
+        case STORY_CUTSCENE_INTRO: return "INTRO";
+        case STORY_CUTSCENE_BOSS_DEFEAT_BREACH: return "BOSS_DEFEAT_BREACH";
+        default: return "NONE";
+    }
+}
+
+static const char *story_puppet_name(int type) {
+    switch (type) {
+        case STORY_PUPPET_RIFT_HOUND: return "RIFT_HOUND";
+        case STORY_PUPPET_SHAMBLER_TROOPER: return "SHAMBLER_TROOPER";
+        case STORY_PUPPET_SHRIEKER: return "SHRIEKER";
+        case STORY_PUPPET_GORE_BRUTE: return "GORE_BRUTE";
+        case STORY_PUPPET_PORTAL_SHEPHERD: return "PORTAL_SHEPHERD";
+        default: return "UNKNOWN";
+    }
+}
+
+static void story_cutscene_set_shot(StoryCutsceneShot *shot,
+                                    unsigned int start_ms, unsigned int end_ms,
+                                    float sx, float sy, float sz,
+                                    float ex, float ey, float ez,
+                                    float slx, float sly, float slz,
+                                    float elx, float ely, float elz,
+                                    int lerp_mode) {
+    shot->start_ms = start_ms;
+    shot->end_ms = end_ms;
+    shot->start_pos[0] = sx; shot->start_pos[1] = sy; shot->start_pos[2] = sz;
+    shot->end_pos[0] = ex; shot->end_pos[1] = ey; shot->end_pos[2] = ez;
+    shot->start_look[0] = slx; shot->start_look[1] = sly; shot->start_look[2] = slz;
+    shot->end_look[0] = elx; shot->end_look[1] = ely; shot->end_look[2] = elz;
+    shot->lerp_mode = lerp_mode;
+}
+
+static StoryPuppetActor *story_cutscene_spawn_puppet(StoryCutsceneState *cs, int type, int move_mode,
+                                                      float x, float y, float z, float yaw,
+                                                      float scale_x, float scale_y, float scale_z,
+                                                      unsigned int now_ms, unsigned int lifetime_ms,
+                                                      float vel_x, float vel_y, float vel_z, float jitter_amp) {
+    for (int i = 0; i < STORY_CUTSCENE_MAX_PUPPETS; i++) {
+        StoryPuppetActor *p = &cs->puppets[i];
+        if (p->active) continue;
+        memset(p, 0, sizeof(*p));
+        p->active = 1;
+        p->type = type;
+        p->move_mode = move_mode;
+        p->x = x; p->y = y; p->z = z;
+        p->base_y = y;
+        p->yaw = yaw;
+        p->scale_x = scale_x; p->scale_y = scale_y; p->scale_z = scale_z;
+        p->spawn_time_ms = now_ms;
+        p->lifetime_ms = lifetime_ms;
+        p->vel_x = vel_x; p->vel_y = vel_y; p->vel_z = vel_z;
+        p->jitter_amp = jitter_amp;
+        cs->puppet_count++;
+        printf("[CUTSCENE] spawn puppet type=%s slot=%d\n", story_puppet_name(type), i);
+        return p;
+    }
+    return NULL;
+}
+
+static void story_cutscene_start_intro(unsigned int now_ms) {
+    StoryCutsceneState *cs = &local_state.story_cutscene;
+    story_cutscene_clear_runtime(cs);
+    cs->active = 1;
+    cs->id = STORY_CUTSCENE_INTRO;
+    cs->start_ms = now_ms;
+    cs->portal.active = 0;
+    cs->shot_count = 2;
+    StoryBossState *boss = &local_state.story_boss;
+    story_cutscene_set_shot(&cs->shots[0], 0, 2500,
+                            boss->x + 180.0f, boss->y + 88.0f, boss->z + 220.0f,
+                            boss->x + 180.0f, boss->y + 88.0f, boss->z + 220.0f,
+                            boss->x, boss->y + 24.0f, boss->z,
+                            boss->x, boss->y + 24.0f, boss->z, 0);
+    story_cutscene_set_shot(&cs->shots[1], 2500, STORY_INTRO_CUTSCENE_DURATION_MS,
+                            boss->x + 220.0f, boss->y + 120.0f, boss->z + 260.0f,
+                            boss->x + 150.0f, boss->y + 92.0f, boss->z + 180.0f,
+                            boss->x, boss->y + 30.0f, boss->z,
+                            boss->x, boss->y + 20.0f, boss->z, 1);
+    cs->camera.shot_index = -1;
+    printf("[CUTSCENE] start id=%s\n", story_cutscene_name(cs->id));
+}
+
+static void story_cutscene_start_breach(unsigned int now_ms) {
+    StoryCutsceneState *cs = &local_state.story_cutscene;
+    StoryBossState *boss = &local_state.story_boss;
+    story_cutscene_clear_runtime(cs);
+    cs->active = 1;
+    cs->id = STORY_CUTSCENE_BOSS_DEFEAT_BREACH;
+    cs->start_ms = now_ms;
+    cs->portal.active = 1;
+    cs->portal.x = boss->x;
+    cs->portal.y = boss->y + 140.0f;
+    cs->portal.z = boss->z - 40.0f;
+    cs->portal.radius = 5.0f;
+    cs->shot_count = 8;
+    cs->camera.shot_index = -1;
+
+    story_cutscene_set_shot(&cs->shots[0], 0, 1000,
+                            boss->x + 120.0f, boss->y + 65.0f, boss->z + 170.0f,
+                            boss->x + 120.0f, boss->y + 65.0f, boss->z + 170.0f,
+                            boss->x, boss->y + 20.0f, boss->z,
+                            boss->x, boss->y + 20.0f, boss->z, 0);
+    story_cutscene_set_shot(&cs->shots[1], 1000, 3000,
+                            boss->x + 170.0f, boss->y + 110.0f, boss->z + 260.0f,
+                            boss->x + 210.0f, boss->y + 140.0f, boss->z + 300.0f,
+                            cs->portal.x, cs->portal.y - 25.0f, cs->portal.z,
+                            cs->portal.x, cs->portal.y, cs->portal.z, 1);
+    story_cutscene_set_shot(&cs->shots[2], 3000, 6000,
+                            boss->x + 190.0f, boss->y + 120.0f, boss->z + 280.0f,
+                            boss->x + 110.0f, boss->y + 100.0f, boss->z + 215.0f,
+                            cs->portal.x, cs->portal.y, cs->portal.z,
+                            cs->portal.x, cs->portal.y, cs->portal.z, 1);
+    story_cutscene_set_shot(&cs->shots[3], 6000, 9000,
+                            boss->x + 70.0f, boss->y + 64.0f, boss->z + 145.0f,
+                            boss->x + 10.0f, boss->y + 52.0f, boss->z + 120.0f,
+                            boss->x + 20.0f, boss->y + 20.0f, boss->z + 20.0f,
+                            boss->x + 8.0f, boss->y + 20.0f, boss->z + 10.0f, 1);
+    story_cutscene_set_shot(&cs->shots[4], 9000, 12000,
+                            boss->x + 130.0f, boss->y + 80.0f, boss->z + 230.0f,
+                            boss->x + 75.0f, boss->y + 68.0f, boss->z + 182.0f,
+                            cs->portal.x, cs->portal.y - 10.0f, cs->portal.z,
+                            cs->portal.x, cs->portal.y - 8.0f, cs->portal.z, 1);
+    story_cutscene_set_shot(&cs->shots[5], 12000, 15000,
+                            boss->x + 90.0f, boss->y + 70.0f, boss->z + 165.0f,
+                            boss->x + 60.0f, boss->y + 64.0f, boss->z + 146.0f,
+                            boss->x + 16.0f, boss->y + 20.0f, boss->z + 20.0f,
+                            boss->x + 10.0f, boss->y + 20.0f, boss->z + 20.0f, 1);
+    story_cutscene_set_shot(&cs->shots[6], 15000, 18000,
+                            boss->x + 165.0f, boss->y + 100.0f, boss->z + 220.0f,
+                            boss->x + 122.0f, boss->y + 90.0f, boss->z + 190.0f,
+                            cs->portal.x, cs->portal.y + 10.0f, cs->portal.z,
+                            cs->portal.x, cs->portal.y + 8.0f, cs->portal.z, 1);
+    story_cutscene_set_shot(&cs->shots[7], 18000, STORY_BREACH_CUTSCENE_DURATION_MS,
+                            boss->x + 160.0f, boss->y + 92.0f, boss->z + 215.0f,
+                            boss->x + 138.0f, boss->y + 88.0f, boss->z + 205.0f,
+                            cs->portal.x, cs->portal.y + 6.0f, cs->portal.z,
+                            cs->portal.x, cs->portal.y + 6.0f, cs->portal.z, 1);
+    printf("[CUTSCENE] start id=%s\n", story_cutscene_name(cs->id));
+}
+
+static void story_cutscene_update(unsigned int now_ms) {
+    StoryCutsceneState *cs = &local_state.story_cutscene;
+    if (!cs->active) return;
+    cs->elapsed_ms = now_ms - cs->start_ms;
+    unsigned int t_ms = cs->elapsed_ms;
+
+    int shot_index = cs->shot_count - 1;
+    for (int i = 0; i < cs->shot_count; i++) {
+        if (t_ms >= cs->shots[i].start_ms && t_ms < cs->shots[i].end_ms) {
+            shot_index = i;
+            break;
+        }
+    }
+    if (shot_index != cs->camera.shot_index) {
+        cs->camera.shot_index = shot_index;
+        printf("[CUTSCENE] shot change id=%s shot=%d\n", story_cutscene_name(cs->id), shot_index);
+    }
+
+    StoryCutsceneShot *shot = &cs->shots[shot_index];
+    float t = 0.0f;
+    if (shot->end_ms > shot->start_ms) {
+        t = (float)(t_ms - shot->start_ms) / (float)(shot->end_ms - shot->start_ms);
+        if (t < 0.0f) t = 0.0f;
+        if (t > 1.0f) t = 1.0f;
+    }
+    cs->camera.active = 1;
+    if (shot->lerp_mode) {
+        for (int k = 0; k < 3; k++) {
+            cs->camera.pos[k] = story_cutscene_lerp(shot->start_pos[k], shot->end_pos[k], t);
+            cs->camera.look[k] = story_cutscene_lerp(shot->start_look[k], shot->end_look[k], t);
+        }
+    } else {
+        for (int k = 0; k < 3; k++) {
+            cs->camera.pos[k] = shot->start_pos[k];
+            cs->camera.look[k] = shot->start_look[k];
+        }
+    }
+
+    cs->shake_amp = 0.0f;
+    cs->glow_pulse = 0.0f;
+    if (cs->id == STORY_CUTSCENE_BOSS_DEFEAT_BREACH) {
+        StoryPortalFx *portal = &cs->portal;
+        if (t_ms >= 1000 && t_ms < 3000) {
+            float stage = (float)(t_ms - 1000) / 2000.0f;
+            portal->rupture_alpha = stage;
+            portal->open_alpha = stage * 0.35f;
+            portal->radius = 7.0f + stage * 20.0f;
+            cs->shake_amp = 1.8f + stage * 2.4f;
+            cs->glow_pulse = stage;
+        } else if (t_ms >= 3000) {
+            float stage = (float)(t_ms - 3000) / 3000.0f;
+            if (stage > 1.0f) stage = 1.0f;
+            portal->rupture_alpha = 1.0f;
+            portal->open_alpha = 0.35f + stage * 0.65f;
+            portal->radius = 27.0f + stage * 45.0f;
+            cs->glow_pulse = 0.7f + 0.3f * sinf((float)t_ms * 0.01f);
+        }
+        if (t_ms >= 12000 && t_ms < 15000) cs->shake_amp = 2.8f;
+        portal->pulse = 0.5f + 0.5f * sinf((float)t_ms * 0.0085f);
+        portal->spin_deg += 0.28f + portal->open_alpha * 1.2f;
+
+        StoryBossState *boss = &local_state.story_boss;
+        if ((cs->event_flags & 1) == 0 && t_ms >= 6000) {
+            cs->event_flags |= 1;
+            for (int i = 0; i < 8; i++) {
+                float lane = (float)i - 3.5f;
+                story_cutscene_spawn_puppet(cs, STORY_PUPPET_RIFT_HOUND, STORY_PUPPET_MOVE_BURST,
+                                            boss->x + lane * 5.6f, voxworld_height_at(boss->x + lane * 5.6f, boss->z + 26.0f) + 2.5f, boss->z + 26.0f,
+                                            180.0f, 1.0f, 1.0f, 1.0f, now_ms, 11000,
+                                            lane * 0.16f, 0.0f, 7.0f + ((i % 2) ? 0.9f : -0.5f), 0.7f);
+            }
+        }
+        if ((cs->event_flags & 2) == 0 && t_ms >= 9000) {
+            cs->event_flags |= 2;
+            for (int i = 0; i < 5; i++) {
+                float lane = (float)i - 2.0f;
+                story_cutscene_spawn_puppet(cs, STORY_PUPPET_SHAMBLER_TROOPER, STORY_PUPPET_MOVE_HEAVY_WALK,
+                                            boss->x + lane * 9.0f, voxworld_height_at(boss->x + lane * 9.0f, boss->z + 28.0f) + 3.5f, boss->z + 28.0f,
+                                            180.0f, 1.25f, 1.25f, 1.25f, now_ms, 12000,
+                                            lane * 0.08f, 0.0f, 3.3f, 0.0f);
+            }
+            for (int i = 0; i < 3; i++) {
+                float side = (i == 0) ? -1.0f : (i == 1 ? 1.0f : 0.0f);
+                story_cutscene_spawn_puppet(cs, STORY_PUPPET_SHRIEKER, STORY_PUPPET_MOVE_HOVER,
+                                            boss->x + side * 34.0f, boss->y + 88.0f + (float)i * 7.0f, boss->z + 8.0f + (float)i * 8.0f,
+                                            180.0f, 1.12f, 1.12f, 1.12f, now_ms, 12000,
+                                            side * 0.45f, 0.0f, 0.3f + 0.2f * (float)i, 0.0f);
+            }
+        }
+        if ((cs->event_flags & 4) == 0 && t_ms >= 12000) {
+            cs->event_flags |= 4;
+            story_cutscene_spawn_puppet(cs, STORY_PUPPET_GORE_BRUTE, STORY_PUPPET_MOVE_STOMP,
+                                        boss->x + 8.0f, voxworld_height_at(boss->x + 8.0f, boss->z + 32.0f) + 4.8f, boss->z + 32.0f,
+                                        180.0f, 1.9f, 1.9f, 1.9f, now_ms, 12000,
+                                        0.0f, 0.0f, 2.2f, 0.0f);
+        }
+        if ((cs->event_flags & 8) == 0 && t_ms >= 15000) {
+            cs->event_flags |= 8;
+            story_cutscene_spawn_puppet(cs, STORY_PUPPET_PORTAL_SHEPHERD, STORY_PUPPET_MOVE_PRESENCE,
+                                        boss->x, boss->y + 84.0f, boss->z + 2.0f,
+                                        180.0f, 1.5f, 1.5f, 1.5f, now_ms, 12000,
+                                        0.0f, 0.2f, 0.0f, 0.0f);
+        }
+    }
+
+    for (int i = 0; i < STORY_CUTSCENE_MAX_PUPPETS; i++) {
+        StoryPuppetActor *p = &cs->puppets[i];
+        if (!p->active) continue;
+        unsigned int alive_ms = now_ms - p->spawn_time_ms;
+        if (p->lifetime_ms > 0 && alive_ms >= p->lifetime_ms) {
+            p->active = 0;
+            continue;
+        }
+        float dt = SHANKPIT_NET_FIXED_DT;
+        p->x += p->vel_x * dt;
+        p->z += p->vel_z * dt;
+        if (p->move_mode == STORY_PUPPET_MOVE_BURST) {
+            p->x += sinf((float)alive_ms * 0.03f + (float)i) * p->jitter_amp * 0.08f;
+        } else if (p->move_mode == STORY_PUPPET_MOVE_HOVER) {
+            p->y = p->base_y + sinf((float)alive_ms * 0.007f + (float)i) * 2.6f;
+        } else if (p->move_mode == STORY_PUPPET_MOVE_STOMP) {
+            p->y = p->base_y + fabsf(sinf((float)alive_ms * 0.0045f)) * 1.5f;
+        } else if (p->move_mode == STORY_PUPPET_MOVE_PRESENCE) {
+            p->y = p->base_y + sinf((float)alive_ms * 0.0035f) * 1.4f;
+        }
+    }
+
+    if (!cs->finished) {
+        unsigned int end_ms = (cs->id == STORY_CUTSCENE_INTRO) ? STORY_INTRO_CUTSCENE_DURATION_MS : STORY_BREACH_CUTSCENE_DURATION_MS;
+        if (t_ms >= end_ms) {
+            cs->finished = 1;
+            cs->active = 0;
+            printf("[CUTSCENE] finished id=%s\n", story_cutscene_name(cs->id));
+        }
+    }
+}
+
 static float story_boss_weapon_damage(int weapon) {
     if (weapon >= 0 && weapon < MAX_WEAPONS) return (float)WPN_STATS[weapon].dmg;
     return 8.0f;
@@ -569,7 +859,7 @@ static int story_boss_is_targeted(const PlayerState *hero, const StoryBossState 
 
 static void story_boss_apply_player_hit(PlayerState *hero, unsigned int now_ms) {
     StoryBossState *boss = &local_state.story_boss;
-    if (local_state.game_mode != MODE_STORY || local_state.story_phase != STORY_PHASE_PLAYING) return;
+    if (local_state.game_mode != MODE_STORY || local_state.story_phase != STORY_PHASE_BOSS_PLAYING) return;
     if (!boss->active || boss->defeated || hero->state == STATE_DEAD) return;
     int weapon = hero->current_weapon;
     float max_dist = 560.0f;
@@ -593,16 +883,16 @@ static void story_boss_apply_player_hit(PlayerState *hero, unsigned int now_ms) 
     if (boss->health <= 0.0f) {
         boss->defeated = 1;
         boss->active = 0;
-        local_state.story_phase = STORY_PHASE_COMPLETE;
+        local_state.story_phase = STORY_PHASE_POST_BOSS_BREACH_CUTSCENE;
         local_state.story_phase_start_ms = now_ms;
-        local_state.match_over = 1;
-        printf("[STORY] boss defeated\n");
+        story_cutscene_start_breach(now_ms);
+        printf("[STORY] boss defeated -> breach cutscene\n");
     }
 }
 
 static void story_boss_tick(PlayerState *hero, unsigned int now_ms) {
     StoryBossState *boss = &local_state.story_boss;
-    if (local_state.game_mode != MODE_STORY || local_state.story_phase != STORY_PHASE_PLAYING) return;
+    if (local_state.game_mode != MODE_STORY || local_state.story_phase != STORY_PHASE_BOSS_PLAYING) return;
     if (!boss->active || boss->defeated || hero->state == STATE_DEAD) return;
     unsigned int cooldown = STORY_BOSS_ATTACK_MIN_MS + (unsigned int)(((boss->x + boss->z) < 0.0f ? -boss->z : boss->z));
     cooldown = STORY_BOSS_ATTACK_MIN_MS + (cooldown % (STORY_BOSS_ATTACK_MAX_MS - STORY_BOSS_ATTACK_MIN_MS + 1U));
@@ -874,16 +1164,38 @@ static void update_projectiles(unsigned int now_ms) {
 void local_update(float fwd, float str, float yaw, float pitch, int shoot, int weapon_req, int jump, int crouch, int reload, int ability, void *server_context, unsigned int cmd_time) {
     PlayerState *p0 = &local_state.players[0];
     if (local_state.game_mode == MODE_STORY) {
-        if (local_state.story_phase == STORY_PHASE_CUTSCENE) {
-            fwd = 0.0f; str = 0.0f; shoot = 0; jump = 0; crouch = 0; reload = 0; ability = 0;
-            if (cmd_time - local_state.story_phase_start_ms >= STORY_CUTSCENE_DURATION_MS) {
-                local_state.story_phase = STORY_PHASE_PLAYING;
-                local_state.story_phase_start_ms = cmd_time;
+        if (local_state.story_phase_start_ms == 0) {
+            local_state.story_phase_start_ms = cmd_time;
+            if (local_state.story_cutscene.active && local_state.story_cutscene.start_ms == 0) {
+                local_state.story_cutscene.start_ms = cmd_time;
             }
-            float dx = local_state.story_boss.x - p0->x;
-            float dz = local_state.story_boss.z - p0->z;
-            yaw = atan2f(dx, dz) * (180.0f / 3.14159f);
-            pitch = -5.0f;
+        }
+        if (local_state.story_phase == STORY_PHASE_INTRO_CUTSCENE ||
+            local_state.story_phase == STORY_PHASE_POST_BOSS_BREACH_CUTSCENE) {
+            fwd = 0.0f; str = 0.0f; shoot = 0; jump = 0; crouch = 0; reload = 0; ability = 0;
+            story_cutscene_update(cmd_time);
+            if (local_state.story_cutscene.camera.active) {
+                float dx = local_state.story_cutscene.camera.look[0] - p0->x;
+                float dz = local_state.story_cutscene.camera.look[2] - p0->z;
+                yaw = atan2f(dx, dz) * (180.0f / 3.14159f);
+            }
+            if (local_state.story_phase == STORY_PHASE_INTRO_CUTSCENE &&
+                local_state.story_cutscene.finished &&
+                local_state.story_cutscene.id == STORY_CUTSCENE_INTRO) {
+                local_state.story_phase = STORY_PHASE_BOSS_PLAYING;
+                local_state.story_phase_start_ms = cmd_time;
+                printf("[STORY] intro cutscene complete -> boss phase\n");
+            }
+            if (local_state.story_phase == STORY_PHASE_POST_BOSS_BREACH_CUTSCENE &&
+                local_state.story_cutscene.finished &&
+                local_state.story_cutscene.id == STORY_CUTSCENE_BOSS_DEFEAT_BREACH &&
+                !local_state.story_cutscene.completion_marked) {
+                local_state.story_cutscene.completion_marked = 1;
+                local_state.story_phase = STORY_PHASE_COMPLETE;
+                local_state.story_phase_start_ms = cmd_time;
+                local_state.match_over = 1;
+                printf("[STORY] breach cutscene complete -> story complete\n");
+            }
         } else if (local_state.story_phase == STORY_PHASE_COMPLETE || local_state.story_phase == STORY_PHASE_FAILED) {
             fwd = 0.0f; str = 0.0f; shoot = 0; jump = 0; crouch = 0; reload = 0; ability = 0;
         }
@@ -901,7 +1213,9 @@ void local_update(float fwd, float str, float yaw, float pitch, int shoot, int w
         reload = 0;
         ability = 0;
     }
-    if (!(local_state.game_mode == MODE_STORY && local_state.story_phase == STORY_PHASE_CUTSCENE)) {
+    if (!(local_state.game_mode == MODE_STORY &&
+          (local_state.story_phase == STORY_PHASE_INTRO_CUTSCENE ||
+           local_state.story_phase == STORY_PHASE_POST_BOSS_BREACH_CUTSCENE))) {
         p0->yaw = yaw; p0->pitch = pitch;
     }
     p0->in_fwd = fwd;
@@ -1038,7 +1352,7 @@ void local_update(float fwd, float str, float yaw, float pitch, int shoot, int w
     }
     buggy_tick_all();
     update_projectiles(cmd_time);
-    if (local_state.game_mode == MODE_STORY && local_state.story_phase == STORY_PHASE_PLAYING) {
+    if (local_state.game_mode == MODE_STORY && local_state.story_phase == STORY_PHASE_BOSS_PLAYING) {
         if (p0->is_shooting >= 5 || (p0->current_weapon == WPN_KNIFE && p0->in_shoot) || (p0->current_weapon == WPN_KATANA && p0->in_shoot)) {
             story_boss_apply_player_hit(p0, cmd_time);
         }
@@ -1074,8 +1388,9 @@ void local_init_match(int num_players, int mode) {
     local_state.transition_timer = 0;
     local_state.winning_team = -1;
     local_state.score_limit = (mode == MODE_TDMB || mode == MODE_TDMO) ? TDMB_SCORE_LIMIT : (mode == MODE_CTFB ? CTFB_SCORE_LIMIT : 0);
-    local_state.story_phase = (mode == MODE_STORY) ? STORY_PHASE_CUTSCENE : STORY_PHASE_PLAYING;
+    local_state.story_phase = (mode == MODE_STORY) ? STORY_PHASE_INTRO_CUTSCENE : STORY_PHASE_BOSS_PLAYING;
     local_state.story_phase_start_ms = 0;
+    story_cutscene_clear_runtime(&local_state.story_cutscene);
 
     if (mode == MODE_TDMB) {
         num_players = 1 + TDMB_BLUE_BOTS + TDMB_RED_BOTS;
@@ -1134,6 +1449,7 @@ void local_init_match(int num_players, int mode) {
         boss->last_attack_ms = 0;
         boss->hurt_flash_until_ms = 0;
         printf("[STORY] boss spawned at %.1f/%.1f/%.1f hp=%.1f\n", boss->x, boss->y, boss->z, boss->max_health);
+        story_cutscene_start_intro(0);
     }
     if (mode == MODE_CTFB) {
         ctf_init_match_state(local_state.scene_id);


### PR DESCRIPTION
### Motivation
- Replace the existing one-off boss-cutscene behavior with a small reusable in-engine cutscene runtime to drive authored camera shots, visual-only puppet actors, and timed VFX beats. 
- Transition boss defeat into a staged post-boss breach sequence (portal rupture → waves → escalation) instead of immediately ending the story. 
- Keep puppets separate from gameplay systems so the feature is safe, scoped, and easy to extend for future cinematic beats. 

### Description
- Added a compact cutscene data model and puppet/portal types to `ServerState` in `packages/common/protocol.h`, including shot lists, camera override, portal FX and puppet actor slots. 
- Implemented cutscene orchestration, shot interpolation, puppet spawn/update logic, portal escalation and event timing in `packages/simulation/local_game.h`, and wired boss defeat to start the new `BOSS_DEFEAT_BREACH` cutscene instead of completing immediately. 
- Added render routines and camera override integration in `apps/lobby/src/main.c` to draw the portal, simple primitive-based puppet silhouettes (Rift Hound, Shambler Trooper, Shrieker, Gore Brute, Portal Shepherd), and to use shot-driven camera positions with shake. 
- Updated story phase enum and flow to explicit phases `INTRO_CUTSCENE`, `BOSS_PLAYING`, `POST_BOSS_BREACH_CUTSCENE`, `COMPLETE`, and `FAILED`, and locked input / camera during both cutscene phases. 
- Files changed: `packages/common/protocol.h`, `packages/simulation/local_game.h`, and `apps/lobby/src/main.c`.

### Testing
- Attempted a build with `make lobby` to validate compile and integration, but the build failed in this environment due to missing SDL2/OpenGL development headers (`SDL2/SDL.h`, `SDL2/SDL_opengl.h`). 
- No unit test changes were required and no automated test suite was executed beyond the attempted build. 
- Runtime logging was added to the cutscene path (`[CUTSCENE] start/shot change/spawn/finished` and `[STORY] boss defeated -> breach cutscene`) to aid verification during manual runs and CI once SDL/OpenGL are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eea96c3e4483278d45129e5f64623b)