### PR TITLE
Make socket types portable and remove direct <netinet/in.h> include from simulation headers

### DIFF
--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -1,6 +1,23 @@
 #ifndef PROTOCOL_H
 #define PROTOCOL_H
 
+#ifdef _WIN32
+    #include <winsock2.h>
+#elif defined(__has_include)
+    #if __has_include(<netinet/in.h>)
+        #include <netinet/in.h>
+    #else
+        typedef struct sockaddr_in {
+            unsigned short sin_family;
+            unsigned short sin_port;
+            unsigned int sin_addr_s_addr;
+            unsigned char sin_zero[8];
+        } sockaddr_in;
+    #endif
+#else
+    #include <netinet/in.h>
+#endif
+
 #define MAX_CLIENTS 70
 #define MAX_WEAPONS 6
 #define MAX_PROJECTILES 1024

--- a/packages/simulation/story_ai.h
+++ b/packages/simulation/story_ai.h
@@ -1,7 +1,6 @@
 #ifndef STORY_AI_H
 #define STORY_AI_H
 
-#include <netinet/in.h>
 #include "../common/protocol.h"
 
 #define STORY_AI_MAX 16


### PR DESCRIPTION
### Motivation
- Including `<netinet/in.h>` from `story_ai.h` caused build failures on environments where that header isn't available or when building non-networked targets that include simulation headers transitively. 
- Provide a platform-aware way to reference `sockaddr_in` so headers that need the type don't require system network headers be present.

### Description
- Removed the direct `#include <netinet/in.h>` from `packages/simulation/story_ai.h` so simulation headers no longer hard-require that system header.
- Added platform-aware socket handling to `packages/common/protocol.h` that includes `winsock2.h` on Windows, uses `__has_include(<netinet/in.h>)` when available, and supplies a minimal `struct sockaddr_in` fallback when `<netinet/in.h>` is not present.
- Changes ensure `ServerState` and other types that reference `struct sockaddr_in` compile on systems without the native header.

### Testing
- Successfully compiled `packages/simulation/story_ai.c` with `gcc -O2 -Wall -Ipackages/common -Ipackages/simulation -Ipackages/world -c packages/simulation/story_ai.c -o /tmp/story_ai.o` (success).
- Ran `make server` which produced a warning but completed successfully (success).
- Ran `make lobby` which still fails in this container due to missing SDL2/OpenGL development headers, which is unrelated to the netinet/header fix (failure, unrelated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe224018883279ff98a33626dd522)