### PR TITLE
Add Stage 1 story rift & portal-swarm phase after Voxworld boss defeat

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -3510,6 +3510,98 @@ static void draw_story_boss_hud(const StoryBossState *boss) {
     }
 }
 
+static void draw_story_rift_world(const StoryRiftState *rift, unsigned int now_ms, int phase) {
+    if (!rift || !rift->active) return;
+    float phase_t = 1.0f;
+    if (phase == STORY_PHASE_RIFT_OPENING) {
+        float d = (float)(now_ms - rift->opened_ms) / 1200.0f;
+        if (d < 0.0f) d = 0.0f;
+        if (d > 1.0f) d = 1.0f;
+        phase_t = d;
+    }
+    float pulse = 0.55f + 0.45f * sinf((float)(now_ms + rift->pulse_seed) * 0.006f);
+    float rad = (rift->radius > 4.0f ? rift->radius : 4.0f) * (0.45f + 0.55f * phase_t);
+
+    glDisable(GL_CULL_FACE);
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+    glColor4f(0.35f + pulse * 0.35f, 0.08f + pulse * 0.15f, 0.65f + pulse * 0.22f, 0.45f);
+    glBegin(GL_TRIANGLE_FAN);
+    glVertex3f(rift->x, rift->y + 8.0f, rift->z);
+    for (int i = 0; i <= 48; i++) {
+        float a = ((float)i / 48.0f) * 6.28318f;
+        float wobble = 1.0f + 0.16f * sinf(a * 5.0f + now_ms * 0.008f);
+        glVertex3f(rift->x + cosf(a) * rad * wobble, rift->y + 8.0f, rift->z + sinf(a) * rad * wobble);
+    }
+    glEnd();
+
+    glColor4f(0.9f, 0.35f, 1.0f, 0.8f);
+    glBegin(GL_LINE_LOOP);
+    for (int i = 0; i < 40; i++) {
+        float a = ((float)i / 40.0f) * 6.28318f;
+        glVertex3f(rift->x + cosf(a) * (rad + 10.0f), rift->y + 10.0f + sinf(a * 3.0f + now_ms * 0.01f) * 4.0f, rift->z + sinf(a) * (rad + 10.0f));
+    }
+    glEnd();
+
+    if (now_ms - rift->last_spew_ms < 360U) {
+        float spew_t = (float)(now_ms - rift->last_spew_ms) / 360.0f;
+        if (spew_t < 0.0f) spew_t = 0.0f;
+        if (spew_t > 1.0f) spew_t = 1.0f;
+        for (int i = 0; i < 16; i++) {
+            float fi = (float)i;
+            float a = fi * 0.392f + now_ms * 0.004f;
+            float d = (8.0f + fi * 1.8f) * spew_t;
+            glColor4f(1.0f, 0.42f + 0.02f * fi, 0.2f, 0.9f * (1.0f - spew_t));
+            glPushMatrix();
+            glTranslatef(rift->x + cosf(a) * d, rift->y + 10.0f + fi * 0.6f * spew_t, rift->z + sinf(a) * d);
+            draw_box(1.4f, 1.4f, 1.4f);
+            glPopMatrix();
+        }
+    }
+
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glDisable(GL_BLEND);
+    glEnable(GL_CULL_FACE);
+}
+
+static void draw_story_swarm_enemy_world(const StoryEnemy *enemy, unsigned int now_ms) {
+    if (!enemy || !enemy->active) return;
+    float pulse = 0.45f + 0.55f * sinf((float)(now_ms - enemy->spawn_ms) * 0.01f);
+    int hurt = now_ms < enemy->hurt_flash_until_ms;
+    glPushMatrix();
+    glTranslatef(enemy->x, enemy->y + enemy->height * 0.5f, enemy->z);
+    glRotatef(180.0f - norm_yaw_deg(enemy->yaw), 0, 1, 0);
+
+    float body_r = hurt ? 0.9f : 0.22f;
+    float body_g = hurt ? 0.2f : 0.16f;
+    float body_b = hurt ? 0.2f : 0.28f;
+    glColor3f(body_r, body_g, body_b);
+    if (enemy->type == STORY_ENEMY_RIFT_HOUND) {
+        draw_box(14.0f, 10.0f, 24.0f);
+        glPushMatrix(); glTranslatef(0.0f, 5.5f, 10.0f); draw_box(10.0f, 8.0f, 12.0f); glPopMatrix();
+    } else if (enemy->type == STORY_ENEMY_SHAMBLER_TROOPER) {
+        draw_box(16.0f, 24.0f, 12.0f);
+        glPushMatrix(); glTranslatef(0.0f, 16.0f, 0.0f); draw_box(12.0f, 10.0f, 10.0f); glPopMatrix();
+    } else {
+        draw_box(24.0f, 34.0f, 20.0f);
+        glPushMatrix(); glTranslatef(0.0f, 20.0f, 0.0f); draw_box(16.0f, 12.0f, 14.0f); glPopMatrix();
+    }
+
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+    glColor4f(0.95f, 0.2f + pulse * 0.5f, 1.0f, 0.5f);
+    glBegin(GL_LINES);
+    for (int i = 0; i < 8; i++) {
+        float x = -6.0f + i * 1.7f;
+        glVertex3f(x, -enemy->height * 0.3f, 0.5f);
+        glVertex3f(x + 1.0f, enemy->height * 0.3f, -0.5f);
+    }
+    glEnd();
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glDisable(GL_BLEND);
+    glPopMatrix();
+}
+
 // --- NEW HELPER: Wireframe Circle ---
 void draw_circle(float x, float y, float r, int segments) {
     glBegin(GL_LINE_LOOP);
@@ -3705,16 +3797,31 @@ void draw_hud(PlayerState *p) {
         if (local_state.story_phase == STORY_PHASE_CUTSCENE) {
             draw_string("STORY: VOXWORLD BREACH", 452, 682, 6);
             draw_string("INTRO IN PROGRESS...", 500, 658, 4);
+        } else if (local_state.story_phase == STORY_PHASE_PLAYING) {
+            draw_string("OBJECTIVE: DEFEAT THE BREACH TITAN", 390, 682, 4);
+        } else if (local_state.story_phase == STORY_PHASE_RIFT_OPENING) {
+            glColor3f(0.9f, 0.6f, 1.0f);
+            draw_string("RIFT DETECTED", 520, 682, 6);
+            glColor3f(0.85f, 0.92f, 0.95f);
+            draw_string("REPOSITION - HOSTILES INBOUND", 430, 658, 4);
+        } else if (local_state.story_phase == STORY_PHASE_SWARM) {
+            glColor3f(1.0f, 0.45f, 0.82f);
+            draw_string("PORTAL SWARM ACTIVE", 482, 682, 6);
+            glColor3f(0.9f, 0.95f, 1.0f);
+            draw_string("CLEAR RIFT HOUND + SHAMBLER + GORE BRUTE", 350, 658, 4);
+        } else if (local_state.story_phase == STORY_PHASE_AFTER_SWARM) {
+            glColor3f(0.62f, 1.0f, 0.72f);
+            draw_string("SWARM CLEARED", 520, 682, 6);
+            glColor3f(0.88f, 0.95f, 1.0f);
+            draw_string("STORY CONTINUES...", 520, 658, 4);
         } else if (local_state.story_phase == STORY_PHASE_COMPLETE) {
             glColor3f(0.55f, 1.0f, 0.65f);
-            draw_string("BREACH TITAN DEFEATED", 420, 682, 7);
+            draw_string("BREACH STABILIZED", 500, 682, 7);
             glColor3f(0.85f, 0.92f, 0.95f);
             draw_string("PRESS ESC TO RETURN", 500, 650, 4);
         } else if (local_state.story_phase == STORY_PHASE_FAILED) {
             glColor3f(1.0f, 0.45f, 0.35f);
             draw_string("MISSION FAILED", 520, 682, 7);
-        } else {
-            draw_string("OBJECTIVE: DEFEAT THE BREACH TITAN", 390, 682, 4);
         }
         draw_story_boss_hud(&local_state.story_boss);
     }
@@ -4377,6 +4484,10 @@ void draw_scene(PlayerState *render_p) {
     }
     if (local_state.game_mode == MODE_STORY && render_p->scene_id == SCENE_VOXWORLD) {
         draw_story_boss_world(&local_state.story_boss, now_ms);
+        draw_story_rift_world(&local_state.story_rift, now_ms, local_state.story_phase);
+        for (int si = 0; si < STORY_MAX_SWARM_ENEMIES; si++) {
+            draw_story_swarm_enemy_world(&local_state.story_swarm[si], now_ms);
+        }
     }
     draw_projectiles();
     if (render_p->in_vehicle && render_p->vehicle_type != VEH_BUGGY) draw_player_3rd(render_p);

--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -290,7 +290,24 @@ typedef struct {
 } CtfMatchState;
 
 typedef enum { MODE_DEATHMATCH=0, MODE_TDM=1, MODE_SURVIVAL=2, MODE_CTF=3, MODE_ODDBALL=4, MODE_LOCAL=98, MODE_NET=99, MODE_EVOLUTION=100, MODE_TDMB=101, MODE_TDMO=102, MODE_CTFB=103, MODE_CTFO=104, MODE_STORY=105 } GameMode;
-typedef enum { STORY_PHASE_CUTSCENE=0, STORY_PHASE_PLAYING=1, STORY_PHASE_COMPLETE=2, STORY_PHASE_FAILED=3 } StoryPhase;
+typedef enum {
+    STORY_PHASE_CUTSCENE = 0,
+    STORY_PHASE_PLAYING = 1,
+    STORY_PHASE_RIFT_OPENING = 2,
+    STORY_PHASE_SWARM = 3,
+    STORY_PHASE_AFTER_SWARM = 4,
+    STORY_PHASE_FAILED = 5,
+    STORY_PHASE_COMPLETE = 6
+} StoryPhase;
+
+#define STORY_MAX_SWARM_ENEMIES 24
+
+typedef enum {
+    STORY_ENEMY_NONE = 0,
+    STORY_ENEMY_RIFT_HOUND = 1,
+    STORY_ENEMY_SHAMBLER_TROOPER = 2,
+    STORY_ENEMY_GORE_BRUTE = 3
+} StoryEnemyType;
 
 typedef struct {
     int active;
@@ -302,6 +319,39 @@ typedef struct {
     unsigned int last_attack_ms;
     unsigned int hurt_flash_until_ms;
 } StoryBossState;
+
+typedef struct {
+    int active;
+    int type;
+    float x, y, z;
+    float vx, vy, vz;
+    float yaw;
+    float radius;
+    float height;
+    float health;
+    float max_health;
+    float speed;
+    float attack_radius;
+    int damage;
+    unsigned int spawn_ms;
+    unsigned int last_attack_ms;
+    unsigned int hurt_flash_until_ms;
+    unsigned int death_ms;
+    int dying;
+} StoryEnemy;
+
+typedef struct {
+    int active;
+    float x, y, z;
+    float yaw;
+    float radius;
+    unsigned int opened_ms;
+    unsigned int next_spew_ms;
+    int spew_count;
+    int wave_spawned;
+    unsigned int pulse_seed;
+    unsigned int last_spew_ms;
+} StoryRiftState;
 
 typedef struct {
     PlayerState players[MAX_CLIENTS];
@@ -321,6 +371,8 @@ typedef struct {
     int story_phase;
     unsigned int story_phase_start_ms;
     StoryBossState story_boss;
+    StoryRiftState story_rift;
+    StoryEnemy story_swarm[STORY_MAX_SWARM_ENEMIES];
     CtfMatchState ctf;
     struct sockaddr_in clients[MAX_CLIENTS];
     ClientMeta client_meta[MAX_CLIENTS];

--- a/packages/simulation/local_game.h
+++ b/packages/simulation/local_game.h
@@ -29,6 +29,10 @@ static int tdmb_last_kills[MAX_CLIENTS];
 #define STORY_BOSS_ATTACK_MIN_MS 2500U
 #define STORY_BOSS_ATTACK_MAX_MS 4000U
 #define STORY_BOSS_ATTACK_RADIUS 125.0f
+#define STORY_RIFT_OPEN_DURATION_MS 1200U
+#define STORY_RIFT_SPEW_INTERVAL_MS 180U
+#define STORY_SWARM_CLEAR_TO_COMPLETE_MS 2500U
+
 
 static int mode_uses_team_scores(int mode) {
     return mode == MODE_TDM || mode == MODE_TDMB || mode == MODE_TDMO || mode == MODE_CTFB;
@@ -551,10 +555,85 @@ static float story_boss_weapon_damage(int weapon) {
     return 8.0f;
 }
 
-static int story_boss_is_targeted(const PlayerState *hero, const StoryBossState *boss, float max_dist, float cone_dot) {
-    float to_x = boss->x - hero->x;
-    float to_y = (boss->y + 36.0f) - (hero->y + EYE_HEIGHT);
-    float to_z = boss->z - hero->z;
+static void story_clear_swarm(void) {
+    memset(local_state.story_swarm, 0, sizeof(local_state.story_swarm));
+    memset(&local_state.story_rift, 0, sizeof(local_state.story_rift));
+}
+
+static void story_enemy_setup_stats(StoryEnemy *enemy, int type) {
+    enemy->type = type;
+    enemy->active = 1;
+    enemy->dying = 0;
+    enemy->death_ms = 0;
+    enemy->hurt_flash_until_ms = 0;
+    if (type == STORY_ENEMY_RIFT_HOUND) {
+        enemy->radius = 16.0f; enemy->height = 30.0f; enemy->max_health = 120.0f;
+        enemy->speed = 1.55f; enemy->attack_radius = 34.0f; enemy->damage = 8;
+    } else if (type == STORY_ENEMY_SHAMBLER_TROOPER) {
+        enemy->radius = 19.0f; enemy->height = 40.0f; enemy->max_health = 180.0f;
+        enemy->speed = 1.2f; enemy->attack_radius = 36.0f; enemy->damage = 11;
+    } else {
+        enemy->radius = 25.0f; enemy->height = 54.0f; enemy->max_health = 320.0f;
+        enemy->speed = 0.9f; enemy->attack_radius = 42.0f; enemy->damage = 18;
+    }
+    enemy->health = enemy->max_health;
+}
+
+static int story_spawn_enemy(int type, float x, float y, float z, unsigned int now_ms) {
+    for (int i = 0; i < STORY_MAX_SWARM_ENEMIES; i++) {
+        StoryEnemy *enemy = &local_state.story_swarm[i];
+        if (enemy->active) continue;
+        memset(enemy, 0, sizeof(*enemy));
+        story_enemy_setup_stats(enemy, type);
+        enemy->x = x; enemy->z = z;
+        float gy = voxworld_height_at(x, z);
+        if (gy < 0.0f) gy = y;
+        enemy->y = gy;
+        enemy->yaw = 0.0f;
+        enemy->spawn_ms = now_ms;
+        enemy->last_attack_ms = now_ms;
+        return 1;
+    }
+    return 0;
+}
+
+static int story_enemy_count_alive(void) {
+    int alive = 0;
+    for (int i = 0; i < STORY_MAX_SWARM_ENEMIES; i++) {
+        if (local_state.story_swarm[i].active) alive++;
+    }
+    return alive;
+}
+
+static void story_begin_rift_opening(unsigned int now_ms, float boss_x, float boss_y, float boss_z) {
+    StoryBossState *boss = &local_state.story_boss;
+    boss->active = 0;
+    boss->defeated = 1;
+    boss->health = 0.0f;
+    local_state.story_phase = STORY_PHASE_RIFT_OPENING;
+    local_state.story_phase_start_ms = now_ms;
+    story_clear_swarm();
+    StoryRiftState *rift = &local_state.story_rift;
+    rift->active = 1;
+    rift->x = boss_x;
+    rift->z = boss_z + 76.0f;
+    rift->y = voxworld_height_at(rift->x, rift->z) + 18.0f;
+    rift->yaw = 180.0f;
+    rift->radius = 18.0f;
+    rift->opened_ms = now_ms;
+    rift->next_spew_ms = now_ms + STORY_RIFT_OPEN_DURATION_MS;
+    rift->last_spew_ms = now_ms;
+    rift->spew_count = 0;
+    rift->wave_spawned = 0;
+    rift->pulse_seed = (unsigned int)(fabsf(boss_x) * 31.0f + fabsf(boss_z) * 17.0f) + now_ms;
+    printf("[STORY] boss defeated; rift opening\n");
+    (void)boss_y;
+}
+
+static int story_target_is_in_cone(const PlayerState *hero, float target_x, float target_y, float target_z, float max_dist, float cone_dot) {
+    float to_x = target_x - hero->x;
+    float to_y = target_y - (hero->y + EYE_HEIGHT);
+    float to_z = target_z - hero->z;
     float dist = sqrtf(to_x * to_x + to_y * to_y + to_z * to_z);
     if (dist <= 0.001f || dist > max_dist) return 0;
     float r = -hero->yaw * 0.0174533f;
@@ -565,6 +644,41 @@ static int story_boss_is_targeted(const PlayerState *hero, const StoryBossState 
     float inv = 1.0f / dist;
     float dot = fx * (to_x * inv) + fy * (to_y * inv) + fz * (to_z * inv);
     return dot >= cone_dot;
+}
+
+static void story_swarm_apply_player_hit(PlayerState *hero, unsigned int now_ms) {
+    if (local_state.story_phase != STORY_PHASE_SWARM) return;
+    int weapon = hero->current_weapon;
+    float max_dist = 420.0f;
+    float cone_dot = 0.9f;
+    if (weapon == WPN_SNIPER) cone_dot = 0.86f;
+    else if (weapon == WPN_SHOTGUN) cone_dot = 0.94f;
+    else if (weapon == WPN_KNIFE || weapon == WPN_KATANA) { max_dist = 26.0f; cone_dot = 0.70f; }
+    StoryEnemy *best = NULL;
+    float best_dist = 100000.0f;
+    for (int i = 0; i < STORY_MAX_SWARM_ENEMIES; i++) {
+        StoryEnemy *enemy = &local_state.story_swarm[i];
+        if (!enemy->active || enemy->dying) continue;
+        float ty = enemy->y + enemy->height * 0.55f;
+        if (!story_target_is_in_cone(hero, enemy->x, ty, enemy->z, max_dist, cone_dot)) continue;
+        float dx = enemy->x - hero->x;
+        float dz = enemy->z - hero->z;
+        float d = dx * dx + dz * dz;
+        if (d < best_dist) { best_dist = d; best = enemy; }
+    }
+    if (!best) return;
+    float dmg = story_boss_weapon_damage(weapon);
+    best->health -= dmg;
+    best->hurt_flash_until_ms = now_ms + 110;
+    if (best->health <= 0.0f) {
+        best->health = 0.0f;
+        best->dying = 1;
+        best->death_ms = now_ms;
+        best->active = 0;
+        hero->hit_feedback = 25;
+    } else {
+        hero->hit_feedback = 10;
+    }
 }
 
 static void story_boss_apply_player_hit(PlayerState *hero, unsigned int now_ms) {
@@ -580,7 +694,7 @@ static void story_boss_apply_player_hit(PlayerState *hero, unsigned int now_ms) 
         max_dist = 24.0f;
         cone_dot = 0.72f;
     }
-    if (!story_boss_is_targeted(hero, boss, max_dist, cone_dot)) return;
+    if (!story_target_is_in_cone(hero, boss->x, boss->y + 36.0f, boss->z, max_dist, cone_dot)) return;
     float dmg = story_boss_weapon_damage(weapon);
     boss->health -= dmg;
     if (boss->health < 0.0f) boss->health = 0.0f;
@@ -591,12 +705,7 @@ static void story_boss_apply_player_hit(PlayerState *hero, unsigned int now_ms) 
         next_damage_log_ms = now_ms + 350;
     }
     if (boss->health <= 0.0f) {
-        boss->defeated = 1;
-        boss->active = 0;
-        local_state.story_phase = STORY_PHASE_COMPLETE;
-        local_state.story_phase_start_ms = now_ms;
-        local_state.match_over = 1;
-        printf("[STORY] boss defeated\n");
+        story_begin_rift_opening(now_ms, boss->x, boss->y, boss->z);
     }
 }
 
@@ -627,6 +736,83 @@ static void story_boss_tick(PlayerState *hero, unsigned int now_ms) {
             local_state.story_phase_start_ms = now_ms;
             local_state.match_over = 1;
         }
+    }
+}
+
+static void story_swarm_spawn_wave(unsigned int now_ms) {
+    StoryRiftState *rift = &local_state.story_rift;
+    if (!rift->active || rift->wave_spawned) return;
+    const int types[3] = { STORY_ENEMY_RIFT_HOUND, STORY_ENEMY_SHAMBLER_TROOPER, STORY_ENEMY_GORE_BRUTE };
+    for (int i = 0; i < 3; i++) {
+        float a = (float)i * 2.09439f + (float)(rift->pulse_seed % 360) * 0.0174533f;
+        float d = rift->radius + 22.0f + (float)(i * 8);
+        float sx = rift->x + cosf(a) * d;
+        float sz = rift->z + sinf(a) * d;
+        story_spawn_enemy(types[i], sx, rift->y, sz, now_ms);
+        rift->last_spew_ms = now_ms;
+        rift->spew_count++;
+    }
+    rift->wave_spawned = 1;
+    printf("[STORY] swarm wave spawned (hound+trooper+brute)\n");
+}
+
+static void story_swarm_tick(PlayerState *hero, unsigned int now_ms) {
+    if (local_state.game_mode != MODE_STORY) return;
+    if (local_state.story_phase == STORY_PHASE_RIFT_OPENING) {
+        StoryRiftState *rift = &local_state.story_rift;
+        if (rift->active) {
+            float t = (float)(now_ms - rift->opened_ms) / (float)STORY_RIFT_OPEN_DURATION_MS;
+            if (t < 0.0f) t = 0.0f;
+            if (t > 1.0f) t = 1.0f;
+            rift->radius = 18.0f + t * 74.0f;
+        }
+        if (now_ms - local_state.story_phase_start_ms >= STORY_RIFT_OPEN_DURATION_MS) {
+            local_state.story_phase = STORY_PHASE_SWARM;
+            local_state.story_phase_start_ms = now_ms;
+            story_swarm_spawn_wave(now_ms);
+        }
+        return;
+    }
+    if (local_state.story_phase != STORY_PHASE_SWARM) return;
+    for (int i = 0; i < STORY_MAX_SWARM_ENEMIES; i++) {
+        StoryEnemy *enemy = &local_state.story_swarm[i];
+        if (!enemy->active) continue;
+        float dx = hero->x - enemy->x;
+        float dz = hero->z - enemy->z;
+        float dist = sqrtf(dx * dx + dz * dz);
+        if (dist > 0.001f) {
+            float inv = 1.0f / dist;
+            enemy->vx = dx * inv * enemy->speed;
+            enemy->vz = dz * inv * enemy->speed;
+            enemy->x += enemy->vx;
+            enemy->z += enemy->vz;
+            enemy->yaw = atan2f(dx, dz) * (180.0f / 3.14159f);
+        }
+        enemy->y = voxworld_height_at(enemy->x, enemy->z);
+        if (dist <= enemy->attack_radius && now_ms - enemy->last_attack_ms >= 850U) {
+            enemy->last_attack_ms = now_ms;
+            int damage = enemy->damage;
+            hero->shield_regen_timer = SHIELD_REGEN_DELAY;
+            if (hero->shield > 0) {
+                if (hero->shield >= damage) { hero->shield -= damage; damage = 0; }
+                else { damage -= hero->shield; hero->shield = 0; }
+            }
+            hero->health -= damage;
+            if (hero->health <= 0) {
+                hero->health = 0;
+                phys_enter_death_state(NULL, hero, now_ms, mode_respawn_delay_ms(local_state.game_mode), 0.0f, 0.0f);
+                local_state.story_phase = STORY_PHASE_FAILED;
+                local_state.story_phase_start_ms = now_ms;
+                local_state.match_over = 1;
+                return;
+            }
+        }
+    }
+    if (story_enemy_count_alive() == 0) {
+        local_state.story_phase = STORY_PHASE_AFTER_SWARM;
+        local_state.story_phase_start_ms = now_ms;
+        local_state.story_rift.active = 0;
+        printf("[STORY] swarm cleared; story continued\n");
     }
 }
 
@@ -886,6 +1072,11 @@ void local_update(float fwd, float str, float yaw, float pitch, int shoot, int w
             pitch = -5.0f;
         } else if (local_state.story_phase == STORY_PHASE_COMPLETE || local_state.story_phase == STORY_PHASE_FAILED) {
             fwd = 0.0f; str = 0.0f; shoot = 0; jump = 0; crouch = 0; reload = 0; ability = 0;
+        } else if (local_state.story_phase == STORY_PHASE_AFTER_SWARM) {
+            if (cmd_time - local_state.story_phase_start_ms >= STORY_SWARM_CLEAR_TO_COMPLETE_MS) {
+                local_state.story_phase = STORY_PHASE_COMPLETE;
+                local_state.story_phase_start_ms = cmd_time;
+            }
         }
     }
     if (local_state.match_over && (local_state.game_mode == MODE_TDMB || local_state.game_mode == MODE_CTFB)) {
@@ -1038,11 +1229,16 @@ void local_update(float fwd, float str, float yaw, float pitch, int shoot, int w
     }
     buggy_tick_all();
     update_projectiles(cmd_time);
-    if (local_state.game_mode == MODE_STORY && local_state.story_phase == STORY_PHASE_PLAYING) {
+    if (local_state.game_mode == MODE_STORY &&
+        (local_state.story_phase == STORY_PHASE_PLAYING || local_state.story_phase == STORY_PHASE_SWARM)) {
         if (p0->is_shooting >= 5 || (p0->current_weapon == WPN_KNIFE && p0->in_shoot) || (p0->current_weapon == WPN_KATANA && p0->in_shoot)) {
-            story_boss_apply_player_hit(p0, cmd_time);
+            if (local_state.story_phase == STORY_PHASE_PLAYING) story_boss_apply_player_hit(p0, cmd_time);
+            else story_swarm_apply_player_hit(p0, cmd_time);
         }
+    }
+    if (local_state.game_mode == MODE_STORY) {
         story_boss_tick(p0, cmd_time);
+        story_swarm_tick(p0, cmd_time);
     }
     if (local_state.game_mode == MODE_CTFB) {
         ctf_tick_flags(cmd_time);
@@ -1076,6 +1272,7 @@ void local_init_match(int num_players, int mode) {
     local_state.score_limit = (mode == MODE_TDMB || mode == MODE_TDMO) ? TDMB_SCORE_LIMIT : (mode == MODE_CTFB ? CTFB_SCORE_LIMIT : 0);
     local_state.story_phase = (mode == MODE_STORY) ? STORY_PHASE_CUTSCENE : STORY_PHASE_PLAYING;
     local_state.story_phase_start_ms = 0;
+    story_clear_swarm();
 
     if (mode == MODE_TDMB) {
         num_players = 1 + TDMB_BLUE_BOTS + TDMB_RED_BOTS;


### PR DESCRIPTION
### Motivation
- Turn the boss-death instant-complete into a playable second phase where a rift opens and a swarm of enemies is spewed for the player to fight. 
- Keep this as a simple, local-only MVP without network snapshots, fixed-pipeline friendly rendering, and minimal new systems that reuse existing physics/damage conventions.

### Description
- Extended story phase enum with `STORY_PHASE_RIFT_OPENING`, `STORY_PHASE_SWARM`, and `STORY_PHASE_AFTER_SWARM`, and added `STORY_MAX_SWARM_ENEMIES`. (changed `packages/common/protocol.h`)
- Added local story swarm state types `StoryEnemy` and `StoryRiftState` and embedded `story_rift` + `story_swarm[]` into `ServerState`. (changed `packages/common/protocol.h`)
- Replaced immediate match end on boss death with `story_begin_rift_opening(now_ms, boss_x, boss_y, boss_z)`, which marks the boss inactive, initializes the rift, and records the opening time. (added to `packages/simulation/local_game.h`)
- Implemented local-only swarm system: spawn/clear helpers, per-enemy stats for Rift Hound / Shambler Trooper / Gore Brute, `story_swarm_tick()` (movement, attack, damage), and `story_swarm_apply_player_hit()` so player weapons damage swarm enemies. Integration triggers: boss death -> RIFT_OPENING (0–1200ms pulse) -> spawn wave at ~1200ms -> SWARM gameplay -> AFTER_SWARM -> delayed COMPLETE. (changed `packages/simulation/local_game.h`)
- Added fixed-pipeline visuals and HUD support: rift portal pulse + spew effect, simple emissive/crack rendering variant for enemies, and HUD overlays per new phase. Rendering helpers added in `apps/lobby/src/main.c` and hooked into the scene draw path. (changed `apps/lobby/src/main.c`)
- Preserved non-story/multiplayer behavior and initialized/cleared the new story state in `local_init_match()`; no new external deps or shader changes introduced.

### Testing
- Attempted a full build with `make -B all`; build failed in this environment due to missing SDL2 development headers (`SDL2/SDL.h`), so runtime verification could not be executed here. (known environment limitation)
- Performed iterative static edits and corrected compile-time string/format issues discovered by local syntax checks during development; those fixes were applied and the changes committed. 
- Verified repository state and committed changes (working tree clean after commit).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eead0dc4ec83279ab43fe4634cab46)