### PR TITLE
Decouple client simulation from rendering with 64Hz fixed timestep

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -5,8 +5,10 @@
 #include <math.h>
 #include <assert.h>
 #include <stdint.h>
+#include <time.h>
 
 #ifdef _WIN32
+    #include <windows.h>
     #include <winsock2.h>
     #include <ws2tcpip.h>
     #pragma comment(lib, "ws2_32.lib")
@@ -5457,6 +5459,31 @@ void net_tick() {
 }
 
 
+
+#define TICK_RATE 64
+#define TICK_DT (1.0f / TICK_RATE)
+
+static double get_time(void) {
+#ifdef _WIN32
+    static LARGE_INTEGER freq;
+    static int init = 0;
+    LARGE_INTEGER counter;
+    if (!init) { QueryPerformanceFrequency(&freq); init = 1; }
+    QueryPerformanceCounter(&counter);
+    return (double)counter.QuadPart / (double)freq.QuadPart;
+#else
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec + (double)ts.tv_nsec / 1000000000.0;
+#endif
+}
+
+static PlayerState render_prev_players[MAX_CLIENTS];
+
+static void snapshot_prev_players(void) {
+    memcpy(render_prev_players, local_state.players, sizeof(render_prev_players));
+}
+
 int main(int argc, char* argv[]) {
     for(int i=1; i<argc; i++) {
         if(strcmp(argv[i], "--host") == 0 && i+1<argc) {
@@ -5487,7 +5514,17 @@ int main(int argc, char* argv[]) {
     }
     
     int running = 1;
+    double previous = get_time();
+    double accumulator = 0.0;
+    float input_fwd = 0.0f, input_str = 0.0f;
+    int input_jump = 0, input_crouch = 0, input_shoot = 0, input_reload = 0, input_use = 0, input_ability = 0;
     while(running) {
+        double now = get_time();
+        double frame_time = now - previous;
+        if (frame_time > 0.25) frame_time = 0.25;
+        previous = now;
+        accumulator += frame_time;
+
         SDL_Event e;
         while(SDL_PollEvent(&e)) {
             if(e.type == SDL_QUIT) running = 0;
@@ -5721,6 +5758,8 @@ int main(int argc, char* argv[]) {
             int reload = in_heli ? k[SDL_SCANCODE_Q] : k[SDL_SCANCODE_R];
             int use = k[SDL_SCANCODE_F];
             int ability = in_heli ? k[SDL_SCANCODE_E] : k[SDL_SCANCODE_E];
+            input_fwd = fwd; input_str = str;
+            input_jump = jump; input_crouch = crouch; input_shoot = shoot; input_reload = reload; input_use = use; input_ability = ability;
             if(k[SDL_SCANCODE_1]) wpn_req=0; if(k[SDL_SCANCODE_2]) wpn_req=1;
             if(k[SDL_SCANCODE_3]) wpn_req=2; if(k[SDL_SCANCODE_4]) wpn_req=3; if(k[SDL_SCANCODE_5]) wpn_req=4; if(k[SDL_SCANCODE_6]) wpn_req=5;
 
@@ -5731,6 +5770,8 @@ int main(int argc, char* argv[]) {
             current_fov += (target_fov - current_fov) * 0.2f;
             glMatrixMode(GL_PROJECTION); glLoadIdentity(); gluPerspective(current_fov, 1280.0/720.0, 0.1, Z_FAR); 
             glMatrixMode(GL_MODELVIEW);
+            while (accumulator >= TICK_DT) {
+                snapshot_prev_players();
             if (app_state == STATE_GAME_NET) {
                 net_local_pid = (my_client_id > 0 && my_client_id < MAX_CLIENTS) ? my_client_id : -1;
                 net_tick();
@@ -5744,7 +5785,7 @@ int main(int argc, char* argv[]) {
                                            my_client_id, net_local_pid,
                                            net_diag.connect_started ? (now_ms - net_diag.connect_start_ms) : 0);
                         }
-                        UserCmd cmd = client_create_cmd(fwd, str, cam_yaw, cam_pitch, shoot, jump, crouch, reload, use, ability, wpn_req);
+                        UserCmd cmd = client_create_cmd(input_fwd, input_str, cam_yaw, cam_pitch, input_shoot, input_jump, input_crouch, input_reload, input_use, input_ability, wpn_req);
                         client_apply_cmd_movement(&local_state.players[net_local_pid], &cmd, now_ms);
                         net_send_cmd(cmd);
                         net_last_cmd_send_ms = now_ms;
@@ -5765,11 +5806,11 @@ int main(int argc, char* argv[]) {
                     (local_state.story_phase == STORY_PHASE_CUTSCENE ||
                      local_state.story_phase == STORY_PHASE_COMPLETE ||
                      local_state.story_phase == STORY_PHASE_FAILED)) {
-                    fwd = 0.0f; str = 0.0f;
-                    jump = 0; crouch = 0; shoot = 0; reload = 0; use = 0; ability = 0;
+                    input_fwd = 0.0f; input_str = 0.0f;
+                    input_jump = 0; input_crouch = 0; input_shoot = 0; input_reload = 0; input_use = 0; input_ability = 0;
                 }
-                local_state.players[0].in_use = use;
-                if (use && local_state.players[0].vehicle_cooldown == 0 && local_state.transition_timer == 0) {
+                local_state.players[0].in_use = input_use;
+                if (input_use && local_state.players[0].vehicle_cooldown == 0 && local_state.transition_timer == 0) {
                     PlayerState *p0 = &local_state.players[0];
                     HelicopterState *near_h = NULL;
                     for (int hi = 0; hi < MAX_HELICOPTERS; hi++) {
@@ -5834,8 +5875,11 @@ int main(int argc, char* argv[]) {
                     local_state.story_phase_start_ms == 0) {
                     local_state.story_phase_start_ms = now_ms;
                 }
-                local_update(fwd, str, cam_yaw, cam_pitch, shoot, wpn_req, jump, crouch, reload, ability, NULL, now_ms);
+                local_update(input_fwd, input_str, cam_yaw, cam_pitch, input_shoot, wpn_req, input_jump, input_crouch, input_reload, input_ability, NULL, now_ms);
             }
+                accumulator -= TICK_DT;
+            }
+
             int render_pid = 0;
             if (app_state == STATE_GAME_NET &&
                 my_client_id > 0 && my_client_id < MAX_CLIENTS &&
@@ -5879,10 +5923,16 @@ int main(int argc, char* argv[]) {
                            phys_last_grounded_on_terrain() ? "terrain" : "box");
                 }
             }
-            draw_scene(render_p);
+            double alpha = accumulator / TICK_DT;
+            if (alpha < 0.0) alpha = 0.0;
+            if (alpha > 1.0) alpha = 1.0;
+            PlayerState blended = *render_p;
+            blended.x = render_prev_players[render_pid].x + (render_p->x - render_prev_players[render_pid].x) * (float)alpha;
+            blended.y = render_prev_players[render_pid].y + (render_p->y - render_prev_players[render_pid].y) * (float)alpha;
+            blended.z = render_prev_players[render_pid].z + (render_p->z - render_prev_players[render_pid].z) * (float)alpha;
+            draw_scene(&blended);
             SDL_GL_SwapWindow(win);
         }
-        SDL_Delay(16);
     }
     proc_tex_destroy(&g_vehicle_noise_tex);
     proc_tex_destroy(&g_vehicle_glitch_tex);

--- a/apps/server/src/main.c
+++ b/apps/server/src/main.c
@@ -974,7 +974,7 @@ int main(int argc, char *argv[]) {
                 float b_fwd = 0.0f;
                 float b_yaw = p->yaw;
                 int b_btns = 0;
-                bot_think(i, local_state.players, &b_fwd, &b_yaw, &b_btns);
+                bot_think(i, local_state.players, SHANKPIT_NET_FIXED_DT, &b_fwd, &b_yaw, &b_btns);
                 p->yaw = b_yaw;
                 float brad = b_yaw * 3.14159f / 180.0f;
                 float bx = sinf(brad) * b_fwd;

--- a/packages/simulation/local_game.h
+++ b/packages/simulation/local_game.h
@@ -860,7 +860,7 @@ static void story_swarm_tick(PlayerState *hero, unsigned int now_ms) {
 }
 
 // --- BOT AI ---
-void bot_think(int bot_idx, PlayerState *players, float *out_fwd, float *out_yaw, int *out_buttons) {
+void bot_think(int bot_idx, PlayerState *players, float dt, float *out_fwd, float *out_yaw, int *out_buttons) {
     PlayerState *me = &players[bot_idx];
     if (me->state == STATE_DEAD || local_state.match_over) { *out_buttons = 0; return; }
     if (local_state.game_mode == MODE_STORY) { *out_buttons = 0; *out_fwd = 0.0f; *out_yaw = me->yaw; return; }
@@ -927,7 +927,7 @@ void bot_think(int bot_idx, PlayerState *players, float *out_fwd, float *out_yaw
         float dz = t->z - me->z;
         float target_yaw = atan2f(dx, dz) * (180.0f / 3.14159f);
         
-        float turn_speed = (me->brain.w_turret > 1.0f) ? me->brain.w_turret : 10.0f;
+        float turn_speed = ((me->brain.w_turret > 1.0f) ? me->brain.w_turret : 10.0f) * (dt * 60.0f);
         float diff = angle_diff(target_yaw, *out_yaw);
         if (diff > turn_speed) diff = turn_speed;
         if (diff < -turn_speed) diff = -turn_speed;
@@ -939,7 +939,7 @@ void bot_think(int bot_idx, PlayerState *players, float *out_fwd, float *out_yaw
         else if (min_dist < 5.0f) *out_fwd = -me->brain.w_aggro; 
         else *out_fwd = 0.2f; 
         
-        *out_yaw += me->brain.w_strafe * 10.0f;
+        *out_yaw += me->brain.w_strafe * (600.0f * dt);
         if (local_state.game_mode == MODE_HEADED_BOT) {
             float pf = headed_policy_predict(bot_idx, headed_policy[bot_idx].mu_fwd, headed_policy[bot_idx].var_fwd, 0.65f);
             float ps = headed_policy_predict(bot_idx, headed_policy[bot_idx].mu_strafe, headed_policy[bot_idx].var_strafe, 0.65f);
@@ -949,7 +949,7 @@ void bot_think(int bot_idx, PlayerState *players, float *out_fwd, float *out_yaw
             if (ps > 1.0f) ps = 1.0f;
             if (ps < -1.0f) ps = -1.0f;
             *out_fwd = 0.35f * (*out_fwd) + 0.65f * pf;
-            me->vx += ps * 0.04f;
+            me->vx += ps * (2.4f * dt);
             *out_yaw += py;
             headed_policy_learn(bot_idx, *out_fwd, ps, py);
         }
@@ -957,7 +957,7 @@ void bot_think(int bot_idx, PlayerState *players, float *out_fwd, float *out_yaw
         if (me->on_ground && (rand()%1000 < (me->brain.w_slide * 1000.0f))) *out_buttons |= BTN_CROUCH;
         if (me->ammo[me->current_weapon] <= 0) *out_buttons |= BTN_RELOAD;
     } else {
-        *out_yaw += 2.0f;
+        *out_yaw += 120.0f * dt;
         *out_fwd = 0.5f;
     }
 }
@@ -1115,6 +1115,7 @@ static void update_projectiles(unsigned int now_ms) {
 
 void local_update(float fwd, float str, float yaw, float pitch, int shoot, int weapon_req, int jump, int crouch, int reload, int ability, void *server_context, unsigned int cmd_time) {
     PlayerState *p0 = &local_state.players[0];
+    const float dt = SHANKPIT_NET_FIXED_DT;
     if (local_state.game_mode == MODE_STORY) {
         if (local_state.story_phase == STORY_PHASE_CUTSCENE) {
             fwd = 0.0f; str = 0.0f; shoot = 0; jump = 0; crouch = 0; reload = 0; ability = 0;
@@ -1273,7 +1274,7 @@ void local_update(float fwd, float str, float yaw, float pitch, int shoot, int w
             } else {
                 float b_fwd=0, b_yaw=p->yaw;
                 int b_btns=0;
-                bot_think(i, local_state.players, &b_fwd, &b_yaw, &b_btns);
+                bot_think(i, local_state.players, dt, &b_fwd, &b_yaw, &b_btns);
                 p->yaw = b_yaw;
                 if (!p->in_vehicle) {
                     float brad = b_yaw * 3.14159f / 180.0f;


### PR DESCRIPTION
### Motivation
- The client simulation was tied to render frame rate, causing bots and gameplay pacing to slow on low-FPS machines and large maps.
- The change aims to run all game logic at a stable, server-matched rate (64 Hz) so simulation behavior is deterministic and independent of rendering FPS.

### Description
- Add `#define TICK_RATE 64` and `#define TICK_DT (1.0f / TICK_RATE)` plus a cross-platform monotonic `get_time()` using `QueryPerformanceCounter` (Windows) or `clock_gettime(CLOCK_MONOTONIC)` (POSIX).
- Refactor the lobby client main loop to an accumulator-based fixed-timestep pattern with a spiral-of-death clamp (`frame_time` max `0.25s`) and `while (accumulator >= TICK_DT)` simulation steps, and compute `alpha = accumulator / TICK_DT` for render interpolation.
- Snapshot previous player state at the start of each tick and blend positions in render using `alpha` so visuals remain smooth when FPS != tick rate.
- Move per-tick logic (input consumption, `local_update`, `net_tick`, remote interpolation, etc.) into the tick loop and cache input sampled each frame for deterministic consumption by ticks.
- Make bot AI time-step aware by adding a `dt` parameter to `bot_think(...)` and scaling yaw/velocity updates by `dt` (e.g. idle spin now `120.0f * dt`), and update server and local call sites to pass `dt` accordingly.

### Testing
- Attempted full build with `make -j2`, which failed in this environment due to missing SDL2 development headers (client build failure). (This surfaced earlier client compile dependency issues but did not indicate runtime logic errors.)
- Compiled the server path directly with `gcc ... apps/server/src/main.c ...` after updating `bot_think` call sites, and the server-side compile succeeded without errors. 
- The edit fixed a `bot_think` signature mismatch that was detected by compilation and resolved, and the server compile test passed after the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a024afce8748327a29ec7906b38664f)