### PR TITLE
Fix cross-platform socket include for simulation headers

### DIFF
--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -1,6 +1,12 @@
 #ifndef PROTOCOL_H
 #define PROTOCOL_H
 
+#ifdef _WIN32
+    #include <winsock2.h>
+#else
+    #include <netinet/in.h>
+#endif
+
 #define MAX_CLIENTS 70
 #define MAX_WEAPONS 6
 #define MAX_PROJECTILES 1024

--- a/packages/simulation/story_ai.h
+++ b/packages/simulation/story_ai.h
@@ -1,7 +1,6 @@
 #ifndef STORY_AI_H
 #define STORY_AI_H
 
-#include <netinet/in.h>
 #include "../common/protocol.h"
 
 #define STORY_AI_MAX 16


### PR DESCRIPTION
### Motivation
- Including `<netinet/in.h>` directly in simulation headers made the headers Linux-specific and caused `struct sockaddr_in` to be undefined/incomplete when other translation units included `protocol.h`.

### Description
- Add platform-guarded socket include to `packages/common/protocol.h` by including `winsock2.h` on Windows (`#ifdef _WIN32`) and `netinet/in.h` otherwise.
- Remove the direct `#include <netinet/in.h>` from `packages/simulation/story_ai.h` so socket types are provided by `protocol.h` instead.
- This ensures `ServerState`'s `struct sockaddr_in clients[MAX_CLIENTS]` is defined whenever `protocol.h` is included.

### Testing
- `make server` completed successfully and produced only a harmless unused-function warning.
- `make lobby` still fails in this environment due to missing SDL2 development headers (e.g. `SDL2/SDL.h`), which is an unrelated environment dependency issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe224018883279ff98a33626dd522)