### PR TITLE
Fix helicopter strafe-right never firing BTN_VEHICLE_2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Recent changes
 
+### 2026-05-29
+- Fixed helicopter strafe-right being completely non-functional: `client_create_cmd` now accepts a `bike` param and sets `BTN_VEHICLE_2`; Q is correctly bound to strafe-right in helicopter mode (was incorrectly wired to the unused `BTN_RELOAD`); `local_update` now sets `p0->in_bike` so offline play is also fixed.
+
 ### 2026-04-26
 - Fixed buggy camera yaw decoupling from body steering and added steering catch-up behavior for tighter vehicle control feel (`cf9a35d`, merged in #273).
 - Replaced STORY mode with a Voxworld breach titan boss prototype to refocus the mode direction (`7a772f7`, merged in #271).

--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -5298,7 +5298,7 @@ void net_connect() {
     }
 }
 
-UserCmd client_create_cmd(float fwd, float str, float yaw, float pitch, int shoot, int jump, int crouch, int reload, int use, int ability, int wpn_idx) {
+UserCmd client_create_cmd(float fwd, float str, float yaw, float pitch, int shoot, int jump, int crouch, int reload, int use, int ability, int bike, int wpn_idx) {
     UserCmd cmd;
     memset(&cmd, 0, sizeof(UserCmd));
     cmd.sequence = ++net_cmd_seq; cmd.timestamp = SDL_GetTicks();
@@ -5309,6 +5309,7 @@ UserCmd client_create_cmd(float fwd, float str, float yaw, float pitch, int shoo
     if(reload) cmd.buttons |= BTN_RELOAD;
     if(use) cmd.buttons |= BTN_USE;
     if(ability) cmd.buttons |= BTN_ABILITY_1;
+    if(bike) cmd.buttons |= BTN_VEHICLE_2;
     client_cmd_hist[cmd.sequence % CLIENT_RECON_HISTORY] = cmd;
     net_latest_seq_sent = cmd.sequence;
     cmd.weapon_idx = wpn_idx; return cmd;
@@ -5964,7 +5965,7 @@ int main(int argc, char* argv[]) {
     double previous = get_time();
     double accumulator = 0.0;
     float input_fwd = 0.0f, input_str = 0.0f;
-    int input_jump = 0, input_crouch = 0, input_shoot = 0, input_reload = 0, input_use = 0, input_ability = 0;
+    int input_jump = 0, input_crouch = 0, input_shoot = 0, input_reload = 0, input_use = 0, input_ability = 0, input_bike = 0;
     while(running) {
         double now = get_time();
         double frame_time = now - previous;
@@ -6205,11 +6206,12 @@ int main(int argc, char* argv[]) {
             }
             int jump = k[SDL_SCANCODE_SPACE]; int crouch = k[SDL_SCANCODE_LCTRL];
             int shoot = (SDL_GetMouseState(NULL, NULL) & SDL_BUTTON(SDL_BUTTON_LEFT));
-            int reload = in_heli ? k[SDL_SCANCODE_Q] : k[SDL_SCANCODE_R];
+            int reload = in_heli ? 0 : k[SDL_SCANCODE_R];
+            int bike = in_heli ? k[SDL_SCANCODE_Q] : 0;
             int use = k[SDL_SCANCODE_F];
             int ability = in_heli ? k[SDL_SCANCODE_E] : k[SDL_SCANCODE_E];
             input_fwd = fwd; input_str = str;
-            input_jump = jump; input_crouch = crouch; input_shoot = shoot; input_reload = reload; input_use = use; input_ability = ability;
+            input_jump = jump; input_crouch = crouch; input_shoot = shoot; input_reload = reload; input_use = use; input_ability = ability; input_bike = bike;
             if(k[SDL_SCANCODE_1]) wpn_req=0; if(k[SDL_SCANCODE_2]) wpn_req=1;
             if(k[SDL_SCANCODE_3]) wpn_req=2; if(k[SDL_SCANCODE_4]) wpn_req=3; if(k[SDL_SCANCODE_5]) wpn_req=4; if(k[SDL_SCANCODE_6]) wpn_req=5;
 
@@ -6235,7 +6237,7 @@ int main(int argc, char* argv[]) {
                                            my_client_id, net_local_pid,
                                            net_diag.connect_started ? (now_ms - net_diag.connect_start_ms) : 0);
                         }
-                        UserCmd cmd = client_create_cmd(input_fwd, input_str, cam_yaw, cam_pitch, input_shoot, input_jump, input_crouch, input_reload, input_use, input_ability, wpn_req);
+                        UserCmd cmd = client_create_cmd(input_fwd, input_str, cam_yaw, cam_pitch, input_shoot, input_jump, input_crouch, input_reload, input_use, input_ability, input_bike, wpn_req);
                         client_apply_cmd_movement(&local_state.players[net_local_pid], &cmd, now_ms);
                         net_send_cmd(cmd);
                         net_last_cmd_send_ms = now_ms;
@@ -6325,7 +6327,7 @@ int main(int argc, char* argv[]) {
                     local_state.story_phase_start_ms == 0) {
                     local_state.story_phase_start_ms = now_ms;
                 }
-                local_update(input_fwd, input_str, cam_yaw, cam_pitch, input_shoot, wpn_req, input_jump, input_crouch, input_reload, input_ability, NULL, now_ms);
+                local_update(input_fwd, input_str, cam_yaw, cam_pitch, input_shoot, wpn_req, input_jump, input_crouch, input_reload, input_ability, input_bike, NULL, now_ms);
             }
                 accumulator -= TICK_DT;
             }

--- a/apps/tests/test_ctfb_respawn.c
+++ b/apps/tests/test_ctfb_respawn.c
@@ -52,10 +52,10 @@ int main(void) {
     ASSERT_TRUE(enemy_flag->dropped_until_ms == death_ms + CTFB_DROPPED_RETURN_MS,
                 "Dropped flag return timer is updated");
 
-    local_update(0, 0, carrier->yaw, carrier->pitch, 0, carrier->current_weapon, 0, 0, 0, 0, NULL, death_ms + 1000);
+    local_update(0, 0, carrier->yaw, carrier->pitch, 0, carrier->current_weapon, 0, 0, 0, 0, 0, NULL, death_ms + 1000);
     ASSERT_TRUE(carrier->state == STATE_DEAD, "Carrier stays dead before 3000ms delay expires");
 
-    local_update(0, 0, carrier->yaw, carrier->pitch, 0, carrier->current_weapon, 0, 0, 0, 0, NULL, death_ms + CTFB_RESPAWN_DELAY_MS);
+    local_update(0, 0, carrier->yaw, carrier->pitch, 0, carrier->current_weapon, 0, 0, 0, 0, 0, NULL, death_ms + CTFB_RESPAWN_DELAY_MS);
     ASSERT_TRUE(carrier->state == STATE_ALIVE, "Carrier respawns after 3000ms delay");
     ASSERT_TRUE(carrier->carried_flag_team_id == -1, "Respawned carrier does not keep enemy flag state");
 

--- a/apps/training/headless.c
+++ b/apps/training/headless.c
@@ -8,7 +8,7 @@ void sim_init(int bots) {
 void sim_step(float fwd, float strafe, float yaw, float pitch, int shoot, int jump) {
     // We are controlling Player 0 (The Agent)
     // The "bots" in the match are the opponents
-    local_update(fwd, strafe, yaw, pitch, shoot, -1, jump, 0, 0, 0, NULL, 0);
+    local_update(fwd, strafe, yaw, pitch, shoot, -1, jump, 0, 0, 0, 0, NULL, 0);
 }
 
 ServerState* sim_get_state() {

--- a/packages/simulation/local_game.h
+++ b/packages/simulation/local_game.h
@@ -168,7 +168,7 @@ typedef struct {
 
 static int ctf_enemy_team(int team_id) { return team_id == 0 ? 1 : 0; }
 
-void local_update(float fwd, float str, float yaw, float pitch, int shoot, int weapon_req, int jump, int crouch, int reload, int ability, void *server_context, unsigned int cmd_time);
+void local_update(float fwd, float str, float yaw, float pitch, int shoot, int weapon_req, int jump, int crouch, int reload, int ability, int bike, void *server_context, unsigned int cmd_time);
 void update_entity(PlayerState *p, float dt, void *server_context, unsigned int cmd_time);
 static inline void heli_spawn_defaults(HelicopterState *h, int id, int scene_id, float x, float y, float z);
 static inline void buggy_spawn_defaults(BuggyState *b, int id, int scene_id, float x, float z, float yaw);
@@ -1113,7 +1113,7 @@ static void update_projectiles(unsigned int now_ms) {
     }
 }
 
-void local_update(float fwd, float str, float yaw, float pitch, int shoot, int weapon_req, int jump, int crouch, int reload, int ability, void *server_context, unsigned int cmd_time) {
+void local_update(float fwd, float str, float yaw, float pitch, int shoot, int weapon_req, int jump, int crouch, int reload, int ability, int bike, void *server_context, unsigned int cmd_time) {
     PlayerState *p0 = &local_state.players[0];
     const float dt = SHANKPIT_NET_FIXED_DT;
     if (local_state.game_mode == MODE_STORY) {
@@ -1154,9 +1154,10 @@ void local_update(float fwd, float str, float yaw, float pitch, int shoot, int w
     }
     p0->in_fwd = fwd;
     p0->in_strafe = str;
+    p0->in_bike = bike;
     if (weapon_req >= 0 && weapon_req < MAX_WEAPONS) p0->current_weapon = weapon_req;
     if (p0->state == STATE_DEAD) {
-        fwd = 0.0f; str = 0.0f; shoot = 0; jump = 0; crouch = 0; reload = 0; ability = 0;
+        fwd = 0.0f; str = 0.0f; shoot = 0; jump = 0; crouch = 0; reload = 0; ability = 0; bike = 0;
     }
     if (p0->state != STATE_DEAD && !(p0->in_vehicle && p0->vehicle_type == VEH_HELICOPTER) &&
         !(p0->in_vehicle && p0->vehicle_type == VEH_BUGGY)) {


### PR DESCRIPTION
Q was wired to BTN_RELOAD in helicopter mode (a no-op) instead of BTN_VEHICLE_2, so in_bike was always 0 and heli strafe-right was dead. Add bike param to client_create_cmd and local_update; bind Q to BTN_VEHICLE_2 in heli mode for both net and offline play.